### PR TITLE
Document AFK halt marker in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ Patterns climb: *Implementation → Helper → Builder → DslClause → Grammar
 
 ---
 
+## AI agent integrations
+
+The AFK (Away From Keyboard) issue delegation loop is governed by a halt marker at `governance/state/afk-halt.json`.
+
+---
+
 ## AI discipline (Karpathy + Cherny)
 
 Every code-touching turn applies four rules: **think before coding · simplicity first · surgical changes · goal-driven execution**. Session continuity uses the Cherny pattern:


### PR DESCRIPTION
Added a section to the root `README.md` to document the AFK (Away From Keyboard) issue delegation loop and its governance via the `governance/state/afk-halt.json` halt marker. This ensures that the external agent loop's control mechanism is clearly documented for maintainers and other agents.

Fixes #66

---
*PR created automatically by Jules for task [4421301305715265213](https://jules.google.com/task/4421301305715265213) started by @spareilleux*