### PR TITLE
docs: refresh tars README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,39 @@
-# TARS - Thinking, Acting, Reasoning System
+# TARS — Thinking, Acting, Reasoning System
 
 [![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
 [![F#](https://img.shields.io/badge/F%23-Functional-378BBA)](https://fsharp.org/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/Tests-819%20passing-brightgreen)]()
+[![Tests](https://img.shields.io/badge/Tests-~820%20passing-brightgreen)]()
 
-A modular, self-improving AI agent framework built in F#. Combines neuro-symbolic reasoning, multi-agent orchestration, probabilistic grammars, and a closed-loop evolution pipeline.
+Modular, self-improving F# agent framework — neuro-symbolic reasoning, multi-agent orchestration, probabilistic grammars, closed-loop evolution. Part of a four-repo ecosystem (`tars` + [`ga`](https://github.com/GuitarAlchemist/ga) + [`ix`](https://github.com/GuitarAlchemist/ix) + [`Demerzel`](https://github.com/GuitarAlchemist/Demerzel)).
 
-> *LLMs as stochastic generators + Symbolic systems as memory, law, and self-control.*
+> *LLMs as stochastic generators + symbolic systems as memory, law, and self-control.*
+
+> **Agent-facing canonical docs:** [`CLAUDE.md`](./CLAUDE.md) (breadcrumb-style). Full v2 docs: [`v2/README.md`](./v2/README.md).
 
 ---
 
 ## Quick Start
 
-The active project lives in [`v2/`](./v2/). All development happens there.
+All active development lives in [`v2/`](./v2/).
 
 ```bash
 cd v2
 dotnet build
-dotnet test          # 819 tests passing
-```
+dotnet test                        # ~820 tests (4 skipped — Docker-gated)
+dotnet format --verify-no-changes
 
-Interactive chat:
-
-```bash
+# Interactive chat
 dotnet run --project src/Tars.Interface.Cli -- chat
-```
 
-Agent-based reasoning:
-
-```bash
+# Agent reasoning (Workflow-of-Thought)
 dotnet run --project src/Tars.Interface.Cli -- agent run "Explain photosynthesis step by step"
-```
 
-Self-improvement loop:
-
-```bash
+# Self-improvement loop
 dotnet run --project src/Tars.Interface.Cli -- evolve --loop 3 --benchmark
 ```
+
+Repo harness verification: `pwsh Scripts/verify.ps1`.
 
 ---
 
@@ -50,7 +46,7 @@ dotnet run --project src/Tars.Interface.Cli -- evolve --loop 3 --benchmark
                                │              │
                     ┌──────────▼──────┐  ┌────▼───────────────┐
                     │  Agent Cortex   │  │   WoT DSL Engine   │
-                    │  (orchestrator) │  │  (.wot.trsx files)  │
+                    │  (orchestrator) │  │  (.wot.trsx files) │
                     └──────┬──────────┘  └────────┬───────────┘
                            │                      │
           ┌────────────────┼──────────────────────┤
@@ -66,15 +62,17 @@ dotnet run --project src/Tars.Interface.Cli -- evolve --loop 3 --benchmark
 |-------|----------|---------|
 | **Core** | Kernel, Core, Security, Llm | Abstractions, event bus, LLM providers, credentials |
 | **Intelligence** | Cortex, Evolution, DSL, Symbolic | Agent brain, promotion pipeline, WoT compiler, reflection |
-| **Knowledge** | Knowledge, Graph | Vector store, temporal knowledge graph, ledger |
+| **Knowledge** | Knowledge, Graph, LinkedData | Vector store, temporal knowledge graph, RDF/SPARQL |
 | **Interface** | CLI, UI, MCP Server | Commands, Blazor dashboard, tool server |
-| **Infra** | Tools, Connectors, Sandbox | 90+ tools, external APIs, Docker sandboxing |
+| **Infra** | Tools, Connectors, Sandbox, Migrations | 90+ tools, external APIs, Docker sandboxing |
+
+Full project map and conventions: [`v2/README.md`](./v2/README.md). LLM access **always** through `LlmFactory.create(logger)`; WoT (`.wot.trsx`) is the primary DSL; Metascript is **frozen**.
 
 ---
 
 ## MCP Server (150+ tools)
 
-TARS exposes a Model Context Protocol server with 150+ tools for use in Claude Code, VS Code, and other MCP clients.
+TARS exposes a Model Context Protocol server for Claude Code, VS Code, and other MCP clients.
 
 ```bash
 dotnet run --project src/Tars.Interface.Cli -- mcp server
@@ -118,15 +116,16 @@ dotnet run --project src/Tars.Interface.Cli -- <command>
 
 ## Cross-Repo Ecosystem
 
-Three repositories connected via MCP federation and filesystem bridges:
+Four sibling repositories connected via MCP federation, filesystem bridges, and the Demerzel governance constitution:
 
-| Repo | Language | Role | Link |
-|------|----------|------|------|
-| **TARS** | F# | Neuro-symbolic agent system | *this repo* |
+| Repo | Language | Role | Bridge |
+|------|----------|------|--------|
+| **TARS** | F# | Neuro-symbolic agent system, **cross-model theory validator** | *this repo* |
+| **[ga](https://github.com/GuitarAlchemist/ga)** | C# / F# DSL | Music theory domain + agentic chatbot | MCP + `~/.ga/traces/` |
 | **[ix](https://github.com/GuitarAlchemist/ix)** | Rust | 39 ML tools (stats, neural nets, optimization, game theory) | MCP federation |
-| **[GA](https://github.com/GuitarAlchemist/ga)** | C# | Music theory domain + chatbot | MCP + trace bridge |
+| **[Demerzel](https://github.com/GuitarAlchemist/Demerzel)** | Governance | 11-article epistemic constitution, ACP server, tribunal | Submodule at `governance/demerzel/` |
 
-All governed by the [Demerzel](https://github.com/GuitarAlchemist/Demerzel) constitution (11 articles, 12 personas, tetravalent logic).
+In the ecosystem, **TARS is the F# theory validator** — used cross-model to validate music-theory hypotheses originating from `ga`. Cross-repo contract drafts under `governance/demerzel/docs/contracts/v0.1.x` are explicitly **not frozen** until the owning plan's Phase 4 milestone.
 
 ### ix ML Integration
 
@@ -140,7 +139,7 @@ ix_ml_predict, ix_statistics_*, ix_optimization_*, ix_neural_*, ix_game_theory_*
 
 ### GA Trace Bridge
 
-TARS discovers patterns from Guitar Alchemist orchestrator traces (`~/.ga/traces/`) and promotes them through the evolution pipeline. 5 pattern families (21 artifacts) seeded from static code analysis.
+TARS discovers patterns from Guitar Alchemist orchestrator traces (`~/.ga/traces/`) and promotes them through the evolution pipeline. 5 pattern families (21 artifacts) seeded from static code analysis. New: `Tars.Evolution/ChatbotClaimsBridge.fs` extracts skill-routing claims from the `ga` chatbot for cross-model validation.
 
 ---
 
@@ -148,53 +147,54 @@ TARS discovers patterns from Guitar Alchemist orchestrator traces (`~/.ga/traces
 
 TARS has a closed self-improvement loop:
 
-1. **Evolve** — Run tasks, observe outcomes
-2. **Extract** — Identify recurring patterns from execution traces
+1. **Evolve** — run tasks, observe outcomes
+2. **Extract** — identify recurring patterns from execution traces
 3. **Promote** — 7-step pipeline: Inspect → Extract → Classify → Propose → Validate → Persist → Govern
 4. **Index** — Bayesian-weighted ranking persisted to `~/.tars/promotion/index.json`
-5. **Select** — PatternSelector reads index, context-gated boost for next execution
+5. **Select** — `PatternSelector` reads index, context-gated boost for next execution
 6. **Repeat** — `tars evolve --loop N` runs N full cycles back-to-back
 
-Patterns climb: *Implementation → Helper → Builder → DslClause → GrammarRule*
+Patterns climb: *Implementation → Helper → Builder → DslClause → GrammarRule*.
 
 ---
 
-## Documentation
+## AI discipline (Karpathy + Cherny)
 
-See **[v2/README.md](./v2/README.md)** for full documentation including architecture details, configuration, and development guides.
+Every code-touching turn applies four rules: **think before coding · simplicity first · surgical changes · goal-driven execution**. Session continuity uses the Cherny pattern:
+
+- `/digest` — captures session state (cursor, in-flight work, hypotheses, success criteria) to `state/digests/latest.md`. Auto-fallback via `.claude/hooks/precompact-digest.ps1`; auto-injected on next session via `.claude/hooks/sessionstart-digest.ps1`.
+- `/learnings` — captures surprises to `docs/solutions/<category>/<date>-<topic>.md`.
+- `/correct` — turns user corrections into permanent rules in [`CLAUDE.md`](./CLAUDE.md)'s **Session-learned rules**.
+
+CI enforces hook integrity via [`.github/workflows/karpathy-cherny-discipline.yml`](./.github/workflows/karpathy-cherny-discipline.yml).
 
 ---
 
-## Active Boundaries
+## Quality cadence
 
-| Area | Status | Description |
-|------|--------|-------------|
-| **`v2/`** | **Active** | F# neuro-symbolic agent framework — all new development happens here |
-| **`v2/agents/`** | **Active** | Declarative agent definitions (Markdown + YAML frontmatter) |
-| **`v2/grammars/`** | **Active** | EBNF grammars for constrained decoding |
-| **`v2/puzzles/`** | **Active** | WoT puzzle benchmarks |
-| **`v2/docs/`** | **Active** | Architecture, roadmap, plans |
-| **`v1/`** | **Legacy** | Original C#/.NET implementation — retained for reference, not maintained |
-| **`archive/docs/`** | **Archived** | 119 historical reports, session summaries, and analysis docs moved from root |
-| **`archive/scripts/`** | **Archived** | 245 legacy PowerShell and F# scripts moved from root |
-| **`governance/`** | **Active** | Demerzel submodule — constitutions, policies, schemas |
+Golden artifacts under `v2/baselines/**` are schema-pinned via `v2/baselines/_schema.json` — drift triggers a CI failure ([PR #21](https://github.com/GuitarAlchemist/tars/pull/21)). Tribunal verdicts dispatch to the Demerzel constitutional tribunal via [`.github/workflows/qa-verdict-dispatch.yml`](./.github/workflows/qa-verdict-dispatch.yml) ([PR #22](https://github.com/GuitarAlchemist/tars/pull/22)). Agent risk surfaces through `.github/workflows/agent-blackbox.yml` against `agent-blackbox.policy.json`.
 
-**CI target:** `v2/` only (`working-directory: v2` in `dotnet.yml`). Archived content does not affect builds.
+---
 
 ## Repository Layout
 
-| Directory | Description |
-|-----------|-------------|
-| **[v2/](./v2/)** | Active project — F# neuro-symbolic agent framework |
-| **[v2/agents/](./v2/agents/)** | Declarative agent definitions (Markdown + YAML frontmatter) |
-| **[v2/grammars/](./v2/grammars/)** | EBNF grammars for constrained decoding |
-| **[v2/puzzles/](./v2/puzzles/)** | WoT puzzle benchmarks |
-| **[v2/docs/](./v2/docs/)** | Architecture, roadmap, plans |
-| **[archive/](./archive/)** | Legacy docs and scripts moved from root |
-| **[v1/](./v1/)** | Legacy C# projects — archived, not maintained |
+| Area | Status | Description |
+|------|--------|-------------|
+| **[v2/](./v2/)** | **Active** | F# neuro-symbolic agent framework — all new development happens here |
+| **[v2/agents/](./v2/agents/)** | Active | Declarative agent definitions (Markdown + YAML frontmatter) |
+| **[v2/grammars/](./v2/grammars/)** | Active | EBNF grammars for constrained decoding |
+| **[v2/baselines/](./v2/baselines/)** | Active | Schema-pinned golden artifacts (validated in CI) |
+| **[v2/puzzles/](./v2/puzzles/)** | Active | WoT puzzle benchmarks |
+| **[v2/docs/](./v2/docs/)** | Active | Architecture, roadmap, plans |
+| **[governance/](./governance/)** | Active | Demerzel submodule — constitution, policies, schemas |
+| **[state/](./state/)** | Active | Digests, quality snapshots, beliefs, PDCA, knowledge |
+| **[v1/](./v1/)** | Legacy | Original C#/.NET implementation — retained for reference, not maintained |
+| **[archive/](./archive/)** | Archived | 119 historical reports + 245 legacy scripts moved from root |
+
+**CI target:** `v2/` only (`working-directory: v2` in `dotnet.yml`). Archived content does not affect builds.
 
 ---
 
 ## License
 
-MIT License — see [LICENSE](./LICENSE) for details.
+MIT — see [LICENSE](./LICENSE).


### PR DESCRIPTION
## Summary

The repo-root `README.md` was 42 days stale (last touched 2026-04-05). This refresh brings it level with what actually shipped to `main` since then.

## What was added

- **Karpathy + Cherny discipline section** — `/digest`, `/learnings`, `/correct` skills + CI hooks landed in #20 but had no top-level README mention.
- **Quality cadence section** — schema-pinned `v2/baselines/**` (#21), `qa-verdict-dispatch.yml` Demerzel tribunal sender (#22), and `agent-blackbox.yml` (#25/#27) had zero README surface.
- **Four-repo ecosystem framing** — old README listed three repos (tars + ix + ga). The full ecosystem is four: **tars + ga + ix + Demerzel**, with Demerzel promoted to a first-class member governed via the submodule at `governance/demerzel/`. TARS's role as **cross-model F# theory validator for ga** is now made explicit.
- **`state/` + `governance/` rows in repository layout** — both directories exist and ship CI-checked artifacts; both were absent from the table.
- **`ChatbotClaimsBridge.fs`** noted in the GA trace bridge subsection (added since 2026-04-05).
- **Cross-repo contract caveat** — drafts under `governance/demerzel/docs/contracts/v0.1.x` are explicitly NOT frozen until the owning plan's Phase 4.

## What was corrected

- **Test badge: 819 → ~820 passing (4 skipped, Docker-gated).** `CLAUDE.md` reports `~820 tests (4 skipped for Docker)`; the README badge had drifted. PR #24 unblocked the F# xUnit `Assert.Equal<string list>` build break that was the source of ga task #189's "main has pre-existing F# build failure" note — that build issue is now resolved on `main` (94097354), so no caveat is needed in the README. (Mentioning here per instructions; not surfacing in the README itself since it's no longer a blocker.)
- **Voice** — tightened to match `ga/README.md` breadcrumb style (terse, factual, links over prose).

## Constraints honored

- Only `README.md` touched (1 file, 58/58 lines changed).
- No edits to `.gitignore`, git config, or any other file.
- Branch and commit naming per spec; HEREDOC-formatted commit message and PR body.

## Test plan

- [ ] Render check: GitHub renders the new README without table/code-block breakage.
- [ ] Cross-link check: all relative paths (`./CLAUDE.md`, `./v2/README.md`, `./v2/agents/`, `./governance/`, `./state/`, workflow files) resolve.
- [ ] No CI failure introduced by README-only change (karpathy-cherny-discipline + dotnet workflows should pass; netlify previews are pre-existing red on `main`).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)