### PR TITLE
feat(quality): schema-pin sidecar for v2/baselines/** golden artifacts

### DIFF
--- a/v2/baselines/_schema.json
+++ b/v2/baselines/_schema.json
@@ -1,0 +1,18 @@
+{
+  "$comment": "Schema pin declaration for v2/baselines/** golden artifacts in tars. Phase 0 deliverable #5 of ga/docs/plans/2026-05-14-arch-cherny-adoption-and-tribunal-ci-plan-v2.md.",
+  "schema_version": 1,
+  "applies_to_path": "v2/baselines/**/*.golden.json",
+  "pins": {
+    "OPTIC-K": "v1.8",
+    "tars_wot_grammar": "frozen — see v2/grammars/wot.trsx",
+    "qa_verdict_schema": "ga/docs/contracts/qa-verdict.schema.json (tars consumes this when emitting tribunal verdicts)",
+    "models": {
+      "glm-4-9b-q4": "current dogfood model — v2/baselines/glm-4-9b-q4/*.golden.json"
+    }
+  },
+  "policy": {
+    "scope": "Golden JSON artifacts produced AFTER this file's git introduction are pinned to these versions. Pre-existing goldens in v2/baselines/glm-4-9b-q4/ are implicitly draft/v0 — they may be re-baselined when WoT grammar evolves or model changes.",
+    "bump_rule": "On model version bump (e.g. glm-4-9b-q4 -> different quantization), add a new subdirectory under v2/baselines/ and update the models map above. Demerzel tribunal is informed via cross-repo dispatch.",
+    "owner": "tars maintainer + cross-repo coordinator (Demerzel tribunal)"
+  }
+}


### PR DESCRIPTION
## Summary

Phase 0 deliverable #5 of [ga v2 plan](https://github.com/GuitarAlchemist/ga/blob/main/docs/plans/2026-05-14-arch-cherny-adoption-and-tribunal-ci-plan-v2.md). Closes silent-baseline-invalidation gap from the 2026-05-14 octo brainstorm.

## What ships

One file: `v2/baselines/_schema.json` pinning:

| Pin | Value |
|---|---|
| OPTIC-K | v1.8 (tars verdicts reference OPTIC-K for embedding-space coherence) |
| tars_wot_grammar | frozen at v2/grammars/wot.trsx |
| qa_verdict_schema | ga/docs/contracts/qa-verdict.schema.json (tars emits tribunal-consumable verdicts) |
| models.glm-4-9b-q4 | current dogfood model |

## Why sidecar at parent path

`v2/baselines/glm-4-9b-q4/` has 9 `*.golden.json` files. Editing each to add a `_schema` field would churn 9 files identically. Sidecar at `v2/baselines/_schema.json` applies to the whole tree, with a `models` map permitting per-model overrides as tars adds new dogfood models (e.g. different quantizations, larger checkpoints).

## Companion PRs

- [ga#212](https://github.com/GuitarAlchemist/ga/pull/212), ix, Demerzel — all add the same sidecar shape with repo-specific pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)