### PR TITLE
refactor(cli): introduce ITarsRuntime composition root (PR1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,16 @@ F# agent system with WoT DSL, evolution pipeline, and MCP tool surface. Part of 
 cd v2                 # working directory is v2/, not repo root
 dotnet build          # full build
 dotnet test           # ~820 tests (4 skipped for Docker)
+dotnet format --verify-no-changes
 ```
 
 Solution: `v2/Tars.sln`, target: `net10.0`.
+
+Repo harness verification:
+
+```powershell
+pwsh Scripts/verify.ps1
+```
 
 ## Layout
 
@@ -78,3 +85,19 @@ The hooks are validated in CI by `.github/workflows/karpathy-cherny-discipline.y
 _Appended by `/correct` when the user corrects an approach. Persists across sessions._
 
 (none yet)
+
+## Agent skills
+
+Per-repo config for the mattpocock engineering skills (`to-issues`, `to-prd`, `triage`, `qa`, `tdd`, `improve-codebase-architecture`, etc.).
+
+### Issue tracker
+
+Issues tracked via GitHub Issues via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical defaults (`needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context (`CONTEXT.md` + `docs/adr/`). See `docs/agents/domain.md`.

--- a/README.md
+++ b/README.md
@@ -1,43 +1,39 @@
-# TARS - Thinking, Acting, Reasoning System
+# TARS — Thinking, Acting, Reasoning System
 
 [![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
 [![F#](https://img.shields.io/badge/F%23-Functional-378BBA)](https://fsharp.org/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/Tests-819%20passing-brightgreen)]()
+[![Tests](https://img.shields.io/badge/Tests-~820%20passing-brightgreen)]()
 
-A modular, self-improving AI agent framework built in F#. Combines neuro-symbolic reasoning, multi-agent orchestration, probabilistic grammars, and a closed-loop evolution pipeline.
+Modular, self-improving F# agent framework — neuro-symbolic reasoning, multi-agent orchestration, probabilistic grammars, closed-loop evolution. Part of a four-repo ecosystem (`tars` + [`ga`](https://github.com/GuitarAlchemist/ga) + [`ix`](https://github.com/GuitarAlchemist/ix) + [`Demerzel`](https://github.com/GuitarAlchemist/Demerzel)).
 
-> *LLMs as stochastic generators + Symbolic systems as memory, law, and self-control.*
+> *LLMs as stochastic generators + symbolic systems as memory, law, and self-control.*
+
+> **Agent-facing canonical docs:** [`CLAUDE.md`](./CLAUDE.md) (breadcrumb-style). Full v2 docs: [`v2/README.md`](./v2/README.md).
 
 ---
 
 ## Quick Start
 
-The active project lives in [`v2/`](./v2/). All development happens there.
+All active development lives in [`v2/`](./v2/).
 
 ```bash
 cd v2
 dotnet build
-dotnet test          # 819 tests passing
-```
+dotnet test                        # ~820 tests (4 skipped — Docker-gated)
+dotnet format --verify-no-changes
 
-Interactive chat:
-
-```bash
+# Interactive chat
 dotnet run --project src/Tars.Interface.Cli -- chat
-```
 
-Agent-based reasoning:
-
-```bash
+# Agent reasoning (Workflow-of-Thought)
 dotnet run --project src/Tars.Interface.Cli -- agent run "Explain photosynthesis step by step"
-```
 
-Self-improvement loop:
-
-```bash
+# Self-improvement loop
 dotnet run --project src/Tars.Interface.Cli -- evolve --loop 3 --benchmark
 ```
+
+Repo harness verification: `pwsh Scripts/verify.ps1`.
 
 ---
 
@@ -50,7 +46,7 @@ dotnet run --project src/Tars.Interface.Cli -- evolve --loop 3 --benchmark
                                │              │
                     ┌──────────▼──────┐  ┌────▼───────────────┐
                     │  Agent Cortex   │  │   WoT DSL Engine   │
-                    │  (orchestrator) │  │  (.wot.trsx files)  │
+                    │  (orchestrator) │  │  (.wot.trsx files) │
                     └──────┬──────────┘  └────────┬───────────┘
                            │                      │
           ┌────────────────┼──────────────────────┤
@@ -66,15 +62,17 @@ dotnet run --project src/Tars.Interface.Cli -- evolve --loop 3 --benchmark
 |-------|----------|---------|
 | **Core** | Kernel, Core, Security, Llm | Abstractions, event bus, LLM providers, credentials |
 | **Intelligence** | Cortex, Evolution, DSL, Symbolic | Agent brain, promotion pipeline, WoT compiler, reflection |
-| **Knowledge** | Knowledge, Graph | Vector store, temporal knowledge graph, ledger |
+| **Knowledge** | Knowledge, Graph, LinkedData | Vector store, temporal knowledge graph, RDF/SPARQL |
 | **Interface** | CLI, UI, MCP Server | Commands, Blazor dashboard, tool server |
-| **Infra** | Tools, Connectors, Sandbox | 90+ tools, external APIs, Docker sandboxing |
+| **Infra** | Tools, Connectors, Sandbox, Migrations | 90+ tools, external APIs, Docker sandboxing |
+
+Full project map and conventions: [`v2/README.md`](./v2/README.md). LLM access **always** through `LlmFactory.create(logger)`; WoT (`.wot.trsx`) is the primary DSL; Metascript is **frozen**.
 
 ---
 
 ## MCP Server (150+ tools)
 
-TARS exposes a Model Context Protocol server with 150+ tools for use in Claude Code, VS Code, and other MCP clients.
+TARS exposes a Model Context Protocol server for Claude Code, VS Code, and other MCP clients.
 
 ```bash
 dotnet run --project src/Tars.Interface.Cli -- mcp server
@@ -118,15 +116,16 @@ dotnet run --project src/Tars.Interface.Cli -- <command>
 
 ## Cross-Repo Ecosystem
 
-Three repositories connected via MCP federation and filesystem bridges:
+Four sibling repositories connected via MCP federation, filesystem bridges, and the Demerzel governance constitution:
 
-| Repo | Language | Role | Link |
-|------|----------|------|------|
-| **TARS** | F# | Neuro-symbolic agent system | *this repo* |
+| Repo | Language | Role | Bridge |
+|------|----------|------|--------|
+| **TARS** | F# | Neuro-symbolic agent system, **cross-model theory validator** | *this repo* |
+| **[ga](https://github.com/GuitarAlchemist/ga)** | C# / F# DSL | Music theory domain + agentic chatbot | MCP + `~/.ga/traces/` |
 | **[ix](https://github.com/GuitarAlchemist/ix)** | Rust | 39 ML tools (stats, neural nets, optimization, game theory) | MCP federation |
-| **[GA](https://github.com/GuitarAlchemist/ga)** | C# | Music theory domain + chatbot | MCP + trace bridge |
+| **[Demerzel](https://github.com/GuitarAlchemist/Demerzel)** | Governance | 11-article epistemic constitution, ACP server, tribunal | Submodule at `governance/demerzel/` |
 
-All governed by the [Demerzel](https://github.com/GuitarAlchemist/Demerzel) constitution (11 articles, 12 personas, tetravalent logic).
+In the ecosystem, **TARS is the F# theory validator** — used cross-model to validate music-theory hypotheses originating from `ga`. Cross-repo contract drafts under `governance/demerzel/docs/contracts/v0.1.x` are explicitly **not frozen** until the owning plan's Phase 4 milestone.
 
 ### ix ML Integration
 
@@ -140,7 +139,7 @@ ix_ml_predict, ix_statistics_*, ix_optimization_*, ix_neural_*, ix_game_theory_*
 
 ### GA Trace Bridge
 
-TARS discovers patterns from Guitar Alchemist orchestrator traces (`~/.ga/traces/`) and promotes them through the evolution pipeline. 5 pattern families (21 artifacts) seeded from static code analysis.
+TARS discovers patterns from Guitar Alchemist orchestrator traces (`~/.ga/traces/`) and promotes them through the evolution pipeline. 5 pattern families (21 artifacts) seeded from static code analysis. New: `Tars.Evolution/ChatbotClaimsBridge.fs` extracts skill-routing claims from the `ga` chatbot for cross-model validation.
 
 ---
 
@@ -148,53 +147,54 @@ TARS discovers patterns from Guitar Alchemist orchestrator traces (`~/.ga/traces
 
 TARS has a closed self-improvement loop:
 
-1. **Evolve** — Run tasks, observe outcomes
-2. **Extract** — Identify recurring patterns from execution traces
+1. **Evolve** — run tasks, observe outcomes
+2. **Extract** — identify recurring patterns from execution traces
 3. **Promote** — 7-step pipeline: Inspect → Extract → Classify → Propose → Validate → Persist → Govern
 4. **Index** — Bayesian-weighted ranking persisted to `~/.tars/promotion/index.json`
-5. **Select** — PatternSelector reads index, context-gated boost for next execution
+5. **Select** — `PatternSelector` reads index, context-gated boost for next execution
 6. **Repeat** — `tars evolve --loop N` runs N full cycles back-to-back
 
-Patterns climb: *Implementation → Helper → Builder → DslClause → GrammarRule*
+Patterns climb: *Implementation → Helper → Builder → DslClause → GrammarRule*.
 
 ---
 
-## Documentation
+## AI discipline (Karpathy + Cherny)
 
-See **[v2/README.md](./v2/README.md)** for full documentation including architecture details, configuration, and development guides.
+Every code-touching turn applies four rules: **think before coding · simplicity first · surgical changes · goal-driven execution**. Session continuity uses the Cherny pattern:
+
+- `/digest` — captures session state (cursor, in-flight work, hypotheses, success criteria) to `state/digests/latest.md`. Auto-fallback via `.claude/hooks/precompact-digest.ps1`; auto-injected on next session via `.claude/hooks/sessionstart-digest.ps1`.
+- `/learnings` — captures surprises to `docs/solutions/<category>/<date>-<topic>.md`.
+- `/correct` — turns user corrections into permanent rules in [`CLAUDE.md`](./CLAUDE.md)'s **Session-learned rules**.
+
+CI enforces hook integrity via [`.github/workflows/karpathy-cherny-discipline.yml`](./.github/workflows/karpathy-cherny-discipline.yml).
 
 ---
 
-## Active Boundaries
+## Quality cadence
 
-| Area | Status | Description |
-|------|--------|-------------|
-| **`v2/`** | **Active** | F# neuro-symbolic agent framework — all new development happens here |
-| **`v2/agents/`** | **Active** | Declarative agent definitions (Markdown + YAML frontmatter) |
-| **`v2/grammars/`** | **Active** | EBNF grammars for constrained decoding |
-| **`v2/puzzles/`** | **Active** | WoT puzzle benchmarks |
-| **`v2/docs/`** | **Active** | Architecture, roadmap, plans |
-| **`v1/`** | **Legacy** | Original C#/.NET implementation — retained for reference, not maintained |
-| **`archive/docs/`** | **Archived** | 119 historical reports, session summaries, and analysis docs moved from root |
-| **`archive/scripts/`** | **Archived** | 245 legacy PowerShell and F# scripts moved from root |
-| **`governance/`** | **Active** | Demerzel submodule — constitutions, policies, schemas |
+Golden artifacts under `v2/baselines/**` are schema-pinned via `v2/baselines/_schema.json` — drift triggers a CI failure ([PR #21](https://github.com/GuitarAlchemist/tars/pull/21)). Tribunal verdicts dispatch to the Demerzel constitutional tribunal via [`.github/workflows/qa-verdict-dispatch.yml`](./.github/workflows/qa-verdict-dispatch.yml) ([PR #22](https://github.com/GuitarAlchemist/tars/pull/22)). Agent risk surfaces through `.github/workflows/agent-blackbox.yml` against `agent-blackbox.policy.json`.
 
-**CI target:** `v2/` only (`working-directory: v2` in `dotnet.yml`). Archived content does not affect builds.
+---
 
 ## Repository Layout
 
-| Directory | Description |
-|-----------|-------------|
-| **[v2/](./v2/)** | Active project — F# neuro-symbolic agent framework |
-| **[v2/agents/](./v2/agents/)** | Declarative agent definitions (Markdown + YAML frontmatter) |
-| **[v2/grammars/](./v2/grammars/)** | EBNF grammars for constrained decoding |
-| **[v2/puzzles/](./v2/puzzles/)** | WoT puzzle benchmarks |
-| **[v2/docs/](./v2/docs/)** | Architecture, roadmap, plans |
-| **[archive/](./archive/)** | Legacy docs and scripts moved from root |
-| **[v1/](./v1/)** | Legacy C# projects — archived, not maintained |
+| Area | Status | Description |
+|------|--------|-------------|
+| **[v2/](./v2/)** | **Active** | F# neuro-symbolic agent framework — all new development happens here |
+| **[v2/agents/](./v2/agents/)** | Active | Declarative agent definitions (Markdown + YAML frontmatter) |
+| **[v2/grammars/](./v2/grammars/)** | Active | EBNF grammars for constrained decoding |
+| **[v2/baselines/](./v2/baselines/)** | Active | Schema-pinned golden artifacts (validated in CI) |
+| **[v2/puzzles/](./v2/puzzles/)** | Active | WoT puzzle benchmarks |
+| **[v2/docs/](./v2/docs/)** | Active | Architecture, roadmap, plans |
+| **[governance/](./governance/)** | Active | Demerzel submodule — constitution, policies, schemas |
+| **[state/](./state/)** | Active | Digests, quality snapshots, beliefs, PDCA, knowledge |
+| **[v1/](./v1/)** | Legacy | Original C#/.NET implementation — retained for reference, not maintained |
+| **[archive/](./archive/)** | Archived | 119 historical reports + 245 legacy scripts moved from root |
+
+**CI target:** `v2/` only (`working-directory: v2` in `dotnet.yml`). Archived content does not affect builds.
 
 ---
 
 ## License
 
-MIT License — see [LICENSE](./LICENSE) for details.
+MIT — see [LICENSE](./LICENSE).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,34 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/v2/src/Tars.Interface.Cli/Commands/Ask.fs
+++ b/v2/src/Tars.Interface.Cli/Commands/Ask.fs
@@ -1,13 +1,11 @@
 module Tars.Interface.Cli.Commands.Ask
 
-open System
-open Serilog
 open Tars.Llm
 open Tars.Interface.Cli
 
-let run (logger: ILogger) (prompt: string) =
+let run (rt: ITarsRuntime) (prompt: string) =
     task {
-        let llmService = LlmFactory.create logger
+        let llmService = rt.Llm ModelChoice.Default
 
         let req: LlmRequest =
             { ModelHint = None

--- a/v2/src/Tars.Interface.Cli/Program.fs
+++ b/v2/src/Tars.Interface.Cli/Program.fs
@@ -218,7 +218,7 @@ let main argv =
 
     task {
         match argv with
-        | [| "ask"; prompt |] -> return! Ask.run logger prompt
+        | [| "ask"; prompt |] -> return! Ask.run (TarsRuntime.production logger) prompt
         | [| "guard-output"; path |] ->
             // Defaults: no required fields, citations not required, extra fields not allowed
             return GuardOutputCommand.run config path None false false

--- a/v2/src/Tars.Interface.Cli/Runtime.fs
+++ b/v2/src/Tars.Interface.Cli/Runtime.fs
@@ -1,0 +1,52 @@
+namespace Tars.Interface.Cli
+
+open Serilog
+open Tars.Core
+open Tars.Llm
+
+/// Which LLM backend/model variant a command wants from the runtime.
+/// The common path is `Default`; the rarer variants become data, not separate
+/// factory methods.
+type ModelChoice =
+    | Default
+    | Model of string
+    | ClaudeCode of string option
+
+/// The CLI composition root: every dependency a command needs, built once and
+/// injected. Commands accept an `ITarsRuntime` instead of constructing the LLM
+/// service, the tool registry, or the configuration themselves. The production
+/// adapter wires the real services; tests supply a stub adapter — so the seam is
+/// the place command logic is tested.
+type ITarsRuntime =
+    /// Loaded TARS configuration.
+    abstract member Config: TarsConfig
+    /// Tool registry with all TARS tools registered (assembly scanned once).
+    abstract member Tools: IToolRegistry
+    /// Resolve an LLM service for the requested model choice.
+    abstract member Llm: ModelChoice -> ILlmService
+
+/// Builds runtime adapters.
+module TarsRuntime =
+
+    /// Production runtime: real LLM via `LlmFactory`, a tool registry scanned
+    /// once from the Tars.Tools assembly, and configuration loaded from disk.
+    let production (logger: ILogger) : ITarsRuntime =
+        let config = ConfigurationLoader.load ()
+
+        // Scan the tool assembly once, lazily, on first access — commands that
+        // never touch tools (e.g. `ask`) pay nothing.
+        let tools =
+            lazy
+                (let registry = Tars.Tools.ToolRegistry()
+                 registry.RegisterAssembly(typeof<Tars.Tools.TarsToolAttribute>.Assembly)
+                 registry :> IToolRegistry)
+
+        { new ITarsRuntime with
+            member _.Config = config
+            member _.Tools = tools.Value
+
+            member _.Llm choice =
+                match choice with
+                | Default -> LlmFactory.create logger
+                | Model model -> LlmFactory.createWithModel logger model
+                | ClaudeCode model -> LlmFactory.createClaudeCode model }

--- a/v2/src/Tars.Interface.Cli/Tars.Interface.Cli.fsproj
+++ b/v2/src/Tars.Interface.Cli/Tars.Interface.Cli.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="Reasoning\CliReasoner.fs" />
     <Compile Include="Reasoning\ReplayReasoner.fs" />
     <Compile Include="LlmFactory.fs" />
+    <Compile Include="Runtime.fs" />
     <Compile Include="ConsoleHelpers.fs" />
     <Compile Include="Commands\AgentHelpers.fs" />
     <Content Include="appsettings.json">

--- a/v2/tests/Tars.Tests/AskCommandTests.fs
+++ b/v2/tests/Tars.Tests/AskCommandTests.fs
@@ -1,0 +1,60 @@
+module Tars.Tests.AskCommandTests
+
+open System
+open System.Threading.Tasks
+open Xunit
+open Tars.Core
+open Tars.Llm
+open Tars.Interface.Cli
+
+// These tests exercise the `ask` command's logic through the ITarsRuntime seam.
+// Before TarsRuntime, a command built its own LlmFactory/ToolRegistry inline and
+// could only be tested by running the CLI; the stub runtime below is the second,
+// real adapter that makes the seam worth its keep.
+
+/// Minimal ILlmService stub returning a fixed completion.
+type private StubLlm(text: string, finishReason: string option) =
+    let response: LlmResponse =
+        { Text = text
+          FinishReason = finishReason
+          Usage = None
+          Raw = None }
+
+    interface ILlmService with
+        member _.CompleteAsync(_) = Task.FromResult response
+        member _.CompleteStreamAsync(_, _) = Task.FromResult response
+        member _.EmbedAsync(_) = Task.FromResult([| 0.0f |])
+
+        member _.RouteAsync(_) =
+            Task.FromResult(
+                ({ Backend = Tars.Llm.LlmBackend.Ollama "stub"
+                   Endpoint = Uri "http://localhost:11434"
+                   ApiKey = None }
+                : Tars.Llm.Routing.RoutedBackend)
+            )
+
+/// Empty tool registry stub — the `ask` command does not use tools.
+type private StubTools() =
+    interface IToolRegistry with
+        member _.Register(_) = ()
+        member _.Get(_) = None
+        member _.GetAll() = []
+
+/// Test runtime: stub LLM + stub tools, real config defaults.
+let private stubRuntime (llm: ILlmService) : ITarsRuntime =
+    { new ITarsRuntime with
+        member _.Config = ConfigurationLoader.load ()
+        member _.Tools = StubTools() :> IToolRegistry
+        member _.Llm _ = llm }
+
+[<Fact>]
+let ``ask returns 0 on a successful completion`` () =
+    let rt = stubRuntime (StubLlm("the answer", Some "stop"))
+    let code = (Commands.Ask.run rt "what is 2+2?").Result
+    Assert.Equal(0, code)
+
+[<Fact>]
+let ``ask returns 1 when the response is a parse error`` () =
+    let rt = stubRuntime (StubLlm("", Some "parse_error"))
+    let code = (Commands.Ask.run rt "bad input").Result
+    Assert.Equal(1, code)

--- a/v2/tests/Tars.Tests/Tars.Tests.fsproj
+++ b/v2/tests/Tars.Tests/Tars.Tests.fsproj
@@ -123,6 +123,7 @@
     <Compile Include="GrammarMlBridgeTests.fs" />
     <Compile Include="AgentDefinitionTests.fs" />
     <Compile Include="ResearchCycleTests.fs" />
+    <Compile Include="AskCommandTests.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
First PR in a five-part architecture-deepening sequence. Introduces the **spine** the other four plug into.

## What
A single seam for CLI command wiring. `ITarsRuntime` exposes:

```fsharp
type ModelChoice = Default | Model of string | ClaudeCode of string option
type ITarsRuntime =
  abstract Config : TarsConfig
  abstract Tools  : IToolRegistry          // assembly-scanned once, lazily
  abstract Llm    : ModelChoice -> ILlmService
```

The production adapter folds in `LlmFactory`'s surface and does the tool-assembly scan once. Commands accept the runtime instead of constructing the LLM service, the tool registry, and config themselves.

## Why
Today wiring is duplicated across the command surface — `LlmFactory.create` ×32 / `new ToolRegistry()` ×20 / `RegisterAssembly(...)` repeated — and **no command is testable without the whole stack**. This change gives that wiring a real seam: a production adapter and a stub adapter.

## Scope of this PR
- New `Runtime.fs` (`ITarsRuntime` + `ModelChoice` + `TarsRuntime.production`).
- `Ask` converted as the first command (`Ask.run rt prompt`).
- `AskCommandTests` drives `Ask.run` through a **stub runtime** — the second adapter that makes the seam real, not hypothetical. Command logic is testable without the CLI for the first time.
- `LlmFactory` is **retained** for the other 55 commands; it gets deleted once they migrate.

CLI builds 0 warnings / 0 errors (warnings-as-errors); 2 new tests green.

## Follow-on work
- #41 — Prompt module (uses `rt.Llm`)
- #42 — IPromotionStore + PromotionGate
- #43 — IPatternSelector.RecordOutcome
- #44 — Workflow module (executors built from `rt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)