### PR TITLE
Define second-brain memory object contracts and provenance model

### DIFF
--- a/docs/contracts/second-brain-memory-objects.md
+++ b/docs/contracts/second-brain-memory-objects.md
@@ -1,0 +1,105 @@
+# TARS V2 Second-Brain Memory Objects Contract
+
+## Goal
+Define the core memory object contracts and provenance model for the TARS V2 second-brain harness. The system requires structured memory objects; vague blobs are insufficient. Each memory item must include provenance, confidence, staleness, source links, semantic type, and an optional grammar-validated contract.
+
+## Design Constraints
+- **JSON-First:** Easy to store as JSONL/Parquet.
+- **Future-Proof:** Compatible with future vector indexing without requiring vectors as the source of truth.
+- **IX Compatibility:** Compatible with IX scoring outputs, but does not mandate IX to be used.
+- **Privacy & Safety:** Supports privacy levels, staleness, and provenance out of the box. No secrets or raw private logs are stored.
+- **Simplicity:** Does not require a cloud database and avoids a complex, over-engineered ontology for the initial loop.
+
+---
+
+## Memory Objects
+
+Below are the candidate memory objects for the TARS second-brain ecosystem:
+
+- `MemoryItem`: The base wrapper for any memory artifact.
+- `SemanticClaim`: A verifiable claim or fact extracted from a source.
+- `DecisionRecord`: An immutable record of a decision made by an agent or human.
+- `AssumptionRecord`: Documented assumptions, often tied to a `DecisionRecord`.
+- `TaskRecord`: High-level tracking of action items or task execution.
+- `CapabilityRecord`: Asserted or demonstrated capabilities of an agent or system.
+- `ClosureRunMemory`: A snapshot of memory captured at the conclusion of a significant run.
+- `TraceSummary`: Distilled context from a raw execution trace.
+- `EvidenceRecord`: Supporting material validating a semantic claim.
+- `ReplayRecord`: Information required to deterministically replay a specific action or chain.
+- `HumanNote`: Manually authored context injected into the system.
+
+---
+
+## Shared Contract Fields
+
+Most memory objects implement a subset of these core fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` | Unique identifier (e.g., UUID or content hash). |
+| `kind` | `string` | Type of the object (e.g., `"DecisionRecord"`). |
+| `source_uri` | `string` | Canonical URI to the primary source. |
+| `source_repo` | `string` | GitHub or local repository identifier. |
+| `source_path` | `string` | File path within the repository. |
+| `source_issue` | `string` | Issue/PR number or link. |
+| `created_at` | `timestamp` | Time of creation of this memory artifact. |
+| `observed_at` | `timestamp` | Time the agent extracted or noticed the underlying fact. |
+| `extracted_by` | `string` | Agent or tool that created this record. |
+| `confidence` | `float` | Subjective or statistical confidence (0.0 to 1.0). |
+| `staleness` | `object` | Expiration strategy and status (see below). |
+| `privacy_level` | `string` | Classification (e.g., `"public"`, `"internal"`, `"confidential"`). |
+| `provenance` | `object` | Lineage describing how this artifact was synthesized. |
+| `semantic_summary`| `string` | Human-readable explanation of the memory. |
+| `structured_payload`| `object` | The strongly-typed data of the memory. |
+| `schema_id` | `string` | Optional JSON schema identifier for the payload. |
+| `grammar_id` | `string` | Optional EBNF grammar identifier for validation. |
+| `embedding_ref` | `string` | External reference to an embedding. |
+| `ix_score_ref` | `string` | External reference to an IX score evaluation. |
+| `links` | `array` | Relationships to other memory item IDs. |
+
+---
+
+## Provenance Model
+
+The provenance model requires that every synthetic or derived fact maintains a line of sight to its origin. Unbounded knowledge ingestion is rejected.
+
+```json
+"provenance": {
+  "derived_from": ["id-1", "id-2"],
+  "extraction_method": "Tars.Evolution.Pipeline",
+  "prompt_hash": "a1b2c3d4",
+  "grounding_sources": [
+    "https://github.com/GuitarAlchemist/tars/issues/90"
+  ]
+}
+```
+
+## Staleness Mechanism
+
+Information degrades over time. Staleness attributes allow the system to decay the value or retrieve-ability of a memory.
+
+```json
+"staleness": {
+  "expires_at": "2026-12-31T23:59:59Z",
+  "review_required": true,
+  "decay_factor_per_day": 0.01
+}
+```
+
+---
+
+## Privacy Notes
+
+The TARS agent operates over mixed-visibility environments.
+- **`privacy_level`** must be strictly enforced. Valid enum values are typically `public`, `internal`, and `confidential`.
+- **Secrets:** Under no circumstances should secrets (API keys, PII, raw private logs) be stored in `structured_payload` or `semantic_summary`. The agent must strip secrets before creating memory objects.
+- Filtering happens at the RAG layer based on this attribute.
+
+---
+
+## Cost Notes
+
+Vector search and LLM extraction are expensive.
+- **No vector truth:** Vectors are pointers, not truth. They can be deleted and regenerated.
+- **JSON storage:** Local JSON/JSONL/Parquet reduces cloud storage costs to zero.
+- RAG systems should prioritize graph relationships (`links`) and `source_repo`/`source_path` indexing to minimize expensive global vector searches.

--- a/examples/second-brain/decision-record.example.json
+++ b/examples/second-brain/decision-record.example.json
@@ -1,0 +1,44 @@
+{
+  "id": "dec-c3d4e5f6-g7h8-9012",
+  "kind": "DecisionRecord",
+  "source_uri": "https://github.com/GuitarAlchemist/tars/pull/95",
+  "source_repo": "GuitarAlchemist/tars",
+  "source_path": "docs/contracts/second-brain-memory-objects.md",
+  "source_issue": "91",
+  "created_at": "2026-06-28T10:00:00Z",
+  "observed_at": "2026-06-28T10:05:00Z",
+  "extracted_by": "JulesAgent",
+  "confidence": 1.0,
+  "staleness": {
+    "expires_at": "2099-12-31T23:59:59Z",
+    "review_required": false,
+    "decay_factor_per_day": 0.0
+  },
+  "privacy_level": "public",
+  "provenance": {
+    "derived_from": ["claim-b2c3d4e5-f6g7-8901"],
+    "extraction_method": "Manual",
+    "prompt_hash": null,
+    "grounding_sources": [
+      "https://github.com/GuitarAlchemist/tars/issues/91"
+    ]
+  },
+  "semantic_summary": "Decided to use a JSON-first approach for memory objects without requiring a cloud vector database.",
+  "structured_payload": {
+    "decision": "Use JSON/JSONL for memory object storage locally.",
+    "context": "Need a simple, future-proof storage model that supports provenance without cloud overhead.",
+    "alternatives_considered": [
+      "Require a cloud vector database from day 1.",
+      "Use unstructured Markdown notes exclusively."
+    ],
+    "consequences": [
+      "Easy local inspection and debugging.",
+      "Vector indexing can be added later as an optional, regenerable layer."
+    ]
+  },
+  "schema_id": "schema-decision-record-v1",
+  "grammar_id": null,
+  "embedding_ref": null,
+  "ix_score_ref": null,
+  "links": ["claim-b2c3d4e5-f6g7-8901"]
+}

--- a/examples/second-brain/memory-item.example.json
+++ b/examples/second-brain/memory-item.example.json
@@ -1,0 +1,36 @@
+{
+  "id": "mem-a1b2c3d4-e5f6-7890",
+  "kind": "MemoryItem",
+  "source_uri": "https://github.com/GuitarAlchemist/tars/issues/90",
+  "source_repo": "GuitarAlchemist/tars",
+  "source_path": "",
+  "source_issue": "90",
+  "created_at": "2026-06-28T09:00:00Z",
+  "observed_at": "2026-06-28T09:05:00Z",
+  "extracted_by": "JulesAgent",
+  "confidence": 0.95,
+  "staleness": {
+    "expires_at": "2027-06-28T09:00:00Z",
+    "review_required": false,
+    "decay_factor_per_day": 0.001
+  },
+  "privacy_level": "public",
+  "provenance": {
+    "derived_from": [],
+    "extraction_method": "Jules.Agent.Extraction",
+    "prompt_hash": "a1b2c3d4e5f6",
+    "grounding_sources": [
+      "https://github.com/GuitarAlchemist/tars/issues/90"
+    ]
+  },
+  "semantic_summary": "Issue #90 is the parent epic for defining the second-brain memory object contracts.",
+  "structured_payload": {
+    "summary": "Parent epic definition for second-brain memory object contracts.",
+    "labels": ["epic", "second-brain"]
+  },
+  "schema_id": null,
+  "grammar_id": null,
+  "embedding_ref": "emb-xyz-123",
+  "ix_score_ref": null,
+  "links": ["mem-b2c3d4e5-f6g7-8901"]
+}

--- a/examples/second-brain/semantic-claim.example.json
+++ b/examples/second-brain/semantic-claim.example.json
@@ -1,0 +1,38 @@
+{
+  "id": "claim-b2c3d4e5-f6g7-8901",
+  "kind": "SemanticClaim",
+  "source_uri": "https://github.com/GuitarAlchemist/tars/issues/91",
+  "source_repo": "GuitarAlchemist/tars",
+  "source_path": "",
+  "source_issue": "91",
+  "created_at": "2026-06-28T09:10:00Z",
+  "observed_at": "2026-06-28T09:15:00Z",
+  "extracted_by": "Tars.Evolution.Pipeline",
+  "confidence": 0.99,
+  "staleness": {
+    "expires_at": "2028-06-28T09:00:00Z",
+    "review_required": false,
+    "decay_factor_per_day": 0.0
+  },
+  "privacy_level": "public",
+  "provenance": {
+    "derived_from": ["mem-a1b2c3d4-e5f6-7890"],
+    "extraction_method": "Tars.Evolution.Pipeline.FactExtractor",
+    "prompt_hash": "c3d4e5f6g7h8",
+    "grounding_sources": [
+      "https://github.com/GuitarAlchemist/tars/issues/91"
+    ]
+  },
+  "semantic_summary": "Memory objects in the TARS system must be structured and include provenance.",
+  "structured_payload": {
+    "claim_type": "architectural_constraint",
+    "subject": "TARS Memory Objects",
+    "predicate": "must_include",
+    "object": "provenance"
+  },
+  "schema_id": "schema-semantic-claim-v1",
+  "grammar_id": "grammar-semantic-claim-v1",
+  "embedding_ref": "emb-qwe-456",
+  "ix_score_ref": "ix-score-9988",
+  "links": ["mem-a1b2c3d4-e5f6-7890"]
+}


### PR DESCRIPTION
Defined the core memory object contracts and provenance model for the TARS V2 second-brain harness.

This PR adds:
- `docs/contracts/second-brain-memory-objects.md`
- `examples/second-brain/memory-item.example.json`
- `examples/second-brain/semantic-claim.example.json`
- `examples/second-brain/decision-record.example.json`

The solution strictly focuses on the contract definitions, JSON-first examples, and structural metadata constraints such as provenance, staleness, and privacy, without implementing runtime storage logic.

---
*PR created automatically by Jules for task [6992892742943927473](https://jules.google.com/task/6992892742943927473) started by @spareilleux*