### PR TITLE
fix(evolution): make PromotionIndex tests hermetic (kill order-dependent flake)

### DIFF
--- a/v2/src/Tars.Evolution/PromotionIndex.fs
+++ b/v2/src/Tars.Evolution/PromotionIndex.fs
@@ -46,11 +46,14 @@ module PromotionIndex =
 
     // ── Build index from live promotion stores ──────────────────────
 
-    /// Build the index from current recurrence records and weights.
-    let build () : PromotionIndexData =
-        let records = PromotionPipeline.getRecurrenceRecords ()
-        let weights = WeightedGrammar.load ()
-        let lineage = PromotionPipeline.getLineageRecords ()
+    /// Build the index from explicit records/weights/lineage. Pure: no I/O,
+    /// no global state — the testable core shared by the live and
+    /// directory-scoped builders below.
+    let buildFrom
+        (records: RecurrenceRecord list)
+        (weights: WeightedGrammar.WeightedRule list)
+        (lineage: LineageRecord list)
+        : PromotionIndexData =
 
         // Find the most recent rollback expansion from lineage for each pattern
         let rollbackByPattern =
@@ -92,12 +95,47 @@ module PromotionIndex =
           GeneratedAt = DateTime.UtcNow
           PatternCount = entries.Length }
 
+    /// Build the index from the live, process-global promotion stores.
+    let build () : PromotionIndexData =
+        buildFrom
+            (PromotionPipeline.getRecurrenceRecords ())
+            (WeightedGrammar.load ())
+            (PromotionPipeline.getLineageRecords ())
+
+    /// Build the index from an isolated promotion directory (reads disk
+    /// directly, bypassing the shared in-memory store). Hermetic and
+    /// parallel-safe — the basis for deterministic tests.
+    let buildFromDir (promotionDir: string) : PromotionIndexData =
+        buildFrom
+            (PromotionPipeline.recurrenceRecordsFrom promotionDir)
+            (WeightedGrammar.loadFrom promotionDir)
+            (PromotionPipeline.lineageRecordsFrom promotionDir)
+
+    /// Persist the index to a specific promotion directory.
+    let saveTo (promotionDir: string) (index: PromotionIndexData) : unit =
+        try
+            Directory.CreateDirectory promotionDir |> ignore
+            let json = JsonSerializer.Serialize(index, jsonOptions)
+            File.WriteAllText(Path.Combine(promotionDir, "index.json"), json)
+        with _ -> () // Best-effort
+
     /// Persist the index to disk for fast loading by agent layer.
     let save (index: PromotionIndexData) : unit =
         try
             let json = JsonSerializer.Serialize(index, jsonOptions)
             File.WriteAllText(indexPath (), json)
         with _ -> () // Best-effort
+
+    /// Load a persisted index from a specific promotion directory.
+    let loadFrom (promotionDir: string) : PromotionIndexData option =
+        try
+            let path = Path.Combine(promotionDir, "index.json")
+            if File.Exists path then
+                let json = File.ReadAllText path
+                Some (JsonSerializer.Deserialize<PromotionIndexData>(json, jsonOptions))
+            else
+                None
+        with _ -> None
 
     /// Load the persisted index from disk.
     let load () : PromotionIndexData option =
@@ -114,6 +152,12 @@ module PromotionIndex =
     let refresh () : PromotionIndexData =
         let index = build ()
         save index
+        index
+
+    /// Build from and persist to an isolated promotion directory.
+    let refreshIn (promotionDir: string) : PromotionIndexData =
+        let index = buildFromDir promotionDir
+        saveTo promotionDir index
         index
 
     // ── Query helpers for pattern selection ──────────────────────────

--- a/v2/src/Tars.Evolution/PromotionPipeline.fs
+++ b/v2/src/Tars.Evolution/PromotionPipeline.fs
@@ -386,6 +386,44 @@ let getLineageRecords () : LineageRecord list =
     ensureLoaded ()
     lineageStore.Values |> Seq.toList
 
