### PR TITLE
refactor(tools): IToolInvoker → ToolOutcome, resilience in one place (PR2)

### DIFF
--- a/v2/src/Tars.Connectors/Mcp/McpServer.fs
+++ b/v2/src/Tars.Connectors/Mcp/McpServer.fs
@@ -139,7 +139,7 @@ type McpServer(registry: IToolRegistry, ?knowledgeGraph: TemporalKnowledgeGraph.
                         |> Some
 
                     log $"Executing tool '{nameProp}' [CID: {correlationId}] with input: {input}"
-                    let! result = Async.StartAsTask(tool.Execute(input))
+                    let! result = Async.StartAsTask(Tars.Core.ToolExecution.runDefault tool input)
 
                     match result with
                     | Result.Ok output ->

--- a/v2/src/Tars.Connectors/Mcp/OfficialMcpBridge.fs
+++ b/v2/src/Tars.Connectors/Mcp/OfficialMcpBridge.fs
@@ -24,7 +24,7 @@ module OfficialMcpBridge =
             Func<string, CancellationToken, Task<string>>(fun arguments _ct ->
                 task {
                     let input = if isNull arguments then "" else arguments
-                    let! result = tool.Execute(input) |> Async.StartAsTask
+                    let! result = Tars.Core.ToolExecution.runDefault tool input |> Async.StartAsTask
                     match result with
                     | Result.Ok output -> return output
                     | Result.Error err -> return $"Error: {err}"

--- a/v2/src/Tars.Core/Tars.Core.fsproj
+++ b/v2/src/Tars.Core/Tars.Core.fsproj
@@ -40,6 +40,7 @@
     <Compile Include="Metrics.fs" />
     <Compile Include="ToolLedger.fs" />
     <Compile Include="Resilience.fs" />
+    <Compile Include="ToolExecution.fs" />
     <Compile Include="Validation.fs" />
     <Compile Include="GrammarDistill.fs" />
     <Compile Include="PolicyEngine.fs" />

--- a/v2/src/Tars.Core/ToolExecution.fs
+++ b/v2/src/Tars.Core/ToolExecution.fs
@@ -1,0 +1,87 @@
+namespace Tars.Core
+
+open System
+open System.Collections.Concurrent
+
+/// Records the outcome of a tool execution. The production recorder writes to the
+/// global ToolLedger (which also feeds Metrics); tests can supply a stub.
+type IToolRecorder =
+    abstract member Record:
+        toolName: string *
+        input: string *
+        output: string *
+        durationMs: float *
+        success: bool *
+        category: ToolFailureCategory ->
+            unit
+
+/// Production recorder — writes to the global ToolLedger.
+type LedgerToolRecorder() =
+    interface IToolRecorder with
+        member _.Record(toolName, input, output, durationMs, success, category) =
+            ToolLedger.record toolName input output durationMs success category None
+
+/// Resilient tool execution: a per-tool circuit breaker plus recording, shared by
+/// every tool caller. The registry now stores raw tools; resilience lives here so
+/// the behaviour is identical whether a tool is invoked via IToolInvoker, the MAF
+/// adapter, or directly. This is the single home of the logic that used to be
+/// wrapped onto each tool at registration.
+module ToolExecution =
+
+    let private defaultRecorder = LedgerToolRecorder() :> IToolRecorder
+
+    // One circuit breaker per tool name, process-wide.
+    let private breakers = ConcurrentDictionary<string, Resilience.CircuitBreaker>()
+
+    let private breakerFor (name: string) =
+        breakers.GetOrAdd(name, (fun _ -> Resilience.CircuitBreaker(3, TimeSpan.FromMinutes(1.0))))
+
+    /// Classify a tool error message into a failure category.
+    let classifyFailure (err: string) : ToolFailureCategory =
+        if err.Contains("timeout") || err.Contains("timed out") then
+            Timeout
+        elif err.Contains("connection") || err.Contains("http") || err.Contains("network") then
+            DependencyFailure
+        else
+            Unknown
+
+    /// Run a tool through its circuit breaker, recording the outcome.
+    let run (recorder: IToolRecorder) (tool: Tool) (input: string) : Async<Result<string, string>> =
+        async {
+            let cb = breakerFor tool.Name
+            let sw = System.Diagnostics.Stopwatch.StartNew()
+            let taskOp () = Async.StartAsTask(tool.Execute input)
+
+            try
+                let! (result: Result<string, string>) = Async.AwaitTask(cb.ExecuteAsync(taskOp))
+                sw.Stop()
+                let duration = sw.Elapsed.TotalMilliseconds
+
+                match result with
+                | Result.Ok output -> recorder.Record(tool.Name, input, output, duration, true, NoFailure)
+                | Result.Error err -> recorder.Record(tool.Name, input, err, duration, false, classifyFailure err)
+
+                return result
+            with
+            | :? InvalidOperationException as ex when ex.Message.Contains("CircuitBreaker is OPEN") ->
+                sw.Stop()
+
+                recorder.Record(
+                    tool.Name,
+                    input,
+                    "Circuit Breaker is OPEN",
+                    sw.Elapsed.TotalMilliseconds,
+                    false,
+                    CircuitBreakerOpen
+                )
+
+                return Result.Error "Circuit Breaker is OPEN"
+            | ex ->
+                sw.Stop()
+                let cat = if ex.Message.Contains("timeout") then Timeout else Unknown
+                recorder.Record(tool.Name, input, ex.Message, sw.Elapsed.TotalMilliseconds, false, cat)
+                return Result.Error ex.Message
+        }
+
+    /// Run a tool through its circuit breaker using the default ledger recorder.
+    let runDefault (tool: Tool) (input: string) : Async<Result<string, string>> = run defaultRecorder tool input

--- a/v2/src/Tars.Core/WorkflowOfThought/ExecutionTypes.fs
+++ b/v2/src/Tars.Core/WorkflowOfThought/ExecutionTypes.fs
@@ -20,9 +20,19 @@ type ExecContext =
     { Inputs: Map<string, string>
       Vars: Map<string, obj> }
 
-/// Platform-agnostic interface for invoking tools
+/// The result of invoking a tool through the invoker seam. Unlike a flat
+/// Result<obj,string>, this admits the distinct failure modes the invoker knows
+/// about, so callers no longer have to string-match to tell them apart.
+type ToolOutcome =
+    | Succeeded of output: string
+    | NotFound
+    | CircuitOpen
+    | Failed of category: string * message: string
+
+/// Platform-agnostic interface for invoking tools, with resilience (circuit
+/// breaker) and recording owned by the implementation.
 type IToolInvoker =
-    abstract Invoke: toolName: string * args: Map<string, string> -> Async<Result<obj, string>>
+    abstract Invoke: toolName: string * args: Map<string, string> -> Async<ToolOutcome>
 
 /// Token usage for reasoning
 type TokenUsage = { Prompt: int; Completion: int }

--- a/v2/src/Tars.Core/WorkflowOfThought/WotExecutor.fs
+++ b/v2/src/Tars.Core/WorkflowOfThought/WotExecutor.fs
@@ -150,10 +150,12 @@ module WotExecutor =
                                 let! r = toolInvoker.Invoke(toolName, resolvedArgs)
 
                                 match r with
-                                | Result.Error e -> return Some $"ToolResult failed: Tool '{toolName}' error: {e}"
-                                | Result.Ok res ->
-                                    let resStr = res.ToString()
-
+                                | ToolOutcome.NotFound -> return Some $"ToolResult failed: Tool '{toolName}' not found"
+                                | ToolOutcome.CircuitOpen ->
+                                    return Some $"ToolResult failed: Tool '{toolName}' circuit breaker open"
+                                | ToolOutcome.Failed(_, e) ->
+                                    return Some $"ToolResult failed: Tool '{toolName}' error: {e}"
+                                | ToolOutcome.Succeeded resStr ->
                                     if resStr.Contains check then
                                         return None
                                     else
@@ -420,7 +422,23 @@ module WotExecutor =
                                         let! r = toolInvoker.Invoke(toolName, resolvedArgs)
 
                                         match r with
-                                        | Result.Error e ->
+                                        | ToolOutcome.NotFound ->
+                                            return
+                                                fail
+                                                    $"Tool '{toolName}' not found"
+                                                    "tool"
+                                                    (Some toolName)
+                                                    (Some resolvedArgs)
+                                                    step.Metadata
+                                        | ToolOutcome.CircuitOpen ->
+                                            return
+                                                fail
+                                                    $"Tool '{toolName}' circuit breaker open"
+                                                    "tool"
+                                                    (Some toolName)
+                                                    (Some resolvedArgs)
+                                                    step.Metadata
+                                        | ToolOutcome.Failed(_, e) ->
                                             return
                                                 fail
                                                     $"Tool '{toolName}' failed: {e}"
@@ -428,8 +446,8 @@ module WotExecutor =
                                                     (Some toolName)
                                                     (Some resolvedArgs)
                                                     step.Metadata
-                                        | Result.Ok value ->
-                                            match storeSingleOutput currentCtx step.Outputs value with
+                                        | ToolOutcome.Succeeded value ->
+                                            match storeSingleOutput currentCtx step.Outputs (box value) with
                                             | Result.Error e ->
                                                 return
                                                     fail

--- a/v2/src/Tars.Cortex/ClaudeCodeBridge.fs
+++ b/v2/src/Tars.Cortex/ClaudeCodeBridge.fs
@@ -261,7 +261,7 @@ module ClaudeCodeBridge =
                                         if payload.Args.IsEmpty then stepInput
                                         else JsonSerializer.Serialize(payload.Args)
 
-                                    let! result = t.Execute(toolInput)
+                                    let! result = Tars.Core.ToolExecution.runDefault t toolInput
                                     sw.Stop()
 
                                     match result with

--- a/v2/src/Tars.Cortex/Patterns.fs
+++ b/v2/src/Tars.Cortex/Patterns.fs
@@ -271,7 +271,7 @@ module Patterns =
                                                 allWarnings
                                                 @ [ PartialFailure.Warning $"SafetyGate preview logged for {action}" ]
 
-                                        let! result = tool.Execute actionInput
+                                        let! result = Tars.Core.ToolExecution.runDefault tool actionInput
 
                                         match result with
                                         | Result.Ok output ->
@@ -2080,7 +2080,7 @@ Output ONLY the synthesized solution."""
                                                         match tryConsumeCall ctx "[WoT] tool execution" with
                                                         | false -> return None
                                                         | true ->
-                                                            let! result = tool.Execute input
+                                                            let! result = Tars.Core.ToolExecution.runDefault tool input
 
                                                             match result with
                                                             | Result.Ok output ->

--- a/v2/src/Tars.Graph/Graph.fs
+++ b/v2/src/Tars.Graph/Graph.fs
@@ -534,7 +534,10 @@ module GraphRuntime =
                     task {
                         try
                             let! result =
-                                Async.StartAsTask(tool.Execute input, cancellationToken = ctx.CancellationToken)
+                                Async.StartAsTask(
+                                    Tars.Core.ToolExecution.runDefault tool input,
+                                    cancellationToken = ctx.CancellationToken
+                                )
                             return Choice1Of2 result
                         with :? OperationCanceledException ->
                             return Choice2Of2 ()

--- a/v2/src/Tars.Interface.Cli/Commands/WotCommand.fs
+++ b/v2/src/Tars.Interface.Cli/Commands/WotCommand.fs
@@ -17,24 +17,8 @@ open Tars.Cortex.WoTTypes
 
 module WotCommand =
 
-    // Invoker implementation
-    type private CliToolInvoker(registry: ToolRegistry) =
-        interface IToolInvoker with
-            member _.Invoke(toolName: string, args: Map<string, string>) =
-                async {
-                    match registry.Get(toolName) with
-                    | None -> return Result.Error $"Tool '{toolName}' not found in registry."
-                    | Some tool ->
-                        try
-                            let json = System.Text.Json.JsonSerializer.Serialize(args)
-                            let! res = tool.Execute json
-
-                            match res with
-                            | Result.Ok(output: string) -> return Result.Ok(output :> obj)
-                            | Result.Error(err: string) -> return Result.Error err
-                        with ex ->
-                            return Result.Error $"Tool execution failed: {ex.Message}"
-                }
+    // Tool invocation goes through Tars.Tools.ToolInvoker, which owns resilience
+    // (circuit breaker + recording) and surfaces typed ToolOutcomes.
 
     // =========================================================================
     // Bridge: DSL Plan -> Cortex WoTPlan
@@ -336,7 +320,7 @@ module WotCommand =
                                 )
                             )
 
-                        let invoker = CliToolInvoker(tools)
+                        let invoker = Tars.Tools.ToolInvoker.create tools
 
                         let inputs =
                             plan.Inputs |> Map.toList |> List.map (fun (k, v) -> k, v) |> Map.ofList
@@ -1098,7 +1082,7 @@ module WotCommand =
                                     )
                                 )
 
-                            let invoker = CliToolInvoker(tools)
+                            let invoker = Tars.Tools.ToolInvoker.create tools
 
                             AnsiConsole.MarkupLine("[bold]Executing Steps...[/]")
 

--- a/v2/src/Tars.Interface.Ui/Main.fs
+++ b/v2/src/Tars.Interface.Ui/Main.fs
@@ -346,7 +346,7 @@ let executeToolCall (toolRegistry: IToolRegistry) (response: string) (userMessag
 
                 let result =
                     try
-                        let res = tool.Execute finalInput |> Async.RunSynchronously
+                        let res = Tars.Core.ToolExecution.runDefault tool finalInput |> Async.RunSynchronously
 
                         match res with
                         | Result.Ok r ->
@@ -531,7 +531,7 @@ let update
                         | Some tool ->
                             // Add timeout to prevent hanging on tools that depend on external services
                             let timeoutMs = 10000 // 10 second timeout
-                            let executionTask = tool.Execute "test input" |> Async.StartAsTask
+                            let executionTask = Tars.Core.ToolExecution.runDefault tool "test input" |> Async.StartAsTask
                             let timeoutTask = Task.Delay(timeoutMs)
 
                             let! completedTask = Task.WhenAny(executionTask, timeoutTask)

--- a/v2/src/Tars.Metascript/Engine.fs
+++ b/v2/src/Tars.Metascript/Engine.fs
@@ -1228,7 +1228,7 @@ Output only the requested result."""
                                 // Fallback: Serialize to JSON
                                 System.Text.Json.JsonSerializer.Serialize(args)
 
-                        let! result = tool.Execute(input)
+                        let! result = Tars.Core.ToolExecution.runDefault tool input
 
                         match result with
                         | Result.Ok s -> return (Map [ "stdout", box s ], List.ofSeq notes)

--- a/v2/src/Tars.Metascript/WotEngine.fs
+++ b/v2/src/Tars.Metascript/WotEngine.fs
@@ -219,7 +219,7 @@ type WotEngine(llm: ILlmServiceFunctional, tools: IToolRegistry) =
                                     else
                                         System.Text.Json.JsonSerializer.Serialize(args)
 
-                                let! toolRes = tool.Execute toolInput |> Async.StartAsTask
+                                let! toolRes = Tars.Core.ToolExecution.runDefault tool toolInput |> Async.StartAsTask
                                 let endTime = DateTimeOffset.UtcNow
 
                                 match toolRes with

--- a/v2/src/Tars.Tools/MafToolAdapter.fs
+++ b/v2/src/Tars.Tools/MafToolAdapter.fs
@@ -15,7 +15,9 @@ let toAIFunction (tool: Tool) : AIFunction =
     let wrapper =
         Func<string, Task<string>>(fun (input: string) ->
             task {
-                let! result = tool.Execute input |> Async.StartAsTask
+                // Route through ToolExecution so MAF-surfaced tools keep circuit
+                // breaking + recording now that the registry stores raw tools.
+                let! result = ToolExecution.runDefault tool input |> Async.StartAsTask
                 return
                     match result with
                     | Result.Ok value -> value

--- a/v2/src/Tars.Tools/Registry.fs
+++ b/v2/src/Tars.Tools/Registry.fs
@@ -10,85 +10,16 @@ type ToolRegistry(failureThreshold: int, durationOfBreak: TimeSpan) =
     let tools =
         System.Collections.Concurrent.ConcurrentDictionary<string, Tars.Core.Tool>()
 
-    // Circuit breakers for each tool
-    let circuitBreakers =
-        System.Collections.Concurrent.ConcurrentDictionary<string, Resilience.CircuitBreaker>()
+    // failureThreshold/durationOfBreak are retained for call-site compatibility;
+    // resilience now lives in Tars.Core.ToolExecution, applied at invocation time.
+    do ignore (failureThreshold, durationOfBreak)
 
     // Default constructor
     new() = ToolRegistry(3, TimeSpan.FromMinutes(1.0))
 
-    member this.Register(tool: Tars.Core.Tool) =
-        let cb =
-            circuitBreakers.GetOrAdd(tool.Name, fun _ -> Resilience.CircuitBreaker(failureThreshold, durationOfBreak))
-
-        let resilientExecute (input: string) : Async<Result<string, string>> =
-            async {
-                let sw = System.Diagnostics.Stopwatch.StartNew()
-                let taskOp () = Async.StartAsTask(tool.Execute input)
-
-                try
-                    let! (result: Result<string, string>) = Async.AwaitTask(cb.ExecuteAsync(taskOp))
-                    sw.Stop()
-                    let duration = sw.Elapsed.TotalMilliseconds
-
-                    match result with
-                    | Result.Ok output ->
-                        Tars.Core.ToolLedger.record
-                            tool.Name
-                            input
-                            output
-                            duration
-                            true
-                            Tars.Core.ToolFailureCategory.NoFailure
-                            None
-                    | Result.Error err ->
-                        let category =
-                            if err.Contains("timeout") || err.Contains("timed out") then
-                                Tars.Core.ToolFailureCategory.Timeout
-                            elif err.Contains("connection") || err.Contains("http") || err.Contains("network") then
-                                Tars.Core.ToolFailureCategory.DependencyFailure
-                            else
-                                Tars.Core.ToolFailureCategory.Unknown
-
-                        ToolLedger.record
-                            tool.Name
-                            input
-                            err
-                            duration
-                            false
-                            category
-                            None
-
-                    return result
-                with
-                | :? InvalidOperationException as ex when ex.Message.Contains("CircuitBreaker is OPEN") ->
-                    sw.Stop()
-
-                    Tars.Core.ToolLedger.record
-                        tool.Name
-                        input
-                        "Circuit Breaker is OPEN"
-                        sw.Elapsed.TotalMilliseconds
-                        false
-                        Tars.Core.ToolFailureCategory.CircuitBreakerOpen
-                        None
-
-                    return Result.Error "Circuit Breaker is OPEN"
-                | ex ->
-                    sw.Stop()
-
-                    let cat =
-                        if ex.Message.Contains("timeout") then
-                            Tars.Core.ToolFailureCategory.Timeout
-                        else
-                            Tars.Core.ToolFailureCategory.Unknown
-
-                    Tars.Core.ToolLedger.record tool.Name input ex.Message sw.Elapsed.TotalMilliseconds false cat None
-                    return Result.Error ex.Message
-            }
-
-        let resilientTool = { tool with Execute = resilientExecute }
-        tools.TryAdd(resilientTool.Name, resilientTool) |> ignore
+    /// Stores the tool as-is. Resilience (circuit breaker + recording) is applied
+    /// by Tars.Core.ToolExecution when the tool is invoked, not at registration.
+    member this.Register(tool: Tars.Core.Tool) = tools.TryAdd(tool.Name, tool) |> ignore
 
     member this.RegisterAssembly(assembly: Assembly) =
         let methods =

--- a/v2/src/Tars.Tools/Tars.Tools.fsproj
+++ b/v2/src/Tars.Tools/Tars.Tools.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="ToolHelpers.fs" />
     <Compile Include="ToolFactory.fs" />
     <Compile Include="Registry.fs" />
+    <Compile Include="ToolInvoker.fs" />
     <Compile Include="MafToolAdapter.fs" />
     <Compile Include="StandardTools.fs" />
     <Compile Include="SemanticTools.fs" />

--- a/v2/src/Tars.Tools/ToolInvoker.fs
+++ b/v2/src/Tars.Tools/ToolInvoker.fs
@@ -1,0 +1,32 @@
+namespace Tars.Tools
+
+open System.Text.Json
+open Tars.Core
+open Tars.Core.WorkflowOfThought
+
+/// Invokes registry tools with resilience + recording (delegating to
+/// Tars.Core.ToolExecution) and surfaces the distinct failure modes as a
+/// ToolOutcome. This is the deep seam the WoT executor (and any other caller
+/// wanting typed outcomes) uses instead of touching tools directly. The recorder
+/// is injectable so tests can observe recording without the global ledger.
+type ToolInvoker(registry: IToolRegistry, recorder: IToolRecorder) =
+
+    /// Default invoker writing to the global ToolLedger.
+    static member create(registry: IToolRegistry) =
+        ToolInvoker(registry, LedgerToolRecorder() :> IToolRecorder)
+
+    interface IToolInvoker with
+        member _.Invoke(toolName, args) =
+            async {
+                match registry.Get toolName with
+                | None -> return ToolOutcome.NotFound
+                | Some tool ->
+                    let input = JsonSerializer.Serialize(args)
+                    let! result = ToolExecution.run recorder tool input
+
+                    return
+                        match result with
+                        | Result.Ok output -> ToolOutcome.Succeeded output
+                        | Result.Error "Circuit Breaker is OPEN" -> ToolOutcome.CircuitOpen
+                        | Result.Error msg -> ToolOutcome.Failed(string (ToolExecution.classifyFailure msg), msg)
+            }

--- a/v2/tests/Tars.Tests/Tars.Tests.fsproj
+++ b/v2/tests/Tars.Tests/Tars.Tests.fsproj
@@ -126,6 +126,7 @@
     <Compile Include="AskCommandTests.fs" />
     <Compile Include="RoutingClassifierTests.fs" />
     <Compile Include="LocalModelPoolTests.fs" />
+    <Compile Include="ToolInvokerTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/v2/tests/Tars.Tests/ToolInvokerTests.fs
+++ b/v2/tests/Tars.Tests/ToolInvokerTests.fs
@@ -1,0 +1,70 @@
+module Tars.Tests.ToolInvokerTests
+
+open System
+open Xunit
+open Tars.Core
+open Tars.Core.WorkflowOfThought
+open Tars.Tools
+
+// The enriched IToolInvoker surfaces typed outcomes and records through an
+// injected IToolRecorder — both testable without the global ledger.
+
+type private StubRecorder() =
+    member val Records = ResizeArray<string * bool * string>()
+
+    interface IToolRecorder with
+        member this.Record(name, _input, _output, _dur, success, category) =
+            this.Records.Add((name, success, string category))
+
+let private mkTool name (exec: string -> Async<Result<string, string>>) : Tool =
+    { Name = name
+      Description = ""
+      Version = "1.0.0"
+      ParentVersion = None
+      CreatedAt = DateTime.UtcNow
+      Execute = exec }
+
+let private invokerWith (tools: Tool list) (recorder: IToolRecorder) : IToolInvoker =
+    let reg = ToolRegistry()
+
+    for t in tools do
+        reg.Register t
+
+    ToolInvoker(reg :> IToolRegistry, recorder) :> IToolInvoker
+
+[<Fact>]
+let ``Invoke returns NotFound for an unregistered tool`` () =
+    let recorder = StubRecorder()
+    let invoker = invokerWith [] recorder
+    let outcome = invoker.Invoke("nope", Map.empty) |> Async.RunSynchronously
+    Assert.Equal(ToolOutcome.NotFound, outcome)
+
+[<Fact>]
+let ``Invoke returns Succeeded and records a success`` () =
+    let recorder = StubRecorder()
+    let tool = mkTool "echo" (fun input -> async { return Result.Ok $"got:{input}" })
+    let invoker = invokerWith [ tool ] recorder
+
+    let outcome = invoker.Invoke("echo", Map.ofList [ "k", "v" ]) |> Async.RunSynchronously
+
+    match outcome with
+    | ToolOutcome.Succeeded out -> Assert.StartsWith("got:", out)
+    | other -> failwith $"expected Succeeded, got %A{other}"
+
+    Assert.True(recorder.Records |> Seq.exists (fun (n, s, _) -> n = "echo" && s))
+
+[<Fact>]
+let ``Invoke returns Failed with a classified category and records a failure`` () =
+    let recorder = StubRecorder()
+    let tool = mkTool "boom" (fun _ -> async { return Result.Error "network down" })
+    let invoker = invokerWith [ tool ] recorder
+
+    let outcome = invoker.Invoke("boom", Map.empty) |> Async.RunSynchronously
+
+    match outcome with
+    | ToolOutcome.Failed(category, message) ->
+        Assert.Equal("DependencyFailure", category) // "network" → DependencyFailure
+        Assert.Equal("network down", message)
+    | other -> failwith $"expected Failed, got %A{other}"
+
+    Assert.True(recorder.Records |> Seq.exists (fun (n, s, _) -> n = "boom" && not s))

--- a/v2/tests/Tars.Tests/WorkflowOfThought/WotGoldenRunTests.fs
+++ b/v2/tests/Tars.Tests/WorkflowOfThought/WotGoldenRunTests.fs
@@ -3,7 +3,7 @@ namespace Tars.Tests.WorkflowOfThought
 open Xunit
 open Tars.Core.WorkflowOfThought
 
-type FakeToolInvoker(responder: string -> Map<string, string> -> Result<obj, string>) =
+type FakeToolInvoker(responder: string -> Map<string, string> -> ToolOutcome) =
     let calls = ResizeArray<string * Map<string, string>>()
     member _.Calls = Seq.toList calls
 
@@ -48,8 +48,8 @@ module WotGoldenRunTests =
                 match tool with
                 | "mock_echo" ->
                     let msg = args.["msg"]
-                    Ok(box msg)
-                | _ -> Error "unknown tool")
+                    ToolOutcome.Succeeded msg
+                | _ -> ToolOutcome.Failed("Unknown", "unknown tool"))
 
         let reasoner =
             { new IReasoner with
@@ -108,7 +108,8 @@ module WotGoldenRunTests =
 
         // Mock Tool Invoker (unused)
         let invoker =
-            FakeToolInvoker(fun (t: string) (a: Map<string, string>) -> Error "should not be called")
+            FakeToolInvoker(fun (t: string) (a: Map<string, string>) ->
+                ToolOutcome.Failed("Unknown", "should not be called"))
 
         // Mock Reasoner
         let mutable reasonerCalled = false
@@ -166,7 +167,7 @@ module WotGoldenRunTests =
             { AllowedTools = Set.empty
               MaxToolCalls = 0 }
 
-        let invoker = FakeToolInvoker(fun _ _ -> Ok(box "dummy"))
+        let invoker = FakeToolInvoker(fun _ _ -> ToolOutcome.Succeeded "dummy")
 
         let reasoner =
             { new IReasoner with


### PR DESCRIPTION
Round-2 architecture-deepening **PR2** (#47). Moves tool resilience into a single home and enriches the invoker seam to surface typed outcomes.

> **Stacked.** Branched off `refactor/llm-backend-seam` (PR #46) for a clean diff; base it there or rebase onto `main` once #46 merges. The new work is the tool-invocation refactor below.

Closes #47.

## What
- `IToolInvoker.Invoke` now returns **`ToolOutcome`** (`Succeeded | NotFound | CircuitOpen | Failed of category*message`) instead of a flat `Result<obj,string>` — callers stop string-matching to tell failure modes apart.
- **`Tars.Core.ToolExecution`** is the single home of resilience: per-tool circuit breaker + recording via an injectable **`IToolRecorder`** (prod `LedgerToolRecorder` → global `ToolLedger`, which also feeds `Metrics`), plus a shared `classifyFailure`. This is the logic that used to be wrapped onto each tool at registration.
- `Registry.Register` now stores **raw** tools; resilience is applied at invocation.
- **`Tars.Tools.ToolInvoker`** — deep invoker mapping execution → `ToolOutcome`, recorder injectable (tested without the global ledger).

## The sweep (no path loses resilience)
Every former direct `tool.Execute` caller reroutes to `ToolExecution.runDefault`: MAF adapter, Graph, UI×2, both MCP bridges, Cortex (ClaudeCodeBridge + Patterns×2), and **Metascript Engine + WotEngine** (frozen — edited with explicit sign-off). WotExecutor's two consumers map `ToolOutcome`; `CliToolInvoker` → `ToolInvoker.create`.

## Note
`ToolOutcome.Failed` carries a **string** category, not the `ToolFailureCategory` DU: defining the DU early enough to reference at the seam flipped bare-name resolution (`Timeout`/`Unknown`/…) and broke unrelated `Graph/Executor.fs`, so it's stringified at the boundary.

## Tests
- New `ToolInvokerTests`: NotFound / Succeeded+record / Failed+classify+record.
- All projects build **0 errors** (Core, Tools, Graph, Cortex, Metascript, Connectors, CLI, UI); full suite **909/910** (the one is the `GoldenRun` `dotnet run` timeout, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)