### PR TITLE
feat(governance): make the AFK delegation loop haltable by Demerzel

### DIFF
--- a/.github/workflows/jules-auto-delegate.yml
+++ b/.github/workflows/jules-auto-delegate.yml
@@ -9,6 +9,13 @@ name: Auto-delegate to Jules
 # applying `ready-for-agent` is collaborator-gated even though this repo is
 # public. A stranger opening an issue cannot trigger this — they can't label.
 #
+# Governance (Demerzel): delegation is gated on a cloud-readable halt marker,
+# `governance/state/afk-halt.json`. Demerzel's local `~/.demerzel/HALT-ALL`
+# marker can't reach a GitHub-hosted workflow, so this repo-committed marker is
+# the AFK loop's equivalent kill switch. Present + unexpired => delegation is
+# paused (the `ready-for-agent` label is kept, and the issue gets a comment).
+# Absent => the loop runs. See docs/adr/0004-afk-agent-delegation-loop.md.
+#
 # Takes effect only once this file is on the default branch (main); `issues`
 # events always run the workflow version from the default branch.
 
@@ -17,19 +24,44 @@ on:
     types: [labeled]
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
   delegate:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     if: ${{ github.event.label.name == 'ready-for-agent' }}
     steps:
-      - name: Add jules label to delegate the issue
+      - name: Checkout (read the governance halt marker)
+        uses: actions/checkout@v4
+
+      - name: Delegate to Jules unless governance has halted the loop
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
         run: |
+          MARKER="governance/state/afk-halt.json"
+          if [ -f "$MARKER" ]; then
+            # Honor an optional expires_at (RFC3339); absent => indefinite halt.
+            EXPIRES=$(jq -r '.expires_at // empty' "$MARKER" 2>/dev/null || true)
+            HALTED=true
+            if [ -n "$EXPIRES" ]; then
+              NOW=$(date -u +%s)
+              EXP=$(date -u -d "$EXPIRES" +%s 2>/dev/null || echo 0)
+              if [ "$EXP" -gt 0 ] && [ "$NOW" -ge "$EXP" ]; then
+                HALTED=false
+                echo "::notice::afk-halt marker present but expired ($EXPIRES) — proceeding"
+              fi
+            fi
+            if [ "$HALTED" = "true" ]; then
+              REASON=$(jq -r '.reason // "no reason given"' "$MARKER" 2>/dev/null || echo "no reason given")
+              BY=$(jq -r '.halted_by // "Demerzel"' "$MARKER" 2>/dev/null || echo "Demerzel")
+              gh issue comment "$ISSUE" --repo "$REPO" --body "⏸️ AFK delegation is **halted by governance** (\`$MARKER\`, by $BY): $REASON. The \`ready-for-agent\` label is kept; re-apply it after resume to delegate."
+              echo "::notice::AFK delegation halted by governance marker — skipping issue #${ISSUE}"
+              exit 0
+            fi
+          fi
           gh issue edit "$ISSUE" --repo "$REPO" --add-label jules
           echo "Delegated issue #${ISSUE} to Jules (ready-for-agent -> jules)"

--- a/.github/workflows/jules-auto-delegate.yml
+++ b/.github/workflows/jules-auto-delegate.yml
@@ -1,9 +1,15 @@
 name: Auto-delegate to Jules
 
 # Review-gated AFK automation. When a maintainer triages an issue with the
-# `ready-for-agent` label, this adds the `jules` label so Google Jules picks
-# it up and opens a PR. The PR still waits for human review before merge —
-# Jules opens PRs, it never merges to main, so review-gating holds by default.
+# `ready-for-agent` label, this invokes Google Jules (via the official
+# jules-action + Jules API) to work the issue and open a PR. The PR still waits
+# for human review before merge — Jules opens PRs, it never merges to main, so
+# review-gating holds by default.
+#
+# Why the API, not the `jules` label: Jules ignores label events applied by a
+# bot (github-actions[bot]). A workflow adding the `jules` label therefore never
+# triggers Jules — verified on issue #58 (bot-applied label: no response;
+# user-applied: picked up in ~75s). So we invoke Jules directly via the API.
 #
 # Security: GitHub only lets users with write/triage access apply labels, so
 # applying `ready-for-agent` is collaborator-gated even though this repo is
