### PR TITLE
chore: lower auto-compact threshold to 40% (CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE=40)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE": "40"
+  },
   "enabledPlugins": {
     "ralph-loop@claude-plugins-official": false
   },


### PR DESCRIPTION
Sets `CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE=40` in `.claude/settings.json`'s `env` block. Claude Code now auto-compacts at 40% of the model's context window instead of the default ~85-95%.

## Why

Context degradation past ~30-40% fill is well-documented. Lowering the threshold forces a checkpoint while the working set is still useful and keeps the prompt cache warm.

## Schema

`autoCompactThreshold` does **not** exist (verified against https://www.schemastore.org/claude-code-settings.json on 2026-05-15). The documented env var is `CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE` — integer 1-100 (percent).

## Rollback

Delete the `env` block.

## Cross-repo

One of four sibling PRs (ga / ix / Demerzel / tars), all on `chore/auto-compact-threshold`.