### PR TITLE
ci: add Agent Blackbox risk report

### DIFF
--- a/.github/workflows/agent-blackbox.yml
+++ b/.github/workflows/agent-blackbox.yml
@@ -1,0 +1,143 @@
+name: Agent Blackbox
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  checks: write
+
+env:
+  VERIFY_COMMAND: "cd v2 && dotnet test --verbosity normal"
+  IX_BLAST_RADIUS_BUILD_COMMAND: ""
+  IX_BLAST_RADIUS_COMMAND: ""
+
+jobs:
+  risk-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Checkout Agent Blackbox
+        uses: actions/checkout@v4
+        with:
+          repository: GuitarAlchemist/agent-blackbox
+          path: .agent-blackbox
+          token: ${{ secrets.AGENT_BLACKBOX_TOKEN || github.token }}
+
+      - name: Collect PR evidence
+        shell: bash
+        run: |
+          mkdir -p dist
+          git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" > dist/changed-files.txt
+          git diff "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" > dist/diff.patch
+          if [ -n "${IX_BLAST_RADIUS_BUILD_COMMAND:-}" ]; then
+            bash -lc "$IX_BLAST_RADIUS_BUILD_COMMAND"
+          fi
+          set +e
+          bash -lc "$VERIFY_COMMAND" > dist/test-output.txt 2>&1
+          verify_exit=$?
+          set -e
+          echo "verify_exit=$verify_exit" >> "$GITHUB_ENV"
+          export AGENT_BLACKBOX_VERIFY_EXIT="$verify_exit"
+          echo "verify command exited with code $verify_exit" >> dist/test-output.txt
+          cat dist/test-output.txt
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          def event(**kwargs):
+              payload = {
+                  "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                  **kwargs,
+              }
+              return json.dumps(payload, sort_keys=True)
+
+          changed_files = [
+              line.strip()
+              for line in Path("dist/changed-files.txt").read_text(encoding="utf-8").splitlines()
+              if line.strip()
+          ]
+          verify_exit = int(os.environ.get("AGENT_BLACKBOX_VERIFY_EXIT", "0"))
+          lines = [
+              event(
+                  event="workflow_evidence",
+                  tool="git.diff",
+                  status="ok",
+                  path="dist/changed-files.txt",
+                  data={"changed_file_count": len(changed_files)},
+              ),
+              event(
+                  event="verification",
+                  tool="shell.exec",
+                  command=os.environ.get("VERIFY_COMMAND", ""),
+                  status="ok" if verify_exit == 0 else "failed",
+              ),
+          ]
+          Path("dist/agent-trace.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Generate risk report
+        shell: bash
+        run: |
+          analyze_args=(analyze \
+            --policy agent-blackbox.policy.json \
+            --changed-files dist/changed-files.txt \
+            --diff dist/diff.patch \
+            --test-output dist/test-output.txt \
+            --trace dist/agent-trace.jsonl \
+            --out-dir dist)
+          if [ -n "${IX_BLAST_RADIUS_COMMAND:-}" ]; then
+            analyze_args+=(--ix-blast-radius-cmd "$IX_BLAST_RADIUS_COMMAND")
+          fi
+          PYTHONPATH=.agent-blackbox python -m cli.agent_blackbox "${analyze_args[@]}"
+
+      - name: Comment risk report
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- agent-blackbox-risk-report -->';
+            const body = marker + '\n' + fs.readFileSync('dist/risk-report.md', 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+            const existing = comments.data.find(comment =>
+              comment.user.type === 'Bot' && comment.body && comment.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Upload risk artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-blackbox-risk-report
+          path: dist/
+
+      - name: Enforce verdict
+        shell: bash
+        env:
+          AGENT_BLACKBOX_REVIEWED: ${{ contains(github.event.pull_request.labels.*.name, 'agent-blackbox-reviewed') }}
+        run: |
+          if [ "$AGENT_BLACKBOX_REVIEWED" = "true" ]; then
+            echo "Agent Blackbox human-review override label present; skipping hard enforcement."
+            exit 0
+          fi
+          PYTHONPATH=.agent-blackbox python -m cli.agent_blackbox enforce --report dist/risk-report.json

--- a/agent-blackbox.policy.json
+++ b/agent-blackbox.policy.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.1.0",
+  "risk_thresholds": {
+    "pass": 0.25,
+    "warn": 0.6
+  },
+  "blocked_paths": [
+    ".github/workflows/**",
+    "infra/production/**",
+    "billing/**",
+    "legal/**",
+    "security/**",
+    "Directory.Packages.props",
+    "global.json"
+  ],
+  "one_way_door_paths": [
+    "schemas/**",
+    "contracts/**",
+    "migrations/**",
+    "**/*.sln",
+    "**/*.slnx",
+    "**/*.csproj",
+    "**/*.fsproj",
+    "governance/demerzel/policies/**",
+    "governance/demerzel/schemas/**"
+  ],
+  "required_evidence": [
+    "changed_files",
+    "test_output",
+    "risk_report"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Agent Blackbox PR risk-report workflow
- add TARS .NET/governance policy
- run cd v2 && dotnet test --verbosity normal as verification evidence

## Verification
- git diff --check
- agent-blackbox.policy.json parses as JSON

Note: this bootstrap PR intentionally changes .github/workflows/**, so Agent Blackbox should report a fail verdict until agent-blackbox-reviewed is applied after report review.