### PR TITLE
ci: CI Health Sweeper — L1 report-only loop for main build health

### DIFF
--- a/.github/workflows/ci-health-sweeper.yml
+++ b/.github/workflows/ci-health-sweeper.yml
@@ -1,0 +1,84 @@
+name: CI Health Sweeper
+
+# Loop-engineering "CI Sweeper" pattern at L1 (report-only): on a schedule, check
+# whether the required `build` check is green on main. If red, open (or update) a
+# single tracking issue labeled `ci-health`; when green again, close it. It
+# REPORTS — it never attempts a fix. Born from the period where `.NET` CI was
+# silently red on every PR for days (the NU1903 restore failure, fixed in #57)
+# with nothing surfacing it. This loop is the antibody to that rot.
+#
+# Single tracking issue => idempotent, no spam. Recovery auto-close => the loop
+# tells you what it observed ("activity detection"). Scoped to the `.NET`
+# workflow / `build` job — the gate that branch protection actually enforces.
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'   # every 6 hours
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+concurrency:
+  group: ci-health-sweeper
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Report on main build health
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Latest .NET run on main.
+          RUN=$(gh run list --repo "$REPO" --workflow ".NET" --branch main --limit 1 \
+                  --json conclusion,status,headSha,url --jq '.[0] // empty')
+          if [ -z "$RUN" ]; then
+            echo "No .NET runs on main yet — nothing to sweep."
+            exit 0
+          fi
+          STATUS=$(echo "$RUN" | jq -r '.status')
+          CONCLUSION=$(echo "$RUN" | jq -r '.conclusion')
+          URL=$(echo "$RUN" | jq -r '.url')
+          SHA=$(echo "$RUN" | jq -r '.headSha' | cut -c1-8)
+          echo "Latest .NET run on main: status=$STATUS conclusion=$CONCLUSION sha=$SHA"
+
+          # Only act on completed runs.
+          if [ "$STATUS" != "completed" ]; then
+            echo "Run still in progress — skipping this sweep."
+            exit 0
+          fi
+
+          # Single open tracking issue keeps this idempotent.
+          EXISTING=$(gh issue list --repo "$REPO" --state open --label ci-health \
+                       --json number --jq '.[0].number // empty')
+
+          if [ "$CONCLUSION" = "success" ]; then
+            if [ -n "$EXISTING" ]; then
+              gh issue comment "$EXISTING" --repo "$REPO" \
+                --body "✅ Recovered — \`build\` is green on main at \`$SHA\` ($URL). Closing."
+              gh issue close "$EXISTING" --repo "$REPO"
+              echo "Closed recovered ci-health issue #$EXISTING"
+            else
+              echo "Build green, no open issue — nothing to do."
+            fi
+            exit 0
+          fi
+
+          # failure / cancelled / timed_out => report (do not fix).
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$REPO" \
+              --body "Still **$CONCLUSION** on main at \`$SHA\` ($URL)."
+            echo "Updated existing ci-health issue #$EXISTING"
+          else
+            gh issue create --repo "$REPO" --label ci-health \
+              --title "🔴 CI health: build is $CONCLUSION on main" \
+              --body "$(printf '🔴 The required `build` check is **%s** on `main` (`%s`).\n\nRun: %s\n\nAutomated L1 report from the CI Health Sweeper — it surfaces a red required gate so it cannot rot silently. It does not attempt a fix.' "$CONCLUSION" "$SHA" "$URL")"
+            echo "Opened new ci-health issue"
+          fi


### PR DESCRIPTION
## Why

The `.NET` build was **silently red on every PR for days** (the NU1903 SQLitePCLRaw restore failure, fixed in #57) and nothing surfaced it — the required gate was rotting invisibly. This is the antibody.

Loop-engineering's **CI Sweeper** pattern at **L1 (report-only)**: it surfaces a red gate, it does not attempt fixes.

## What

`.github/workflows/ci-health-sweeper.yml` — scheduled every 6h (+ `workflow_dispatch`):
- Checks the latest `.NET` run's `build` conclusion on `main`
- **Red** → opens (or updates) a single `ci-health` tracking issue
- **Green again** → closes it with a recovery comment

Properties:
- **Idempotent** — one tracking issue, no spam
- **Activity detection** — recovery auto-close tells you what it observed
- **Scoped** — only the `build` gate that branch protection enforces
- Created the `ci-health` label (auto-managed)

## Validation

After merge, I can `workflow_dispatch` it once to confirm it correctly reports green (or catches red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)