+// ── Root-aware store access (hermetic, parallel-safe) ───────────────
+// The functions above read the process-global in-memory store (lazily
+// loaded once from ~/.tars). These read/write a caller-supplied
+// promotion directory directly, so callers (notably tests) can operate
+// on an isolated store without racing the shared one.
+
+/// Read recurrence records straight from a specific promotion directory.
+let recurrenceRecordsFrom (promotionDir: string) : RecurrenceRecord list =
+    try
+        let path = Path.Combine(promotionDir, "recurrence.json")
+        if File.Exists path then
+            JsonSerializer.Deserialize<RecurrenceRecord list>(File.ReadAllText path, jsonOptions)
+        else []
+    with _ -> []
+
+/// Read lineage records straight from a specific promotion directory.
+let lineageRecordsFrom (promotionDir: string) : LineageRecord list =
+    try
+        let path = Path.Combine(promotionDir, "lineage.json")
+        if File.Exists path then
+            JsonSerializer.Deserialize<LineageRecord list>(File.ReadAllText path, jsonOptions)
+        else []
+    with _ -> []
+
+/// Persist recurrence + lineage stores to a specific promotion directory.
+let saveStoresTo
+    (promotionDir: string)
+    (recurrence: RecurrenceRecord list)
+    (lineage: LineageRecord list)
+    : unit =
+    Directory.CreateDirectory promotionDir |> ignore
+    File.WriteAllText(
+        Path.Combine(promotionDir, "recurrence.json"),
+        JsonSerializer.Serialize(recurrence, jsonOptions))
+    File.WriteAllText(
+        Path.Combine(promotionDir, "lineage.json"),
+        JsonSerializer.Serialize(lineage, jsonOptions))
+
 /// Get patterns at a specific promotion level
 let getPatternsAtLevel (level: PromotionLevel) : RecurrenceRecord list =
     ensureLoaded ()

--- a/v2/src/Tars.Evolution/WeightedGrammar.fs
+++ b/v2/src/Tars.Evolution/WeightedGrammar.fs
@@ -262,12 +262,18 @@ module WeightedGrammar =
             File.WriteAllText(weightsPath, json)
         with _ -> () // graceful degradation
 
-    /// Load weighted rules from ~/.tars/promotion/weights.json
-    let load () : WeightedRule list =
+    /// Load weighted rules from a specific promotion directory's weights.json.
+    /// Lets callers (notably hermetic tests) read an isolated store instead of
+    /// the shared ~/.tars one.
+    let loadFrom (dir: string) : WeightedRule list =
         try
-            if File.Exists(weightsPath) then
-                let json = File.ReadAllText(weightsPath)
+            let path = Path.Combine(dir, "weights.json")
+            if File.Exists(path) then
+                let json = File.ReadAllText(path)
                 let dtos = JsonSerializer.Deserialize<WeightedRuleDto list>(json, jsonOptions)
                 dtos |> List.map fromDto
             else []
         with _ -> []
+
+    /// Load weighted rules from ~/.tars/promotion/weights.json
+    let load () : WeightedRule list = loadFrom weightsDir

--- a/v2/tests/Tars.Tests/PromotionIndexTests.fs
+++ b/v2/tests/Tars.Tests/PromotionIndexTests.fs
@@ -1,60 +1,95 @@
 module Tars.Tests.PromotionIndexTests
 
+open System
+open System.IO
 open Xunit
-open Xunit.Abstractions
 open Tars.Evolution
 
-type PromotionIndexTests(output: ITestOutputHelper) =
+// These tests exercise PromotionIndex against an ISOLATED, seeded promotion
+// store (a unique temp directory), not the process-global ~/.tars store.
+// The store-from-live variants are shared, mutable, and lazily cached, so
+// reading them under xUnit's parallel runner is order-dependent and flaky:
+// a partial ambient state (PatternCount > 0 but < 5 ga. patterns) slips past
+// a naive "skip if empty" guard. Seeding deterministic data in a private
+// directory makes the assertions test PromotionIndex.build's *logic* on known
+// input — hermetic, parallel-safe, and meaningful (no green-but-dead skip).
 
