### PR TITLE
Add AI agent integrations documentation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ TARS discovers patterns from Guitar Alchemist orchestrator traces (`~/.ga/traces
 
 ---
 
+## AI agent integrations
+
+This repository supports autonomous issue resolution via AI agents. You can delegate issues to Codex by mentioning `@codex` in a comment, or to Jules by adding the `jules` label to the issue.
+
+---
+
 ## Self-Improvement Loop
 
 TARS has a closed self-improvement loop:


### PR DESCRIPTION
This PR adds a short "## AI agent integrations" section to README.md as part of a smoke test to verify Codex issue→PR integration. The section documents that the repository supports delegating issues to Codex by mentioning @codex in a comment and to Jules by adding the jules label.

Verification:
- README.md has been updated correctly.
- Build and tests in v2/ were run; no regressions were introduced by this documentation-only change.

Fixes #55

---
*PR created automatically by Jules for task [104465472184910417](https://jules.google.com/task/104465472184910417) started by @spareilleux*