### PR TITLE
refactor(llm): ILlmBackend seam + typed routing + LlamaSharp model pool (PR1+PR4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,16 @@ F# agent system with WoT DSL, evolution pipeline, and MCP tool surface. Part of 
 cd v2                 # working directory is v2/, not repo root
 dotnet build          # full build
 dotnet test           # ~820 tests (4 skipped for Docker)
+dotnet format --verify-no-changes
 ```
 
 Solution: `v2/Tars.sln`, target: `net10.0`.
+
+Repo harness verification:
+
+```powershell
+pwsh Scripts/verify.ps1
+```
 
 ## Layout
 
@@ -78,3 +85,19 @@ The hooks are validated in CI by `.github/workflows/karpathy-cherny-discipline.y
 _Appended by `/correct` when the user corrects an approach. Persists across sessions._
 
 (none yet)
+
+## Agent skills
+
+Per-repo config for the mattpocock engineering skills (`to-issues`, `to-prd`, `triage`, `qa`, `tdd`, `improve-codebase-architecture`, etc.).
+
+### Issue tracker
+
+Issues tracked via GitHub Issues via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical defaults (`needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context (`CONTEXT.md` + `docs/adr/`). See `docs/agents/domain.md`.

--- a/README.md
+++ b/README.md
@@ -1,43 +1,39 @@
-# TARS - Thinking, Acting, Reasoning System
+# TARS — Thinking, Acting, Reasoning System
 
 [![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
 [![F#](https://img.shields.io/badge/F%23-Functional-378BBA)](https://fsharp.org/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/Tests-819%20passing-brightgreen)]()
+[![Tests](https://img.shields.io/badge/Tests-~820%20passing-brightgreen)]()
 
-A modular, self-improving AI agent framework built in F#. Combines neuro-symbolic reasoning, multi-agent orchestration, probabilistic grammars, and a closed-loop evolution pipeline.
+Modular, self-improving F# agent framework — neuro-symbolic reasoning, multi-agent orchestration, probabilistic grammars, closed-loop evolution. Part of a four-repo ecosystem (`tars` + [`ga`](https://github.com/GuitarAlchemist/ga) + [`ix`](https://github.com/GuitarAlchemist/ix) + [`Demerzel`](https://github.com/GuitarAlchemist/Demerzel)).
 
-> *LLMs as stochastic generators + Symbolic systems as memory, law, and self-control.*
+> *LLMs as stochastic generators + symbolic systems as memory, law, and self-control.*
+
+> **Agent-facing canonical docs:** [`CLAUDE.md`](./CLAUDE.md) (breadcrumb-style). Full v2 docs: [`v2/README.md`](./v2/README.md).
 
 ---
 
 ## Quick Start
 
-The active project lives in [`v2/`](./v2/). All development happens there.
+All active development lives in [`v2/`](./v2/).
 
 ```bash
 cd v2
 dotnet build
-dotnet test          # 819 tests passing
-```
+dotnet test                        # ~820 tests (4 skipped — Docker-gated)
+dotnet format --verify-no-changes
 
-Interactive chat:
-
-```bash
+# Interactive chat
 dotnet run --project src/Tars.Interface.Cli -- chat
-```
 
-Agent-based reasoning:
-
-```bash
+# Agent reasoning (Workflow-of-Thought)
 dotnet run --project src/Tars.Interface.Cli -- agent run "Explain photosynthesis step by step"
-```
 
-Self-improvement loop:
-
-```bash
+# Self-improvement loop
 dotnet run --project src/Tars.Interface.Cli -- evolve --loop 3 --benchmark
 ```
+
+Repo harness verification: `pwsh Scripts/verify.ps1`.
 
 ---
 
@@ -50,7 +46,7 @@ dotnet run --project src/Tars.Interface.Cli -- evolve --loop 3 --benchmark
                                │              │
                     ┌──────────▼──────┐  ┌────▼───────────────┐
                     │  Agent Cortex   │  │   WoT DSL Engine   │
-                    │  (orchestrator) │  │  (.wot.trsx files)  │
+                    │  (orchestrator) │  │  (.wot.trsx files) │
                     └──────┬──────────┘  └────────┬───────────┘
                            │                      │
           ┌────────────────┼──────────────────────┤
@@ -66,15 +62,17 @@ dotnet run --project src/Tars.Interface.Cli -- evolve --loop 3 --benchmark
 |-------|----------|---------|
 | **Core** | Kernel, Core, Security, Llm | Abstractions, event bus, LLM providers, credentials |
 | **Intelligence** | Cortex, Evolution, DSL, Symbolic | Agent brain, promotion pipeline, WoT compiler, reflection |
-| **Knowledge** | Knowledge, Graph | Vector store, temporal knowledge graph, ledger |
+| **Knowledge** | Knowledge, Graph, LinkedData | Vector store, temporal knowledge graph, RDF/SPARQL |
 | **Interface** | CLI, UI, MCP Server | Commands, Blazor dashboard, tool server |
-| **Infra** | Tools, Connectors, Sandbox | 90+ tools, external APIs, Docker sandboxing |
+| **Infra** | Tools, Connectors, Sandbox, Migrations | 90+ tools, external APIs, Docker sandboxing |
+
+Full project map and conventions: [`v2/README.md`](./v2/README.md). LLM access **always** through `LlmFactory.create(logger)`; WoT (`.wot.trsx`) is the primary DSL; Metascript is **frozen**.
 
 ---
 
 ## MCP Server (150+ tools)
 
-TARS exposes a Model Context Protocol server with 150+ tools for use in Claude Code, VS Code, and other MCP clients.
+TARS exposes a Model Context Protocol server for Claude Code, VS Code, and other MCP clients.
 
 ```bash
 dotnet run --project src/Tars.Interface.Cli -- mcp server
@@ -118,15 +116,16 @@ dotnet run --project src/Tars.Interface.Cli -- <command>
 
 ## Cross-Repo Ecosystem
 
-Three repositories connected via MCP federation and filesystem bridges:
+Four sibling repositories connected via MCP federation, filesystem bridges, and the Demerzel governance constitution:
 
-| Repo | Language | Role | Link |
-|------|----------|------|------|
-| **TARS** | F# | Neuro-symbolic agent system | *this repo* |
+| Repo | Language | Role | Bridge |
+|------|----------|------|--------|
+| **TARS** | F# | Neuro-symbolic agent system, **cross-model theory validator** | *this repo* |
+| **[ga](https://github.com/GuitarAlchemist/ga)** | C# / F# DSL | Music theory domain + agentic chatbot | MCP + `~/.ga/traces/` |
 | **[ix](https://github.com/GuitarAlchemist/ix)** | Rust | 39 ML tools (stats, neural nets, optimization, game theory) | MCP federation |
-| **[GA](https://github.com/GuitarAlchemist/ga)** | C# | Music theory domain + chatbot | MCP + trace bridge |
+| **[Demerzel](https://github.com/GuitarAlchemist/Demerzel)** | Governance | 11-article epistemic constitution, ACP server, tribunal | Submodule at `governance/demerzel/` |
 
-All governed by the [Demerzel](https://github.com/GuitarAlchemist/Demerzel) constitution (11 articles, 12 personas, tetravalent logic).
+In the ecosystem, **TARS is the F# theory validator** — used cross-model to validate music-theory hypotheses originating from `ga`. Cross-repo contract drafts under `governance/demerzel/docs/contracts/v0.1.x` are explicitly **not frozen** until the owning plan's Phase 4 milestone.
 
 ### ix ML Integration
 
@@ -140,7 +139,7 @@ ix_ml_predict, ix_statistics_*, ix_optimization_*, ix_neural_*, ix_game_theory_*
 
 ### GA Trace Bridge
 
-TARS discovers patterns from Guitar Alchemist orchestrator traces (`~/.ga/traces/`) and promotes them through the evolution pipeline. 5 pattern families (21 artifacts) seeded from static code analysis.
+TARS discovers patterns from Guitar Alchemist orchestrator traces (`~/.ga/traces/`) and promotes them through the evolution pipeline. 5 pattern families (21 artifacts) seeded from static code analysis. New: `Tars.Evolution/ChatbotClaimsBridge.fs` extracts skill-routing claims from the `ga` chatbot for cross-model validation.
 
 ---
 
@@ -148,53 +147,54 @@ TARS discovers patterns from Guitar Alchemist orchestrator traces (`~/.ga/traces
 
 TARS has a closed self-improvement loop:
 
-1. **Evolve** — Run tasks, observe outcomes
-2. **Extract** — Identify recurring patterns from execution traces
+1. **Evolve** — run tasks, observe outcomes
+2. **Extract** — identify recurring patterns from execution traces
 3. **Promote** — 7-step pipeline: Inspect → Extract → Classify → Propose → Validate → Persist → Govern
 4. **Index** — Bayesian-weighted ranking persisted to `~/.tars/promotion/index.json`
-5. **Select** — PatternSelector reads index, context-gated boost for next execution
+5. **Select** — `PatternSelector` reads index, context-gated boost for next execution
 6. **Repeat** — `tars evolve --loop N` runs N full cycles back-to-back
 
-Patterns climb: *Implementation → Helper → Builder → DslClause → GrammarRule*
+Patterns climb: *Implementation → Helper → Builder → DslClause → GrammarRule*.
 
 ---
 
-## Documentation
+## AI discipline (Karpathy + Cherny)
 
-See **[v2/README.md](./v2/README.md)** for full documentation including architecture details, configuration, and development guides.
+Every code-touching turn applies four rules: **think before coding · simplicity first · surgical changes · goal-driven execution**. Session continuity uses the Cherny pattern:
+
+- `/digest` — captures session state (cursor, in-flight work, hypotheses, success criteria) to `state/digests/latest.md`. Auto-fallback via `.claude/hooks/precompact-digest.ps1`; auto-injected on next session via `.claude/hooks/sessionstart-digest.ps1`.
+- `/learnings` — captures surprises to `docs/solutions/<category>/<date>-<topic>.md`.
+- `/correct` — turns user corrections into permanent rules in [`CLAUDE.md`](./CLAUDE.md)'s **Session-learned rules**.
+
+CI enforces hook integrity via [`.github/workflows/karpathy-cherny-discipline.yml`](./.github/workflows/karpathy-cherny-discipline.yml).
 
 ---
 
-## Active Boundaries
+## Quality cadence
 
-| Area | Status | Description |
-|------|--------|-------------|
-| **`v2/`** | **Active** | F# neuro-symbolic agent framework — all new development happens here |
-| **`v2/agents/`** | **Active** | Declarative agent definitions (Markdown + YAML frontmatter) |
-| **`v2/grammars/`** | **Active** | EBNF grammars for constrained decoding |
-| **`v2/puzzles/`** | **Active** | WoT puzzle benchmarks |
-| **`v2/docs/`** | **Active** | Architecture, roadmap, plans |
-| **`v1/`** | **Legacy** | Original C#/.NET implementation — retained for reference, not maintained |
-| **`archive/docs/`** | **Archived** | 119 historical reports, session summaries, and analysis docs moved from root |
-| **`archive/scripts/`** | **Archived** | 245 legacy PowerShell and F# scripts moved from root |
-| **`governance/`** | **Active** | Demerzel submodule — constitutions, policies, schemas |
+Golden artifacts under `v2/baselines/**` are schema-pinned via `v2/baselines/_schema.json` — drift triggers a CI failure ([PR #21](https://github.com/GuitarAlchemist/tars/pull/21)). Tribunal verdicts dispatch to the Demerzel constitutional tribunal via [`.github/workflows/qa-verdict-dispatch.yml`](./.github/workflows/qa-verdict-dispatch.yml) ([PR #22](https://github.com/GuitarAlchemist/tars/pull/22)). Agent risk surfaces through `.github/workflows/agent-blackbox.yml` against `agent-blackbox.policy.json`.
 
-**CI target:** `v2/` only (`working-directory: v2` in `dotnet.yml`). Archived content does not affect builds.
+---
 
 ## Repository Layout
 
-| Directory | Description |
-|-----------|-------------|
-| **[v2/](./v2/)** | Active project — F# neuro-symbolic agent framework |
-| **[v2/agents/](./v2/agents/)** | Declarative agent definitions (Markdown + YAML frontmatter) |
-| **[v2/grammars/](./v2/grammars/)** | EBNF grammars for constrained decoding |
-| **[v2/puzzles/](./v2/puzzles/)** | WoT puzzle benchmarks |
-| **[v2/docs/](./v2/docs/)** | Architecture, roadmap, plans |
-| **[archive/](./archive/)** | Legacy docs and scripts moved from root |
-| **[v1/](./v1/)** | Legacy C# projects — archived, not maintained |
+| Area | Status | Description |
+|------|--------|-------------|
+| **[v2/](./v2/)** | **Active** | F# neuro-symbolic agent framework — all new development happens here |
+| **[v2/agents/](./v2/agents/)** | Active | Declarative agent definitions (Markdown + YAML frontmatter) |
+| **[v2/grammars/](./v2/grammars/)** | Active | EBNF grammars for constrained decoding |
+| **[v2/baselines/](./v2/baselines/)** | Active | Schema-pinned golden artifacts (validated in CI) |
+| **[v2/puzzles/](./v2/puzzles/)** | Active | WoT puzzle benchmarks |
+| **[v2/docs/](./v2/docs/)** | Active | Architecture, roadmap, plans |
+| **[governance/](./governance/)** | Active | Demerzel submodule — constitution, policies, schemas |
+| **[state/](./state/)** | Active | Digests, quality snapshots, beliefs, PDCA, knowledge |
+| **[v1/](./v1/)** | Legacy | Original C#/.NET implementation — retained for reference, not maintained |
+| **[archive/](./archive/)** | Archived | 119 historical reports + 245 legacy scripts moved from root |
+
+**CI target:** `v2/` only (`working-directory: v2` in `dotnet.yml`). Archived content does not affect builds.
 
 ---
 
 ## License
 
-MIT License — see [LICENSE](./LICENSE) for details.
+MIT — see [LICENSE](./LICENSE).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,34 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/v2/src/Tars.Interface.Cli/Commands/Ask.fs
+++ b/v2/src/Tars.Interface.Cli/Commands/Ask.fs
@@ -1,13 +1,11 @@
 module Tars.Interface.Cli.Commands.Ask
 
-open System
-open Serilog
 open Tars.Llm
 open Tars.Interface.Cli
 
-let run (logger: ILogger) (prompt: string) =
+let run (rt: ITarsRuntime) (prompt: string) =
     task {
-        let llmService = LlmFactory.create logger
+        let llmService = rt.Llm ModelChoice.Default
 
         let req: LlmRequest =
             { ModelHint = None

--- a/v2/src/Tars.Interface.Cli/Program.fs
+++ b/v2/src/Tars.Interface.Cli/Program.fs
@@ -218,7 +218,7 @@ let main argv =
 
     task {
         match argv with
-        | [| "ask"; prompt |] -> return! Ask.run logger prompt
+        | [| "ask"; prompt |] -> return! Ask.run (TarsRuntime.production logger) prompt
         | [| "guard-output"; path |] ->
             // Defaults: no required fields, citations not required, extra fields not allowed
             return GuardOutputCommand.run config path None false false

--- a/v2/src/Tars.Interface.Cli/Runtime.fs
+++ b/v2/src/Tars.Interface.Cli/Runtime.fs
@@ -1,0 +1,52 @@
+namespace Tars.Interface.Cli
+
+open Serilog
+open Tars.Core
+open Tars.Llm
+
+/// Which LLM backend/model variant a command wants from the runtime.
+/// The common path is `Default`; the rarer variants become data, not separate
+/// factory methods.
+type ModelChoice =
+    | Default
+    | Model of string
+    | ClaudeCode of string option
+
+/// The CLI composition root: every dependency a command needs, built once and
+/// injected. Commands accept an `ITarsRuntime` instead of constructing the LLM
+/// service, the tool registry, or the configuration themselves. The production
+/// adapter wires the real services; tests supply a stub adapter — so the seam is
+/// the place command logic is tested.
+type ITarsRuntime =
+    /// Loaded TARS configuration.
+    abstract member Config: TarsConfig
+    /// Tool registry with all TARS tools registered (assembly scanned once).
+    abstract member Tools: IToolRegistry
+    /// Resolve an LLM service for the requested model choice.
+    abstract member Llm: ModelChoice -> ILlmService
+
+/// Builds runtime adapters.
+module TarsRuntime =
+
+    /// Production runtime: real LLM via `LlmFactory`, a tool registry scanned
+    /// once from the Tars.Tools assembly, and configuration loaded from disk.
+    let production (logger: ILogger) : ITarsRuntime =
+        let config = ConfigurationLoader.load ()
+
+        // Scan the tool assembly once, lazily, on first access — commands that
+        // never touch tools (e.g. `ask`) pay nothing.
+        let tools =
+            lazy
+                (let registry = Tars.Tools.ToolRegistry()
+                 registry.RegisterAssembly(typeof<Tars.Tools.TarsToolAttribute>.Assembly)
+                 registry :> IToolRegistry)
+
+        { new ITarsRuntime with
+            member _.Config = config
+            member _.Tools = tools.Value
+
+            member _.Llm choice =
+                match choice with
+                | Default -> LlmFactory.create logger
+                | Model model -> LlmFactory.createWithModel logger model
+                | ClaudeCode model -> LlmFactory.createClaudeCode model }

--- a/v2/src/Tars.Interface.Cli/Tars.Interface.Cli.fsproj
+++ b/v2/src/Tars.Interface.Cli/Tars.Interface.Cli.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="Reasoning\CliReasoner.fs" />
     <Compile Include="Reasoning\ReplayReasoner.fs" />
     <Compile Include="LlmFactory.fs" />
+    <Compile Include="Runtime.fs" />
     <Compile Include="ConsoleHelpers.fs" />
     <Compile Include="Commands\AgentHelpers.fs" />
     <Content Include="appsettings.json">

--- a/v2/src/Tars.Llm/Backends.fs
+++ b/v2/src/Tars.Llm/Backends.fs
@@ -1,0 +1,98 @@
+namespace Tars.Llm
+
+open System
+open System.Net.Http
+open System.Threading.Tasks
+open Tars.Llm.Routing
+
+/// A chat-completion backend resolved to a single provider/endpoint/model/key.
+/// This is the one place provider dispatch lives: routing decides *which* backend,
+/// and the adapters wrap the existing per-provider client functions unchanged.
+type ILlmBackend =
+    /// Non-streaming chat completion.
+    abstract member Complete: LlmRequest -> Task<LlmResponse>
+    /// Streaming chat completion; tokens are delivered to onToken as they arrive.
+    abstract member Stream: LlmRequest * (string -> unit) -> Task<LlmResponse>
+
+/// Resolves a routed backend to its adapter.
+/// The single `resolve` match replaces the per-interface dispatch that used to be
+/// duplicated across DefaultLlmService.
+module Backends =
+
+    let private openAiCompatible (http: HttpClient) (endpoint: Uri) (model: string) (apiKey: string option) =
+        { new ILlmBackend with
+            member _.Complete req =
+                OpenAiCompatibleClient.sendChatAsync http endpoint model apiKey req
+
+            member _.Stream(req, onToken) =
+                OpenAiCompatibleClient.sendChatStreamAsync http endpoint model apiKey req onToken }
+
+    let private ollama (http: HttpClient) (endpoint: Uri) (model: string) (apiKey: string option) =
+        { new ILlmBackend with
+            member _.Complete req =
+                OllamaClient.sendChatAsync http endpoint model apiKey req
+
+            member _.Stream(req, onToken) =
+                OllamaClient.sendChatStreamAsync http endpoint model apiKey req onToken }
+
+    let private gemini (http: HttpClient) (endpoint: Uri) (model: string) (apiKey: string option) =
+        { new ILlmBackend with
+            member _.Complete req =
+                GoogleGeminiClient.generateContentAsync http endpoint model apiKey req
+
+            member _.Stream(_req, _onToken) =
+                raise (NotImplementedException("Google Gemini streaming not implemented")) }
+
+    let private anthropic (http: HttpClient) (endpoint: Uri) (model: string) (apiKey: string option) =
+        { new ILlmBackend with
+            member _.Complete req =
+                AnthropicClient.sendMessageAsync http endpoint model apiKey req
+
+            member _.Stream(req, onToken) =
+                AnthropicClient.sendMessageStreamAsync http endpoint model apiKey req onToken }
+
+    let private llamaCpp (http: HttpClient) (endpoint: Uri) (model: string) config (apiKey: string option) =
+        { new ILlmBackend with
+            member _.Complete req =
+                LlamaCppClient.sendChatAsync http endpoint model config apiKey req
+
+            member _.Stream(req, onToken) =
+                LlamaCppClient.sendChatStreamAsync http endpoint model config apiKey req onToken }
+
+    let private llamaSharp (cfg: LlmServiceConfig) (modelPath: string) (apiKey: string option) =
+        let svc = LlamaSharpFactory.getService cfg apiKey modelPath
+
+        { new ILlmBackend with
+            member _.Complete req = (svc :> ILlmService).CompleteAsync req
+            member _.Stream(req, onToken) = (svc :> ILlmService).CompleteStreamAsync(req, onToken) }
+
+    /// The single provider-dispatch match: a routed backend becomes its adapter.
+    let resolve (cfg: LlmServiceConfig) (http: HttpClient) (routed: RoutedBackend) : ILlmBackend =
+        match routed.Backend with
+        | Ollama model -> ollama http routed.Endpoint model routed.ApiKey
+        | Vllm model
+        | OpenAI model
+        | DockerModelRunner model -> openAiCompatible http routed.Endpoint model routed.ApiKey
+        | GoogleGemini model -> gemini http routed.Endpoint model routed.ApiKey
+        | Anthropic model -> anthropic http routed.Endpoint model routed.ApiKey
+        | LlamaCpp(model, config) -> llamaCpp http routed.Endpoint model config routed.ApiKey
+        | LlamaSharp modelPath -> llamaSharp cfg modelPath routed.ApiKey
+
+/// Embedding routing is independent of chat-backend routing: it selects by the
+/// configured embedding-model name, not by the routed chat backend.
+module Embedder =
+
+    let private isOllamaEmbedding (model: string) =
+        model.Contains("nomic")
+        || model.Contains("mxbai")
+        || model.Contains("llama")
+        || model.Contains("qwen")
+
+    /// Select the embedding backend by model name and run it (Task flavor).
+    let embed (http: HttpClient) (routing: RoutingConfig) (text: string) : Task<float32[]> =
+        let model = routing.DefaultEmbeddingModel
+
+        if isOllamaEmbedding model then
+            OllamaClient.getEmbeddingsAsync http routing.OllamaBaseUri model text
+        else
+            OpenAiCompatibleClient.getEmbeddingsAsync http routing.OpenAIBaseUri model routing.OpenAIKey text

--- a/v2/src/Tars.Llm/Backends.fs
+++ b/v2/src/Tars.Llm/Backends.fs
@@ -63,8 +63,8 @@ module Backends =
         let svc = LlamaSharpFactory.getService cfg apiKey modelPath
 
         { new ILlmBackend with
-            member _.Complete req = (svc :> ILlmService).CompleteAsync req
-            member _.Stream(req, onToken) = (svc :> ILlmService).CompleteStreamAsync(req, onToken) }
+            member _.Complete req = svc.CompleteAsync req
+            member _.Stream(req, onToken) = svc.CompleteStreamAsync(req, onToken) }
 
     /// The single provider-dispatch match: a routed backend becomes its adapter.
     let resolve (cfg: LlmServiceConfig) (http: HttpClient) (routed: RoutedBackend) : ILlmBackend =

--- a/v2/src/Tars.Llm/LlamaSharpFactory.fs
+++ b/v2/src/Tars.Llm/LlamaSharpFactory.fs
@@ -1,14 +1,91 @@
 namespace Tars.Llm
 
-open System.Collections.Concurrent
+open System
+open System.Collections.Generic
 
-/// <summary>
-/// Factory to manage LlamaSharp instances to avoid reloading models.
-/// </summary>
+/// A bounded pool of in-process local (LlamaSharp) model services. Acquiring a
+/// model path returns a ready ILlmService; when the resident count exceeds the
+/// bound the least-recently-used entry is evicted and its native handles are
+/// disposed. Dispose() frees every resident model at shutdown.
+///
+/// Eviction assumes the evicted model is not concurrently in use — safe for the
+/// default serial, single-resident-model usage. Raise the bound only when models
+/// are used one-at-a-time per slot.
+type ILocalModelPool =
+    inherit IDisposable
+    abstract member Acquire: cfg: LlmServiceConfig * modelPath: string -> ILlmService
+
+/// Bounded LRU pool. `create` builds a service for a model path (its result must
+/// be IDisposable for eviction to release handles); injecting it keeps the
+/// eviction/LRU bookkeeping testable without loading a real model.
+type LocalModelPool(maxResident: int, create: LlmServiceConfig -> string -> ILlmService) =
+    let gate = obj ()
+    // Most-recently-used at the end; least-recently-used (eviction target) at the front.
+    let entries = LinkedList<string * ILlmService>()
+    let index = Dictionary<string, LinkedListNode<string * ILlmService>>()
+    let mutable disposed = false
+
+    let disposeService (svc: ILlmService) =
+        match box svc with
+        | :? IDisposable as d -> d.Dispose()
+        | _ -> ()
+
+    interface ILocalModelPool with
+        member _.Acquire(cfg, modelPath) =
+            lock gate (fun () ->
+                if disposed then
+                    raise (ObjectDisposedException("LocalModelPool"))
+
+                match index.TryGetValue modelPath with
+                | true, node ->
+                    // Cache hit — promote to most-recently-used.
+                    entries.Remove node
+                    entries.AddLast node |> ignore
+                    snd node.Value
+                | _ ->
+                    let svc = create cfg modelPath
+                    let node = entries.AddLast((modelPath, svc))
+                    index.[modelPath] <- node
+
+                    // Evict least-recently-used entries beyond the bound.
+                    while entries.Count > max 1 maxResident do
+                        let lru = entries.First
+                        entries.RemoveFirst()
+                        index.Remove(fst lru.Value) |> ignore
+                        disposeService (snd lru.Value)
+
+                    svc)
+
+    interface IDisposable with
+        member _.Dispose() =
+            lock gate (fun () ->
+                if not disposed then
+                    disposed <- true
+
+                    for (_, svc) in entries do
+                        disposeService svc
+
+                    entries.Clear()
+                    index.Clear())
+
+/// Process-wide shared local-model pool and the thin accessor the backend
+/// resolver uses. Replaces the former unbounded, never-disposed cache.
 module LlamaSharpFactory =
-    
-    let private cache = ConcurrentDictionary<string, LlamaSharpService>()
-    
-    let getService (config: LlmServiceConfig) (apiKey: string option) (modelPath: string) =
-        cache.GetOrAdd(modelPath, fun path ->
-            new LlamaSharpService(config, path))
+
+    let private poolSize =
+        match Int32.TryParse(Environment.GetEnvironmentVariable("TARS_LLAMASHARP_POOL_SIZE")) with
+        | true, n when n > 0 -> n
+        | _ -> 1
+
+    let private shared: ILocalModelPool =
+        let pool =
+            new LocalModelPool(poolSize, (fun cfg path -> new LlamaSharpService(cfg, path) :> ILlmService))
+            :> ILocalModelPool
+        // Best-effort release of native handles on graceful process exit.
+        AppDomain.CurrentDomain.ProcessExit.Add(fun _ -> pool.Dispose())
+        pool
+
+    /// Acquire (load-or-reuse) the local model service for a model path.
+    /// apiKey is unused by the local backend and kept only for call-site stability.
+    let getService (cfg: LlmServiceConfig) (_apiKey: string option) (modelPath: string) : ILlmService =
+        shared.Acquire(cfg, modelPath)

--- a/v2/src/Tars.Llm/LlamaSharpService.fs
+++ b/v2/src/Tars.Llm/LlamaSharpService.fs
@@ -187,3 +187,17 @@ type LlamaSharpService(_config: LlmServiceConfig, modelPath: string) =
             task {
                 return { Backend = LlamaSharp modelPath; Endpoint = Uri("local://llama.sharp"); ApiKey = None }
             }
+
+    /// Releases the native LLamaSharp handles (weights, context, embedder) and the
+    /// generation semaphore. The model pool calls this on eviction and shutdown;
+    /// without it these GPU/native resources leaked for the process lifetime.
+    interface IDisposable with
+        member _.Dispose() =
+            match box executor with
+            | :? IDisposable as d -> d.Dispose()
+            | _ -> ()
+
+            embedder.Dispose()
+            context.Dispose()
+            model.Dispose()
+            semaphore.Dispose()

--- a/v2/src/Tars.Llm/LlmService.fs
+++ b/v2/src/Tars.Llm/LlmService.fs
@@ -37,80 +37,17 @@ module LlmService =
                     let req = enrichRequest cfg.Routing req
                     let routed = chooseBackend cfg.Routing req
 
+                    // Ollama keeps its functional-path validation (generateValidated);
+                    // every other backend delegates to the shared resolver and wraps
+                    // exceptions into LlmError generically — same behaviour as before,
+                    // dispatch defined once.
                     match routed.Backend with
                     | Ollama model ->
                         return! OllamaClientAsync.generateValidated httpClient routed.Endpoint model routed.ApiKey req
-                    | Vllm model ->
+                    | _ ->
                         try
                             let! res =
-                                OpenAiCompatibleClient.sendChatAsync httpClient routed.Endpoint model routed.ApiKey req
-                                |> Async.AwaitTask
-                                |> AsyncResult.ofAsync
-
-                            return res
-                        with ex ->
-                            return! AsyncResult.ofResult (rerror<LlmResponse> (LlmError.fromException ex))
-                    | OpenAI model ->
-                        try
-                            let! res =
-                                OpenAiCompatibleClient.sendChatAsync httpClient routed.Endpoint model routed.ApiKey req
-                                |> Async.AwaitTask
-                                |> AsyncResult.ofAsync
-
-                            return res
-                        with ex ->
-                            return! AsyncResult.ofResult (rerror<LlmResponse> (LlmError.fromException ex))
-                    | GoogleGemini model ->
-                        try
-                            let! res =
-                                GoogleGeminiClient.generateContentAsync
-                                    httpClient
-                                    routed.Endpoint
-                                    model
-                                    routed.ApiKey
-                                    req
-                                |> Async.AwaitTask
-                                |> AsyncResult.ofAsync
-
-                            return res
-                        with ex ->
-                            return! AsyncResult.ofResult (rerror<LlmResponse> (LlmError.fromException ex))
-                    | Anthropic model ->
-                        try
-                            let! res =
-                                AnthropicClient.sendMessageAsync httpClient routed.Endpoint model routed.ApiKey req
-                                |> Async.AwaitTask
-                                |> AsyncResult.ofAsync
-
-                            return res
-                        with ex ->
-                            return! AsyncResult.ofResult (rerror<LlmResponse> (LlmError.fromException ex))
-                    | DockerModelRunner model ->
-                        try
-                            let! res =
-                                OpenAiCompatibleClient.sendChatAsync httpClient routed.Endpoint model routed.ApiKey req
-                                |> Async.AwaitTask
-                                |> AsyncResult.ofAsync
-
-                            return res
-                        with ex ->
-                            return! AsyncResult.ofResult (rerror<LlmResponse> (LlmError.fromException ex))
-                    | LlamaCpp(model, config) ->
-                        try
-                            let! res =
-                                LlamaCppClient.sendChatAsync httpClient routed.Endpoint model config routed.ApiKey req
-                                |> Async.AwaitTask
-                                |> AsyncResult.ofAsync
-
-                            return res
-                        with ex ->
-                            return! AsyncResult.ofResult (rerror<LlmResponse> (LlmError.fromException ex))
-                    | LlamaSharp modelPath ->
-                        try
-                            let svc = LlamaSharpFactory.getService cfg routed.ApiKey modelPath
-
-                            let! res =
-                                (svc :> ILlmService).CompleteAsync(req)
+                                (Backends.resolve cfg httpClient routed).Complete req
                                 |> Async.AwaitTask
                                 |> AsyncResult.ofAsync
 
@@ -158,105 +95,17 @@ module LlmService =
                 task {
                     let req = enrichRequest cfg.Routing req
                     let routed = chooseBackend cfg.Routing req
-
-                    match routed.Backend with
-                    | Ollama model ->
-                        return! OllamaClient.sendChatAsync httpClient routed.Endpoint model routed.ApiKey req
-                    | Vllm model ->
-                        return! OpenAiCompatibleClient.sendChatAsync httpClient routed.Endpoint model routed.ApiKey req
-                    | OpenAI model ->
-                        return! OpenAiCompatibleClient.sendChatAsync httpClient routed.Endpoint model routed.ApiKey req
-                    | GoogleGemini model ->
-                        return!
-                            GoogleGeminiClient.generateContentAsync httpClient routed.Endpoint model routed.ApiKey req
-                    | Anthropic model ->
-                        return! AnthropicClient.sendMessageAsync httpClient routed.Endpoint model routed.ApiKey req
-                    | DockerModelRunner model ->
-                        return! OpenAiCompatibleClient.sendChatAsync httpClient routed.Endpoint model routed.ApiKey req
-                    | LlamaCpp(model, config) ->
-                        return! LlamaCppClient.sendChatAsync httpClient routed.Endpoint model config routed.ApiKey req
-                    | LlamaSharp modelPath ->
-                        let svc = LlamaSharpFactory.getService cfg routed.ApiKey modelPath
-                        return! (svc :> ILlmService).CompleteAsync(req)
+                    return! (Backends.resolve cfg httpClient routed).Complete req
                 }
 
             member _.CompleteStreamAsync(req: LlmRequest, onToken: string -> unit) : Task<LlmResponse> =
                 task {
                     let req = enrichRequest cfg.Routing req
                     let routed = chooseBackend cfg.Routing req
-
-                    match routed.Backend with
-                    | Ollama model ->
-                        return!
-                            OllamaClient.sendChatStreamAsync httpClient routed.Endpoint model routed.ApiKey req onToken
-                    | Vllm model ->
-                        return!
-                            OpenAiCompatibleClient.sendChatStreamAsync
-                                httpClient
-                                routed.Endpoint
-                                model
-                                routed.ApiKey
-                                req
-                                onToken
-                    | OpenAI model ->
-                        return!
-                            OpenAiCompatibleClient.sendChatStreamAsync
-                                httpClient
-                                routed.Endpoint
-                                model
-                                routed.ApiKey
-                                req
-                                onToken
-                    | GoogleGemini _ ->
-                        return raise (NotImplementedException("Google Gemini streaming not implemented"))
-                    | Anthropic model ->
-                        return!
-                            AnthropicClient.sendMessageStreamAsync
-                                httpClient routed.Endpoint model routed.ApiKey req onToken
-                    | DockerModelRunner model ->
-                        return!
-                            OpenAiCompatibleClient.sendChatStreamAsync
-                                httpClient
-                                routed.Endpoint
-                                model
-                                routed.ApiKey
-                                req
-                                onToken
-                    | LlamaCpp(model, config) ->
-                        return!
-                            LlamaCppClient.sendChatStreamAsync
-                                httpClient
-                                routed.Endpoint
-                                model
-                                config
-                                routed.ApiKey
-                                req
-                                onToken
-                    | LlamaSharp modelPath ->
-                        let svc = LlamaSharpFactory.getService cfg routed.ApiKey modelPath
-                        return! (svc :> ILlmService).CompleteStreamAsync(req, onToken)
+                    return! (Backends.resolve cfg httpClient routed).Stream(req, onToken)
                 }
 
-            member _.EmbedAsync(text: string) : Task<float32[]> =
-                task {
-                    let model = cfg.Routing.DefaultEmbeddingModel
-
-                    if
-                        model.Contains("nomic")
-                        || model.Contains("mxbai")
-                        || model.Contains("llama")
-                        || model.Contains("qwen")
-                    then
-                        return! OllamaClient.getEmbeddingsAsync httpClient cfg.Routing.OllamaBaseUri model text
-                    else
-                        return!
-                            OpenAiCompatibleClient.getEmbeddingsAsync
-                                httpClient
-                                cfg.Routing.OpenAIBaseUri
-                                model
-                                cfg.Routing.OpenAIKey
-                                text
-                }
+            member _.EmbedAsync(text: string) : Task<float32[]> = Embedder.embed httpClient cfg.Routing text
 
             member _.RouteAsync(req: LlmRequest) : Task<RoutedBackend> =
                 task {

--- a/v2/src/Tars.Llm/Routing.fs
+++ b/v2/src/Tars.Llm/Routing.fs
@@ -81,6 +81,49 @@ type RoutedBackend =
       Endpoint: Uri
       ApiKey: string option }
 
+/// Provider family inferred from an explicit model name. Isolates the fragile
+/// substring matching so routing can decide over a closed, compiler-checked type.
+type ModelFamily =
+    | OpenAIFamily
+    | AnthropicFamily
+    | GeminiFamily
+    | LocalFamily
+
+module ModelFamily =
+    /// Classify an explicit model name into its provider family.
+    let classify (model: string) : ModelFamily =
+        let has (s: string) = model.Contains(s, StringComparison.OrdinalIgnoreCase)
+
+        if has "gpt" then OpenAIFamily
+        elif has "claude" then AnthropicFamily
+        elif has "gemini" then GeminiFamily
+        else LocalFamily
+
+/// Routing intent inferred from a model hint. The order of classification is
+/// significant and mirrors the original sequential matching.
+type RoutingHint =
+    | CodeHint
+    | CheapHint
+    | ReasoningHint
+    | DockerHint
+    | LlamaCppHint
+    | FastHint
+    | DefaultHint
+
+module RoutingHint =
+    /// Classify a (possibly empty) model hint into a routing intent.
+    let classify (hint: string) : RoutingHint =
+        let has (s: string) = hint.Contains(s, StringComparison.OrdinalIgnoreCase)
+
+        if has "code" then CodeHint
+        elif has "cheap" then CheapHint
+        elif has "reason" || has "analysis" || has "think" || has "math" || has "complex" || has "step" || has "smart" then
+            ReasoningHint
+        elif has "docker" then DockerHint
+        elif has "llamacpp" || has "perf" || has "gguf" then LlamaCppHint
+        elif has "fast" || has "quick" then FastHint
+        else DefaultHint
+
 /// <summary>
 /// Routes an LLM request to the appropriate backend based on model hints.
 /// </summary>
@@ -104,20 +147,21 @@ let chooseBackend (cfg: RoutingConfig) (req: LlmRequest) : RoutedBackend =
 
     match req.Model with
     | Some model ->
-        // If model is explicitly set, try to guess backend or default to Ollama
-        if model.Contains("gpt", StringComparison.OrdinalIgnoreCase) then
+        // If model is explicitly set, classify its provider family then route.
+        match ModelFamily.classify model with
+        | OpenAIFamily ->
             { Backend = OpenAI model
               Endpoint = cfg.OpenAIBaseUri
               ApiKey = cfg.OpenAIKey }
-        elif model.Contains("claude", StringComparison.OrdinalIgnoreCase) then
+        | AnthropicFamily ->
             { Backend = Anthropic model
               Endpoint = cfg.AnthropicBaseUri
               ApiKey = cfg.AnthropicKey }
-        elif model.Contains("gemini", StringComparison.OrdinalIgnoreCase) then
+        | GeminiFamily ->
             { Backend = GoogleGemini model
               Endpoint = cfg.GoogleGeminiBaseUri
               ApiKey = cfg.GoogleGeminiKey }
-        else
+        | LocalFamily ->
             // Check if it matches configured llama.cpp model
             match cfg.LlamaCppBaseUri, cfg.DefaultLlamaCppModel, cfg.LlamaSharpModelPath with
             | Some llamaUri, Some llamaModel, _ when
@@ -156,24 +200,14 @@ let chooseBackend (cfg: RoutingConfig) (req: LlmRequest) : RoutedBackend =
                       Endpoint = cfg.OllamaBaseUri
                       ApiKey = cfg.OllamaKey }
 
-        match hint with
-        | h when h.Contains("code", StringComparison.OrdinalIgnoreCase) ->
-            localRoute (cfg.CodingModel |> Option.defaultValue cfg.DefaultOllamaModel)
+        match RoutingHint.classify hint with
+        | CodeHint -> localRoute (cfg.CodingModel |> Option.defaultValue cfg.DefaultOllamaModel)
 
-        | h when h.Contains("cheap", StringComparison.OrdinalIgnoreCase) -> localRoute cfg.DefaultOllamaModel
+        | CheapHint -> localRoute cfg.DefaultOllamaModel
 
-        | h when
-            h.Contains("reason", StringComparison.OrdinalIgnoreCase)
-            || h.Contains("analysis", StringComparison.OrdinalIgnoreCase)
-            || h.Contains("think", StringComparison.OrdinalIgnoreCase)
-            || h.Contains("math", StringComparison.OrdinalIgnoreCase)
-            || h.Contains("complex", StringComparison.OrdinalIgnoreCase)
-            || h.Contains("step", StringComparison.OrdinalIgnoreCase)
-            || h.Contains("smart", StringComparison.OrdinalIgnoreCase)
-            ->
-            localRoute (cfg.ReasoningModel |> Option.defaultValue cfg.DefaultOllamaModel)
+        | ReasoningHint -> localRoute (cfg.ReasoningModel |> Option.defaultValue cfg.DefaultOllamaModel)
 
-        | h when h.Contains("docker", StringComparison.OrdinalIgnoreCase) ->
+        | DockerHint ->
             match cfg.DockerModelRunnerBaseUri, cfg.DefaultDockerModelRunnerModel with
             | Some uri, Some model ->
                 { Backend = DockerModelRunner model
@@ -181,11 +215,7 @@ let chooseBackend (cfg: RoutingConfig) (req: LlmRequest) : RoutedBackend =
                   ApiKey = cfg.DockerModelRunnerKey }
             | _ -> localRoute cfg.DefaultOllamaModel
 
-        | h when
-            h.Contains("llamacpp", StringComparison.OrdinalIgnoreCase)
-            || h.Contains("perf", StringComparison.OrdinalIgnoreCase)
-            || h.Contains("gguf", StringComparison.OrdinalIgnoreCase)
-            ->
+        | LlamaCppHint ->
             match cfg.LlamaCppBaseUri, cfg.DefaultLlamaCppModel with
             | Some uri, Some model ->
                 { Backend = LlamaCpp(model, Some LlamaCppConfig.Default)
@@ -193,13 +223,9 @@ let chooseBackend (cfg: RoutingConfig) (req: LlmRequest) : RoutedBackend =
                   ApiKey = cfg.LlamaCppKey }
             | _ -> localRoute cfg.DefaultOllamaModel
 
-        | h when
-            h.Contains("fast", StringComparison.OrdinalIgnoreCase)
-            || h.Contains("quick", StringComparison.OrdinalIgnoreCase)
-            ->
-            localRoute (cfg.FastModel |> Option.defaultValue cfg.DefaultOllamaModel)
+        | FastHint -> localRoute (cfg.FastModel |> Option.defaultValue cfg.DefaultOllamaModel)
 
-        | _ -> localRoute cfg.DefaultOllamaModel
+        | DefaultHint -> localRoute cfg.DefaultOllamaModel
 
 module RoutingConfig =
     /// <summary>

--- a/v2/src/Tars.Llm/Tars.Llm.fsproj
+++ b/v2/src/Tars.Llm/Tars.Llm.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="LlamaCppClient.fs" />
     <Compile Include="LlamaSharpService.fs" />
     <Compile Include="LlamaSharpFactory.fs" />
+    <Compile Include="Backends.fs" />
     <Compile Include="LlmService.fs" />
     <Compile Include="ChatClientAdapter.fs" />
     <Compile Include="VllmClient.fs" />

--- a/v2/tests/Tars.Tests/AskCommandTests.fs
+++ b/v2/tests/Tars.Tests/AskCommandTests.fs
@@ -1,0 +1,60 @@
+module Tars.Tests.AskCommandTests
+
+open System
+open System.Threading.Tasks
+open Xunit
+open Tars.Core
+open Tars.Llm
+open Tars.Interface.Cli
+
+// These tests exercise the `ask` command's logic through the ITarsRuntime seam.
+// Before TarsRuntime, a command built its own LlmFactory/ToolRegistry inline and
+// could only be tested by running the CLI; the stub runtime below is the second,
+// real adapter that makes the seam worth its keep.
+
+/// Minimal ILlmService stub returning a fixed completion.
+type private StubLlm(text: string, finishReason: string option) =
+    let response: LlmResponse =
+        { Text = text
+          FinishReason = finishReason
+          Usage = None
+          Raw = None }
+
+    interface ILlmService with
+        member _.CompleteAsync(_) = Task.FromResult response
+        member _.CompleteStreamAsync(_, _) = Task.FromResult response
+        member _.EmbedAsync(_) = Task.FromResult([| 0.0f |])
+
+        member _.RouteAsync(_) =
+            Task.FromResult(
+                ({ Backend = Tars.Llm.LlmBackend.Ollama "stub"
+                   Endpoint = Uri "http://localhost:11434"
+                   ApiKey = None }
+                : Tars.Llm.Routing.RoutedBackend)
+            )
+
+/// Empty tool registry stub — the `ask` command does not use tools.
+type private StubTools() =
+    interface IToolRegistry with
+        member _.Register(_) = ()
+        member _.Get(_) = None
+        member _.GetAll() = []
+
+/// Test runtime: stub LLM + stub tools, real config defaults.
+let private stubRuntime (llm: ILlmService) : ITarsRuntime =
+    { new ITarsRuntime with
+        member _.Config = ConfigurationLoader.load ()
+        member _.Tools = StubTools() :> IToolRegistry
+        member _.Llm _ = llm }
+
+[<Fact>]
+let ``ask returns 0 on a successful completion`` () =
+    let rt = stubRuntime (StubLlm("the answer", Some "stop"))
+    let code = (Commands.Ask.run rt "what is 2+2?").Result
+    Assert.Equal(0, code)
+
+[<Fact>]
+let ``ask returns 1 when the response is a parse error`` () =
+    let rt = stubRuntime (StubLlm("", Some "parse_error"))
+    let code = (Commands.Ask.run rt "bad input").Result
+    Assert.Equal(1, code)

--- a/v2/tests/Tars.Tests/LocalModelPoolTests.fs
+++ b/v2/tests/Tars.Tests/LocalModelPoolTests.fs
@@ -1,0 +1,103 @@
+module Tars.Tests.LocalModelPoolTests
+
+open System
+open System.Threading.Tasks
+open System.Collections.Generic
+open Xunit
+open Tars.Llm
+open Tars.Llm.Routing
+
+// The pool's create function is injectable, so the LRU / eviction / disposal
+// bookkeeping is testable with a fake disposable service — no real model load.
+
+type private FakeModel() =
+    member val Disposed = false with get, set
+
+    interface ILlmService with
+        member _.CompleteAsync(_) =
+            Task.FromResult(
+                { Text = ""
+                  FinishReason = None
+                  Usage = None
+                  Raw = None }
+            )
+
+        member _.CompleteStreamAsync(_, _) =
+            Task.FromResult(
+                { Text = ""
+                  FinishReason = None
+                  Usage = None
+                  Raw = None }
+            )
+
+        member _.EmbedAsync(_) = Task.FromResult(Array.empty<float32>)
+
+        member _.RouteAsync(_) =
+            Task.FromResult(
+                ({ Backend = LlmBackend.Ollama "fake"
+                   Endpoint = Uri "http://localhost"
+                   ApiKey = None }
+                : RoutedBackend)
+            )
+
+    interface IDisposable with
+        member this.Dispose() = this.Disposed <- true
+
+// create ignores cfg, so a null config is never dereferenced.
+let private noCfg = Unchecked.defaultof<LlmServiceConfig>
+
+[<Fact>]
+let ``Acquire reuses the same service for a repeated model path`` () =
+    let mutable created = 0
+
+    let pool =
+        new LocalModelPool(
+            2,
+            fun _ _ ->
+                created <- created + 1
+                new FakeModel() :> ILlmService
+        )
+        :> ILocalModelPool
+
+    let a1 = pool.Acquire(noCfg, "modelA")
+    let a2 = pool.Acquire(noCfg, "modelA")
+
+    Assert.Same(a1, a2)
+    Assert.Equal(1, created)
+
+[<Fact>]
+let ``Exceeding the bound evicts and disposes the least-recently-used model`` () =
+    let fakes = Dictionary<string, FakeModel>()
+
+    let create =
+        fun _ path ->
+            let f = new FakeModel()
+            fakes.[path] <- f
+            f :> ILlmService
+
+    let pool = new LocalModelPool(1, create) :> ILocalModelPool
+
+    pool.Acquire(noCfg, "A") |> ignore
+    pool.Acquire(noCfg, "B") |> ignore // bound is 1 → A is evicted
+
+    Assert.True(fakes.["A"].Disposed, "evicted model A should be disposed")
+    Assert.False(fakes.["B"].Disposed, "resident model B should not be disposed")
+
+[<Fact>]
+let ``Dispose releases all resident models`` () =
+    let fakes = Dictionary<string, FakeModel>()
+
+    let create =
+        fun _ path ->
+            let f = new FakeModel()
+            fakes.[path] <- f
+            f :> ILlmService
+
+    let pool = new LocalModelPool(3, create)
+    (pool :> ILocalModelPool).Acquire(noCfg, "A") |> ignore
+    (pool :> ILocalModelPool).Acquire(noCfg, "B") |> ignore
+
+    (pool :> IDisposable).Dispose()
+
+    Assert.True(fakes.["A"].Disposed)
+    Assert.True(fakes.["B"].Disposed)

--- a/v2/tests/Tars.Tests/RoutingClassifierTests.fs
+++ b/v2/tests/Tars.Tests/RoutingClassifierTests.fs
@@ -1,0 +1,57 @@
+module Tars.Tests.RoutingClassifierTests
+
+open Xunit
+open Tars.Llm.Routing
+
+// The de-stringly-typed routing classifiers are now pure functions over a closed
+// DU — directly testable without constructing a service or hitting a backend.
+
+[<Theory>]
+[<InlineData("gpt-4o", "OpenAIFamily")>]
+[<InlineData("GPT-3.5-turbo", "OpenAIFamily")>]
+[<InlineData("claude-opus-4-8", "AnthropicFamily")>]
+[<InlineData("gemini-2.0-flash", "GeminiFamily")>]
+[<InlineData("llama3.2", "LocalFamily")>]
+[<InlineData("qwen2.5-coder", "LocalFamily")>]
+[<InlineData("", "LocalFamily")>]
+let ``ModelFamily.classify maps model names to provider families`` (model: string) (expected: string) =
+    let actual =
+        match ModelFamily.classify model with
+        | OpenAIFamily -> "OpenAIFamily"
+        | AnthropicFamily -> "AnthropicFamily"
+        | GeminiFamily -> "GeminiFamily"
+        | LocalFamily -> "LocalFamily"
+
+    Assert.Equal(expected, actual)
+
+[<Theory>]
+[<InlineData("code", "CodeHint")>]
+[<InlineData("cheap", "CheapHint")>]
+[<InlineData("reasoning", "ReasoningHint")>]
+[<InlineData("analysis", "ReasoningHint")>]
+[<InlineData("think-hard", "ReasoningHint")>]
+[<InlineData("docker", "DockerHint")>]
+[<InlineData("llamacpp", "LlamaCppHint")>]
+[<InlineData("perf", "LlamaCppHint")>]
+[<InlineData("fast", "FastHint")>]
+[<InlineData("quick", "FastHint")>]
+[<InlineData("", "DefaultHint")>]
+[<InlineData("whatever", "DefaultHint")>]
+let ``RoutingHint.classify maps hints to routing intents`` (hint: string) (expected: string) =
+    let actual =
+        match RoutingHint.classify hint with
+        | CodeHint -> "CodeHint"
+        | CheapHint -> "CheapHint"
+        | ReasoningHint -> "ReasoningHint"
+        | DockerHint -> "DockerHint"
+        | LlamaCppHint -> "LlamaCppHint"
+        | FastHint -> "FastHint"
+        | DefaultHint -> "DefaultHint"
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``RoutingHint.classify preserves original precedence: code before reasoning`` () =
+    // A hint containing both "code" and "reason" must classify as CodeHint,
+    // matching the original sequential matching order.
+    Assert.Equal(CodeHint, RoutingHint.classify "code-reasoning")

--- a/v2/tests/Tars.Tests/Tars.Tests.fsproj
+++ b/v2/tests/Tars.Tests/Tars.Tests.fsproj
@@ -123,6 +123,7 @@
     <Compile Include="GrammarMlBridgeTests.fs" />
     <Compile Include="AgentDefinitionTests.fs" />
     <Compile Include="ResearchCycleTests.fs" />
+    <Compile Include="AskCommandTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/v2/tests/Tars.Tests/Tars.Tests.fsproj
+++ b/v2/tests/Tars.Tests/Tars.Tests.fsproj
@@ -125,6 +125,7 @@
     <Compile Include="ResearchCycleTests.fs" />
     <Compile Include="AskCommandTests.fs" />
     <Compile Include="RoutingClassifierTests.fs" />
+    <Compile Include="LocalModelPoolTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/v2/tests/Tars.Tests/Tars.Tests.fsproj
+++ b/v2/tests/Tars.Tests/Tars.Tests.fsproj
@@ -124,6 +124,7 @@
     <Compile Include="AgentDefinitionTests.fs" />
     <Compile Include="ResearchCycleTests.fs" />
     <Compile Include="AskCommandTests.fs" />
+    <Compile Include="RoutingClassifierTests.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Round-2 architecture-deepening: the coupled **1+4 pair**. Collapses LLM backend dispatch onto a single seam, de-stringly-types routing, and gives local (LlamaSharp) models a bounded lifecycle.

> **Stacked on #45.** This branch descends from `refactor/tars-runtime-seam`, so until #45 merges this PR's diff also shows that commit. The *new* work is entirely under `src/Tars.Llm/` + tests. Review against #45, or merge #45 first.

Closes #49.

## Commit 1 — `ILlmBackend` provider seam + typed routing (PR1)
- **`ILlmBackend`** (`Complete`/`Stream`) with one thin adapter per provider; **`Backends.resolve`** is the only place the 8-way provider match lives.
- `DefaultLlmService`'s three interfaces (`ILlmService`, `ILlmServiceFunctional`, `ICancellableLlmService`) **delegate to the resolver** instead of each repeating the dispatch (`−169` lines, almost all duplicated dispatch).
- **Typed routing**: `ModelFamily` / `RoutingHint` classifiers turn `model.Contains("gpt"/"claude"/…)` and hint substrings into **total matches over closed DUs**, with the substring rules isolated in pure, unit-tested `classify` functions.
- Behaviour preserved exactly: Ollama keeps `generateValidated`; Gemini streaming still raises `NotImplementedException` (inside its adapter); embedding-model selection unchanged.

## Commit 2 — `ILocalModelPool` bounded lifecycle (PR4)
- Replaces the static, **unbounded, never-disposed** LlamaSharp cache.
- `LlamaSharpService : IDisposable` (releases weights, context, embedder, semaphore).
- `LocalModelPool`: bounded LRU (size `TARS_LLAMASHARP_POOL_SIZE`, default 1), **dispose-on-evict**, plus `ProcessExit` shutdown disposal. The injectable `create` makes the LRU/eviction/disposal logic unit-testable without loading a real model.
- `getService` kept as a thin accessor, so `Backends.resolve` is unchanged — the pool is the local-model adapter behind the seam.
- Caveat: eviction assumes the evicted model is not concurrently mid-inference (safe for the default serial, bound-1 usage); documented on the type.

## Tests
- New `RoutingClassifierTests` (model-family / hint classification incl. precedence) and `LocalModelPoolTests` (reuse, evict+dispose past bound, dispose-all).
- Tars.Llm builds **0 warnings / 0 errors** (warnings-as-errors); **909/910** tests pass. The one failure is the `GoldenRun` demo-ping end-to-end test timing out on `dotnet run` (~44s) vs its 15s budget in this environment — the command runs correctly (exit 0), not a logic regression.

## Deferred
- Cross-client role-map/DTO/error dedup (a later Tars.Llm cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)