-    [<Fact>]
-    let ``PromotionIndex builds and persists from live stores`` () =
-        let index = PromotionIndex.refresh ()
-        output.WriteLine($"Index has {index.PatternCount} patterns")
+let private mkRecord name level score context : RecurrenceRecord =
+    { PatternId = name
+      PatternName = name
+      FirstSeen = DateTime(2026, 1, 1)
+      LastSeen = DateTime(2026, 6, 1)
+      OccurrenceCount = 5
+      TaskIds = [ name + "-t1"; name + "-t2"; name + "-t3" ]
+      Contexts = [ context ]
+      CurrentLevel = level
+      PromotionHistory = [ (level, DateTime(2026, 3, 1)) ]
+      AverageScore = score }
 
-        if index.PatternCount = 0 then
-            output.WriteLine("SKIP: No promotion data on disk (CI environment)")
-        else
+/// Deterministic seed: 5 distinct ga.* patterns spanning every promotion
+/// level (so the rank-descending sort is actually exercised) plus one
+/// non-ga pattern (so the ga. filter is meaningful).
+let private seededRecords () : RecurrenceRecord list =
+    [ mkRecord "ga.confidence_evidence_response" Helper 0.92
+          "TheoryAgent returns structured JSON with confidence score and evidence list"
+      mkRecord "ga.domain_compute" Builder 0.88
+          "compute the scale notes for C major key from the deterministic domain model"
+      mkRecord "ga.embedding_router" DslClause 0.90
+          "route this query to the best agent via embedding similarity scoring"
+      mkRecord "ga.lifecycle_hooks" Implementation 0.75
+          "per-request state lifecycle hooks keyed by correlation id"
+      mkRecord "ga.orchestrator_pipeline" GrammarRule 0.85
+          "orchestrator pipeline pre hooks skill scan agent dispatch post hooks"
+      mkRecord "tars.meta_reflection" Helper 0.70
+          "tars self-reflection on completed task outcomes" ]
 
-        for entry in index.Entries do
-            output.WriteLine($"  {entry.PatternName}: level={PromotionLevel.label entry.Level} (rank={entry.LevelRank}), score={entry.Score:F3}, weight={entry.Weight:F3}")
+/// Run a test body against a private, seeded promotion directory; always
+/// cleaned up afterwards.
+let private withSeededStore (f: string -> unit) =
+    let dir =
+        Path.Combine(Path.GetTempPath(), "tars-promo-test-" + Guid.NewGuid().ToString("N"))
+    Directory.CreateDirectory dir |> ignore
+    try
+        PromotionPipeline.saveStoresTo dir (seededRecords ()) []
+        f dir
+    finally
+        try Directory.Delete(dir, true) with _ -> ()
 
-        let gaEntries = index.Entries |> List.filter (fun e -> e.PatternName.StartsWith("ga."))
+[<Fact>]
+let ``PromotionIndex builds and persists from an isolated store`` () =
+    withSeededStore (fun dir ->
+        let index = PromotionIndex.refreshIn dir
+
+        Assert.Equal(6, index.PatternCount)
+
+        let gaEntries =
+            index.Entries |> List.filter (fun e -> e.PatternName.StartsWith("ga."))
         Assert.True(gaEntries.Length >= 5, $"Expected at least 5 GA patterns, got {gaEntries.Length}")
 
         let ranks = index.Entries |> List.map (fun e -> e.LevelRank)
         let isSorted = ranks |> List.pairwise |> List.forall (fun (a, b) -> a >= b)
         Assert.True(isSorted, "Index entries should be sorted by level rank descending")
 
-    [<Fact>]
-    let ``PromotionIndex can be loaded from disk`` () =
-        let original = PromotionIndex.refresh ()
+        Assert.True(
+            File.Exists(Path.Combine(dir, "index.json")),
+            "refreshIn should persist index.json to the store directory"))
 
