### PR TITLE
fix(tests): unblock build — xUnit Assert.Equal<string list> -> <string>

### DIFF
--- a/v2/tests/Tars.Tests/ConstrainedDecodingTests.fs
+++ b/v2/tests/Tars.Tests/ConstrainedDecodingTests.fs
@@ -69,7 +69,7 @@ module ConstrainedDecodingTests =
     let ``listGrammars lists all .ebnf files`` () =
         withTempGrammarDir [ ("a.ebnf", ""); ("b.ebnf", ""); ("c.txt", "") ] (fun dir ->
             let grammars = ConstrainedDecoding.listGrammars dir |> List.sort
-            Assert.Equal<string list>([ "a"; "b" ], grammars)
+            Assert.Equal<string>([ "a"; "b" ], grammars)
         )
 
     [<Fact>]

--- a/v2/tests/Tars.Tests/MetaCognitionTests.fs
+++ b/v2/tests/Tars.Tests/MetaCognitionTests.fs
@@ -135,7 +135,7 @@ module MetaCognitionTests =
     [<Fact>]
     let ``Extract domain tags defaults to general`` () =
         let tags = GapDetection.extractDomainTags "hello world"
-        Assert.Equal<string list>([ "general" ], tags)
+        Assert.Equal<string>([ "general" ], tags)
 
     [<Fact>]
     let ``Failure rate by domain computes correctly`` () =

--- a/v2/tests/Tars.Tests/TextNormalizerTests.fs
+++ b/v2/tests/Tars.Tests/TextNormalizerTests.fs
@@ -15,14 +15,14 @@ let ``tokenize splits words correctly`` () =
     let input = "one two three"
     let expected = [ "one"; "two"; "three" ]
     let actual = TextNormalizer.tokenize input
-    Assert.Equal<string list>(expected, actual)
+    Assert.Equal<string>(expected, actual)
 
 [<Fact>]
 let ``removeStopWords filters common words`` () =
     let input = [ "the"; "quick"; "brown"; "fox"; "is"; "a"; "dog" ]
     let expected = [ "quick"; "brown"; "fox"; "dog" ]
     let actual = TextNormalizer.removeStopWords input
-    Assert.Equal<string list>(expected, actual)
+    Assert.Equal<string>(expected, actual)
 
 [<Fact>]
 let ``extractKeywords performs full pipeline`` () =
@@ -30,4 +30,4 @@ let ``extractKeywords performs full pipeline`` () =
     let input = "The Quick, Brown Fox jumps over the quick dog."
     let expected = [ "quick"; "brown"; "fox"; "jumps"; "over"; "dog" ]
     let actual = TextNormalizer.extractKeywords input
-    Assert.Equal<string list>(expected, actual)
+    Assert.Equal<string>(expected, actual)


### PR DESCRIPTION
xUnit 2.9.3's only generic `Equal<T>` overload matching an explicit type argument is `Equal<T>(IEnumerable<T>, IEnumerable<T>)`. With `<string list>` as T the F# compiler resolves the call to `Equal(seq<string list>, seq<string list>)` and rejects the `string list` arguments with FS0193 (`'string list'` is not compatible with `'string list seq'`).

Switching to `<string>` selects T = `string`, comparing the two `string list` args as `seq<string>` element-wise — which is the intent (ordered list equality of strings).

## Affected lines

- v2/tests/Tars.Tests/TextNormalizerTests.fs:18,25,33
- v2/tests/Tars.Tests/MetaCognitionTests.fs:138
- v2/tests/Tars.Tests/ConstrainedDecodingTests.fs:72

## Verification

Local build: 0 errors (was 5 FS0193 errors).

## Why now

Unblocks PR #23 (`chore: auto-compact threshold 40%`) — was failing on the same pre-existing main breakage.