### PR TITLE
Document AFK auto-delegate loop in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ Patterns climb: *Implementation → Helper → Builder → DslClause → Grammar
 
 ---
 
+## AI agent integrations
+
+Issues labeled `ready-for-agent` are automatically delegated to Jules via `.github/workflows/jules-auto-delegate.yml`.
+
+---
+
 ## AI discipline (Karpathy + Cherny)
 
 Every code-touching turn applies four rules: **think before coding · simplicity first · surgical changes · goal-driven execution**. Session continuity uses the Cherny pattern:


### PR DESCRIPTION
Add "AI agent integrations" section to README.md noting that issues labeled "ready-for-agent" are automatically delegated to Jules.

Fixes #58

---
*PR created automatically by Jules for task [13697225367105033759](https://jules.google.com/task/13697225367105033759) started by @spareilleux*