-        if original.PatternCount = 0 then
-            output.WriteLine("SKIP: No promotion data on disk (CI environment)")
-        else
+[<Fact>]
+let ``PromotionIndex can be loaded from disk`` () =
+    withSeededStore (fun dir ->
+        let original = PromotionIndex.refreshIn dir
 
-        match PromotionIndex.load () with
-        | Some loaded ->
-            Assert.Equal(original.PatternCount, loaded.PatternCount)
-            output.WriteLine($"Loaded {loaded.PatternCount} patterns from disk")
-        | None ->
-            Assert.Fail("Expected to load index from disk after refresh")
+        match PromotionIndex.loadFrom dir with
+        | Some loaded -> Assert.Equal(original.PatternCount, loaded.PatternCount)
+        | None -> Assert.Fail("Expected to load index from disk after refresh"))
 
-    [<Fact>]
-    let ``PromotionIndex findForGoal scores GA patterns`` () =
-        let index = PromotionIndex.refresh ()
-
-        if index.PatternCount = 0 then
-            output.WriteLine("SKIP: No promotion data on disk (CI environment)")
-        else
+[<Fact>]
+let ``PromotionIndex findForGoal scores GA patterns`` () =
+    withSeededStore (fun dir ->
+        let index = PromotionIndex.buildFromDir dir
 
         let routingMatch = PromotionIndex.findForGoal "route this query to the best agent" index
-        let routingName = routingMatch |> Option.map (fun e -> e.PatternName) |> Option.defaultValue "none"
-        output.WriteLine($"Routing goal match: {routingName}")
-
         let skillMatch = PromotionIndex.findForGoal "compute the scale notes for C major" index
-        let skillName = skillMatch |> Option.map (fun e -> e.PatternName) |> Option.defaultValue "none"
-        output.WriteLine($"Skill goal match: {skillName}")
 
         Assert.True(routingMatch.IsSome, "Expected a match for routing goal")
-        Assert.True(skillMatch.IsSome, "Expected a match for skill goal")
+        Assert.True(skillMatch.IsSome, "Expected a match for skill goal"))


### PR DESCRIPTION
## Problem

`PromotionIndexTests` is the flaky test that intermittently reddens `verify.ps1` / `build` across PRs (it failed in tars #35 and #36 runs). It calls `PromotionIndex.refresh()`, which reads the **process-global `~/.tars` promotion store** through lazily-cached in-memory stores. Under xUnit's parallel runner, *other* tests mutate that shared state mid-run, so the suite intermittently sees a **partial ambient state** — `PatternCount > 0` but `< 5` `ga.` patterns — that slips past the naive `if PatternCount = 0 then skip` guard and fails `Expected at least 5 GA patterns`.

It's a shared-global-state + test-ordering flake, not a code defect.

## Fix (root cause, not a metric hack)

The cheap "green" would be to weaken/skip the assertion — a green-but-dead test (Goodhart). Instead this makes the test **hermetic** by adding pure, directory-scoped store access so the index can be built from an **isolated, seeded** store:

- `PromotionIndex.build` → refactored into a pure `buildFrom records weights lineage` + a live `build()` and a `buildFromDir dir`; adds `saveTo`/`loadFrom`/`refreshIn`.
- `PromotionPipeline` → `recurrenceRecordsFrom` / `lineageRecordsFrom` / `saveStoresTo` (read/write a caller-supplied dir, bypassing the shared in-memory store).
- `WeightedGrammar` → `loadFrom dir` (`load()` now delegates to it).

The **live API (`build`/`save`/`load`/`refresh`) is unchanged** — zero production behavior change. The 3 tests now seed deterministic data (5 `ga.` patterns spanning every promotion level + 1 non-ga) in a unique temp dir and assert real behavior — **no skips**, order-independent, parallel-safe.

## Verification

- `dotnet test --filter ~PromotionIndex` → **3/3 pass, 0 skipped**
- `--filter ~Promotion|~Weighted|~Grammar` → **118/118 pass** (no regression from the live-path refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)