@@ -16,8 +22,9 @@ name: Auto-delegate to Jules
 # paused (the `ready-for-agent` label is kept, and the issue gets a comment).
 # Absent => the loop runs. See docs/adr/0004-afk-agent-delegation-loop.md.
 #
-# Takes effect only once this file is on the default branch (main); `issues`
-# events always run the workflow version from the default branch.
+# Requires the JULES_API_KEY secret (generate at jules.google). Takes effect
+# only once this file is on the default branch (main); `issues` events always
+# run the workflow version from the default branch.
 
 on:
   issues:
@@ -30,17 +37,19 @@ permissions:
 jobs:
   delegate:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     if: ${{ github.event.label.name == 'ready-for-agent' }}
     steps:
       - name: Checkout (read the governance halt marker)
         uses: actions/checkout@v4
 
-      - name: Delegate to Jules unless governance has halted the loop
+      - name: Governance halt-gate + preflight
+        id: gate
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
+          HAS_KEY: ${{ secrets.JULES_API_KEY != '' }}
         run: |
           MARKER="governance/state/afk-halt.json"
           if [ -f "$MARKER" ]; then
@@ -60,8 +69,42 @@ jobs:
               BY=$(jq -r '.halted_by // "Demerzel"' "$MARKER" 2>/dev/null || echo "Demerzel")
               gh issue comment "$ISSUE" --repo "$REPO" --body "⏸️ AFK delegation is **halted by governance** (\`$MARKER\`, by $BY): $REASON. The \`ready-for-agent\` label is kept; re-apply it after resume to delegate."
               echo "::notice::AFK delegation halted by governance marker — skipping issue #${ISSUE}"
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi
-          gh issue edit "$ISSUE" --repo "$REPO" --add-label jules
-          echo "Delegated issue #${ISSUE} to Jules (ready-for-agent -> jules)"
+          if [ "$HAS_KEY" != "true" ]; then
+            gh issue comment "$ISSUE" --repo "$REPO" --body "⚠️ AFK delegation is configured but the \`JULES_API_KEY\` secret is not set, so Jules was not invoked. Add the secret (Settings → Secrets and variables → Actions) and re-apply the \`ready-for-agent\` label."
+            echo "::warning::JULES_API_KEY not configured — skipping issue #${ISSUE}"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Build Jules prompt from the issue
+        if: steps.gate.outputs.proceed == 'true'
+        id: prompt
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          TITLE=$(gh issue view "$ISSUE" --repo "$REPO" --json title --jq '.title')
+          BODY=$(gh issue view "$ISSUE" --repo "$REPO" --json body --jq '.body')
+          {
+            echo "text<<JULES_EOF"
+            echo "Implement GitHub issue #${ISSUE}: ${TITLE}"
+            echo ""
+            echo "$BODY"
+            echo ""
+            echo "Open a pull request targeting main with the change. Keep it minimal and scoped to the issue. Ensure the build and tests pass before opening the PR."
+            echo "JULES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Delegate to Jules
+        if: steps.gate.outputs.proceed == 'true'
+        uses: google-labs-code/jules-action@v1.0.0
+        with:
+          prompt: ${{ steps.prompt.outputs.text }}
+          jules_api_key: ${{ secrets.JULES_API_KEY }}
+          starting_branch: main

--- a/docs/adr/0004-afk-agent-delegation-loop.md
+++ b/docs/adr/0004-afk-agent-delegation-loop.md
@@ -38,11 +38,23 @@ Two governance facts shaped the design:
    constitution (reversibility, escalation, observability), an un-haltable
    autonomous loop is exactly what governance must prevent.
 
+3. **A bot-applied `jules` label does not trigger Jules.** The first design had
+   the workflow add the `jules` label (Jules' normal trigger). Smoke test on
+   issue #58 disproved it: the label applied by `github-actions[bot]` produced
+   **no** Jules response over a 15-min watch, while the *same label* re-applied by
+   a human user was picked up in ~75s. Jules ignores label events authored by a
+   bot, so a workflow-applied label silently dead-ends.
+
 ## Decision
 
-- **Trigger seam:** `ready-for-agent` (triage label) → workflow adds `jules`.
-  Decoupling the triage label from the agent trigger keeps the human triage
-  vocabulary stable and centralizes the governance gate in one workflow.
+- **Trigger seam:** `ready-for-agent` (triage label) → workflow **invokes Jules
+  via the API** (the official `google-labs-code/jules-action@v1.0.0`, authed with
+  a `JULES_API_KEY` secret), feeding the issue title + body as the prompt. We do
+  **not** apply the `jules` label from the workflow, because (fact 3) Jules
+  ignores bot-applied labels. Decoupling the triage label (`ready-for-agent`)
+  from the invocation keeps the human triage vocabulary stable and centralizes
+  the governance gate in one workflow. The `jules` label remains available for
+  manual (human) delegation.
 - **Review gate:** Jules only *opens* PRs; merge requires the `build` status
   check (branch protection on `main`) plus a human. Review-gating holds by
   default — nothing reaches `main` unattended.
@@ -91,5 +103,8 @@ Mirrors the Demerzel HALT-ALL marker. All fields optional except by convention:
 - **Security:** label application is restricted to write/triage collaborators, so
   the trigger is gated even on this public repo. The `@codex` comment path is
   *not* label-gated (anyone can comment) and is out of scope here.
+- **Operational dependency:** requires a `JULES_API_KEY` Actions secret. If it is
+  absent the workflow no-ops with an explanatory issue comment rather than
+  failing silently.
 - **Follow-up:** a resume-replay mechanism, and bringing the `@codex` comment
   path under the same marker if it is adopted for AFK use.

--- a/docs/adr/0004-afk-agent-delegation-loop.md
+++ b/docs/adr/0004-afk-agent-delegation-loop.md
@@ -1,0 +1,95 @@
+# ADR 0004 — AFK agent-delegation loop (issue → Jules → PR), governed by Demerzel
+
+- **Status:** Accepted — 2026-06-24
+- **Context source:** Session wiring autonomous issue delegation to external
+  coding agents (Codex / Jules) and bringing the resulting loop under governance.
+  Relates to ADR 0002/0003 (self-hosting improvement) — this is the *external*
+  agent loop, complementary to TARS's internal self-improvement loop.
+- **Question:** How should TARS delegate work to an external autonomous coding
+  agent from a GitHub issue, AFK (no human in the loop at trigger time), without
+  the new loop escaping Demerzel's ecosystem-wide control?
+
+## Context
+
+Both vendor GitHub Apps are installed on `GuitarAlchemist`: **Jules**
+(`google-labs-jules`, Gemini) triggered by the `jules` label, and **Codex**
+(`chatgpt-codex-connector`, OpenAI) triggered by an `@codex` comment. Jules is
+the chosen path (works; Codex is quota-limited). Verified end-to-end #55 → #56.
+
+The AFK loop:
+
+```
+maintainer triages an issue → adds `ready-for-agent`
+   → .github/workflows/jules-auto-delegate.yml adds `jules`
+   → Jules works in cloud → opens a PR
+   → PR must pass the required `build` check → human reviews + merges
+```
+
+Two governance facts shaped the design:
+
+1. **Output is already governed.** `qa-verdict-dispatch.yml` dispatches every
+   `pull_request` to Demerzel's qa-tribunal, so Jules' PRs already receive a
+   governance verdict automatically. No new wiring needed for output review.
+2. **The *trigger* was not under Demerzel's kill switch.** Demerzel's loop
+   control is the local marker `~/.demerzel/HALT-ALL`, read at Step 0 by
+   `/auto-optimize` consumers running on a dev machine. The AFK loop runs in
+   GitHub's cloud (Actions + Jules cloud) and never sees that local file — so an
+   ecosystem-wide HALT would **not** stop AFK delegation. By Demerzel's own
+   constitution (reversibility, escalation, observability), an un-haltable
+   autonomous loop is exactly what governance must prevent.
+
+## Decision
+
+- **Trigger seam:** `ready-for-agent` (triage label) → workflow adds `jules`.
+  Decoupling the triage label from the agent trigger keeps the human triage
+  vocabulary stable and centralizes the governance gate in one workflow.
+- **Review gate:** Jules only *opens* PRs; merge requires the `build` status
+  check (branch protection on `main`) plus a human. Review-gating holds by
+  default — nothing reaches `main` unattended.
+- **Governance kill switch (cloud-reachable):** the workflow reads a
+  repo-committed marker `governance/state/afk-halt.json` before delegating. This
+  is the AFK loop's equivalent of `~/.demerzel/HALT-ALL`, reachable from CI
+  because it lives in git. Present + unexpired ⇒ delegation is paused (the
+  `ready-for-agent` label is kept and the issue gets an explanatory comment);
+  absent ⇒ the loop runs. A git-committed marker is chosen over a GitHub repo
+  variable for **auditability** — halt/resume is visible in history, matching
+  Demerzel's git-native style.
+
+### Marker schema (`governance/state/afk-halt.json`)
+
+Mirrors the Demerzel HALT-ALL marker. All fields optional except by convention:
+
+```json
+{
+  "schema_version": "0.1",
+  "halted_at": "2026-06-24T12:00:00Z",
+  "halted_by": "Demerzel",
+  "reason": "Investigating agent cost burn",
+  "expires_at": "2026-06-25T12:00:00Z"
+}
+```
+
+- `expires_at` (RFC3339, optional): once past, the workflow treats the marker as
+  inactive and proceeds. Absent ⇒ indefinite halt until the file is removed.
+- The marker's **absence** is the running state; it is intentionally **not**
+  committed by default.
+
+### Halt / resume procedure (Demerzel or operator)
+
+- **Halt:** commit `governance/state/afk-halt.json` to `main` (optionally with
+  `reason` / `expires_at`). Subsequent `ready-for-agent` labels are parked.
+- **Resume:** delete the marker from `main`. Re-apply `ready-for-agent` to any
+  issue parked during the halt to delegate it (the label was retained).
+
+## Consequences
+
+- **Positive:** the new autonomous loop is now both *governed at the output*
+  (tribunal) and *haltable at the trigger* (marker), closing the kill-switch
+  gap. Halt/resume is auditable in git.
+- **Limitation:** resume does not auto-replay parked issues — re-applying the
+  label is a manual (or future-automated) step. Acceptable for v1.
+- **Security:** label application is restricted to write/triage collaborators, so
+  the trigger is gated even on this public repo. The `@codex` comment path is
+  *not* label-gated (anyone can comment) and is out of scope here.
+- **Follow-up:** a resume-replay mechanism, and bringing the `@codex` comment
+  path under the same marker if it is adopted for AFK use.

--- a/governance/state/README.md
+++ b/governance/state/README.md
@@ -8,6 +8,11 @@ Belief state persistence directory for Demerzel governance integration.
 - `pdca/` — PDCA cycle tracking (*.pdca.json)
 - `knowledge/` — Knowledge transfer records (*.knowledge.json)
 - `snapshots/` — Belief snapshots for reconnaissance (*.snapshot.json)
+- `afk-halt.json` — **kill switch for the AFK agent-delegation loop** (absent =
+  running). When present + unexpired, `.github/workflows/jules-auto-delegate.yml`
+  pauses delegating `ready-for-agent` issues to Jules. The cloud-reachable
+  equivalent of Demerzel's `~/.demerzel/HALT-ALL`. Schema + halt/resume procedure
+  in `docs/adr/0004-afk-agent-delegation-loop.md`.
 
 ## File Naming
 


### PR DESCRIPTION
## Why

The AFK delegation loop (`ready-for-agent` → `jules` → PR) runs in **GitHub's cloud**, so Demerzel's local `~/.demerzel/HALT-ALL` marker can't reach it — an ecosystem-wide HALT would **not** stop AFK delegation.

The loop's **output** is already governed (`qa-verdict-dispatch.yml` → qa-tribunal verdicts on every PR). This PR closes the remaining **trigger** gap so a new autonomous loop can't escape Demerzel's kill switch (constitution: reversibility, escalation, observability).

## What

- **`jules-auto-delegate.yml`** now checks out the repo and reads a cloud-reachable kill switch — `governance/state/afk-halt.json` — before delegating:
  - **present + unexpired** → delegation paused (the `ready-for-agent` label is kept, the issue gets a comment)
  - **absent** → loop runs
  - honors an optional `expires_at`, mirroring the HALT-ALL marker schema
- **ADR 0004** — records the loop, the governance design, marker schema, and halt/resume procedure
- **`governance/state/README.md`** — points to the marker for discoverability

## Halt / resume

- **Halt:** commit `governance/state/afk-halt.json` to `main` (optional `reason` / `expires_at`)
- **Resume:** delete the marker; re-apply `ready-for-agent` to any parked issue

## Notes

- Marker is **git-committed** (not a repo variable) deliberately — halt/resume is auditable in history, matching Demerzel's git-native style.
- The `@codex` comment path isn't label-gated and is out of scope here (noted as follow-up in the ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)