### PR TITLE
docs: add AFK delegation halt marker to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ TARS discovers patterns from Guitar Alchemist orchestrator traces (`~/.ga/traces
 
 ---
 
+## AI agent integrations
+
+Autonomous issue delegation is governed by a halt marker at `governance/state/afk-halt.json`.
+
+---
+
 ## Self-Improvement Loop
 
 TARS has a closed self-improvement loop:


### PR DESCRIPTION
Add a sentence noting that delegations are governed by a halt marker at `governance/state/afk-halt.json` under the existing `## AI agent integrations` section.

---
*PR created automatically by Jules for task [1381979756652838667](https://jules.google.com/task/1381979756652838667) started by @spareilleux*