### PR TITLE
docs(second-brain): design source-grounded synthesis & evidence bundle contracts

### DIFF
--- a/v2/docs/contracts/evidence-bundle.contract.md
+++ b/v2/docs/contracts/evidence-bundle.contract.md
@@ -1,0 +1,219 @@
+# Evidence Bundle Contracts
+
+This document defines the data contracts (JSON schemas and F# type equivalents) for the source-grounded synthesis pipeline in the TARS second-brain harness.
+
+These contracts enforce strict separation between LLM-generated summaries and the factual evidence backing them. By mandating explicit source references and surfacing staleness/contradiction markers, these contracts prevent plausible but unsupported claims from entering durable memory.
+
+## 1. SourceSet
+A bounded collection of artifacts provided as context to the LLM.
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SourceSet",
+  "type": "object",
+  "properties": {
+    "setId": { "type": "string", "format": "uuid" },
+    "description": { "type": "string" },
+    "artifacts": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/SourceReference" }
+    }
+  },
+  "required": ["setId", "artifacts"]
+}
+```
+
+```fsharp
+type SourceSet = {
+    SetId: Guid
+    Description: string option
+    Artifacts: SourceReference list
+}
+```
+
+## 2. SourceReference
+A pointer to a specific artifact serving as evidence.
+
+```json
+{
+  "title": "SourceReference",
+  "type": "object",
+  "properties": {
+    "artifactId": { "type": "string" },
+    "uri": { "type": "string", "format": "uri" },
+    "versionHash": { "type": "string" },
+    "timestamp": { "type": "string", "format": "date-time" }
+  },
+  "required": ["artifactId", "uri", "timestamp"]
+}
+```
+
+```fsharp
+type SourceReference = {
+    ArtifactId: string
+    Uri: string
+    VersionHash: string option
+    Timestamp: DateTime
+}
+```
+
+## 3. GroundedClaim
+A specific finding synthesized by the LLM, strictly linked to its supporting sources. The claim is explicitly separated from the evidence.
+
+```json
+{
+  "title": "GroundedClaim",
+  "type": "object",
+  "properties": {
+    "claimId": { "type": "string", "format": "uuid" },
+    "statement": { "type": "string" },
+    "supportingEvidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "artifactId": { "type": "string" },
+          "exactQuote": { "type": "string" }
+        },
+        "required": ["artifactId", "exactQuote"]
+      }
+    }
+  },
+  "required": ["claimId", "statement", "supportingEvidence"]
+}
+```
+
+```fsharp
+type EvidenceLink = {
+    ArtifactId: string
+    ExactQuote: string
+}
+
+type GroundedClaim = {
+    ClaimId: Guid
+    Statement: string
+    SupportingEvidence: EvidenceLink list
+}
+```
+
+## 4. StalenessWarning
+Generated when a source referenced in a claim might be outdated.
+
+```json
+{
+  "title": "StalenessWarning",
+  "type": "object",
+  "properties": {
+    "artifactId": { "type": "string" },
+    "reason": { "type": "string" },
+    "newerVersionUri": { "type": "string", "format": "uri" }
+  },
+  "required": ["artifactId", "reason"]
+}
+```
+
+```fsharp
+type StalenessWarning = {
+    ArtifactId: string
+    Reason: string
+    NewerVersionUri: string option
+}
+```
+
+## 5. ContradictionCandidate
+Raised when a new claim directly opposes an existing durable memory item.
+
+```json
+{
+  "title": "ContradictionCandidate",
+  "type": "object",
+  "properties": {
+    "newClaimId": { "type": "string", "format": "uuid" },
+    "existingMemoryId": { "type": "string", "format": "uuid" },
+    "description": { "type": "string" }
+  },
+  "required": ["newClaimId", "existingMemoryId", "description"]
+}
+```
+
+```fsharp
+type ContradictionCandidate = {
+    NewClaimId: Guid
+    ExistingMemoryId: Guid
+    Description: string
+}
+```
+
+## 6. EvidenceBundle
+The aggregate package of synthesized claims and their metadata, ready for evaluation.
+
+```json
+{
+  "title": "EvidenceBundle",
+  "type": "object",
+  "properties": {
+    "bundleId": { "type": "string", "format": "uuid" },
+    "sourceSetId": { "type": "string", "format": "uuid" },
+    "claims": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/GroundedClaim" }
+    },
+    "stalenessWarnings": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/StalenessWarning" }
+    },
+    "contradictions": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/ContradictionCandidate" }
+    }
+  },
+  "required": ["bundleId", "sourceSetId", "claims"]
+}
+```
+
+```fsharp
+type EvidenceBundle = {
+    BundleId: Guid
+    SourceSetId: Guid
+    Claims: GroundedClaim list
+    StalenessWarnings: StalenessWarning list
+    Contradictions: ContradictionCandidate list
+}
+```
+
+## 7. MemoryPromotionDecision
+The output of the IX/Seldon/Demerzel assessment pipeline, dictating whether a bundle is promoted to memory, rejected, or escalated.
+
+```json
+{
+  "title": "MemoryPromotionDecision",
+  "type": "object",
+  "properties": {
+    "bundleId": { "type": "string", "format": "uuid" },
+    "status": {
+      "type": "string",
+      "enum": ["Accepted", "Rejected", "Escalated"]
+    },
+    "ixScore": { "type": "number" },
+    "reasoning": { "type": "string" },
+    "requiresHumanReview": { "type": "boolean" }
+  },
+  "required": ["bundleId", "status", "ixScore", "reasoning"]
+}
+```
+
+```fsharp
+type PromotionStatus =
+    | Accepted
+    | Rejected
+    | Escalated
+
+type MemoryPromotionDecision = {
+    BundleId: Guid
+    Status: PromotionStatus
+    IxScore: float
+    Reasoning: string
+    RequiresHumanReview: bool
+}
+```

--- a/v2/docs/design/source-grounded-second-brain-synthesis.md
+++ b/v2/docs/design/source-grounded-second-brain-synthesis.md
@@ -1,0 +1,53 @@
+# Source-Grounded Synthesis for TARS Second Brain
+
+## Goal
+Design the source-grounded synthesis and evidence-bundle promotion flow for the TARS second-brain harness. The core objective is to prevent the promotion of plausible, unsupported summaries into durable memory. Knowledge is only promoted when grounded in explicit sources, shaped by grammar contracts, scored by IX, and accepted through rigorous promotion rules (Seldon/Demerzel/human).
+
+## Core Principles
+1. **Source Set is Bounded:** Synthesis operates over a specific, finite set of artifacts.
+2. **Explicit Citations:** Every claim must cite specific source artifacts to be valid.
+3. **Claims ≠ Evidence:** Synthesized claims must be separated from the raw evidence supporting them.
+4. **Contradictions & Staleness:** Conflicting information or outdated sources must be proactively surfaced.
+5. **Explicit Promotion:** Promoting findings to durable memory is a deliberate, gated process, not automatic.
+
+## Candidate Flow
+
+```text
+SourceSet
+  -> semantic synthesis
+  -> candidate ResearchFinding
+  -> EvidenceBundle
+  -> grammar/schema validation
+  -> IX scoring / drift / contradiction checks
+  -> Seldon learning assessment
+  -> MemoryUpdateCandidate
+  -> accepted MemoryItem or escalation
+```
+
+### Flow Breakdown
+
+1. **SourceSet & Semantic Synthesis**: A bounded `SourceSet` (e.g. recent logs, traces, issues) is fed into the LLM context. The LLM performs a semantic synthesis to generate a candidate `ResearchFinding`.
+2. **EvidenceBundle Creation**: The synthesis is structured into an `EvidenceBundle`, separating claims from evidence. Every `GroundedClaim` is linked back to a `SourceReference`.
+3. **Validation & Assessment**:
+   - **Grammar/Schema Validation:** Ensures the bundle aligns with established `.trsx` and JSON schemas.
+   - **IX Scoring:** IX analyzes the claims for logical drift and checks against known contradictions.
+   - **Seldon Assessment:** Seldon evaluates the "learning value" of the claim against the existing knowledge graph.
+4. **Memory Promotion**: The evaluated bundle becomes a `MemoryUpdateCandidate`. The decision logic outputs a `MemoryPromotionDecision` resulting in an accepted `MemoryItem` or an escalation for human review.
+
+## Promotion Rules (Seldon / Demerzel / Human)
+
+- **Seldon (Teacher/Assessor):** Validates if a claim is a novel, source-grounded learning. If Seldon determines the claim is missing a citation, it is automatically rejected.
+- **Demerzel (Governance):** Checks the claim against existing policies and cross-repo health metrics. If the claim implies a policy violation, it is escalated.
+- **IX (Scoring):** Assesses the confidence and robustness of the claim based on the provided evidence. Low-scoring claims are rejected or flagged as `ReviewRequired`.
+- **Human Escalation:** Any `MemoryUpdateCandidate` that flags contradictions, staleness, or falls below a high-confidence threshold but above absolute rejection must be reviewed by a human before becoming a durable `MemoryItem`.
+
+## Contradiction and Staleness Handling
+
+- **Staleness:** A `StalenessWarning` is generated when a cited source is older than a specified decay threshold or when a newer version of the same artifact exists. Stale evidence reduces the IX score.
+- **Contradiction:** If a new `GroundedClaim` directly opposes an existing durable `MemoryItem`, a `ContradictionCandidate` is raised. The system does not overwrite the existing memory automatically; it escalates the conflict for human resolution, preserving both sides of the contradiction in the escalation context.
+
+## Ecosystem Boundaries
+
+- **TARS:** Drives the core semantic extraction and execution flow via `Tars.Evolution`. TARS orchestrates the pipeline but defers judgment.
+- **IX:** Provides the MCTS-driven logical scoring, evaluating the strength of evidence and detecting drift.
+- **Seldon:** Acts as the learning assessor, ensuring knowledge fits the pedagogical and governance frameworks before integration.

--- a/v2/examples/second-brain/evidence-bundle.example.json
+++ b/v2/examples/second-brain/evidence-bundle.example.json
@@ -1,0 +1,40 @@
+{
+  "bundleId": "a1b2c3d4-e5f6-7890-1234-56789abcdef0",
+  "sourceSetId": "b2c3d4e5-f6a7-8901-2345-6789abcdef01",
+  "claims": [
+    {
+      "claimId": "c3d4e5f6-a7b8-9012-3456-789abcdef012",
+      "statement": "TARS agents must not instantiate DefaultLlmService directly; they must always use LlmFactory.create(logger).",
+      "supportingEvidence": [
+        {
+          "artifactId": "art-001",
+          "exactQuote": "LLM access always goes through LlmFactory.create(logger) — never instantiate DefaultLlmService directly."
+        }
+      ]
+    },
+    {
+      "claimId": "d4e5f6a7-b8c9-0123-4567-89abcdef0123",
+      "statement": "Evidence bundles must explicitely separate synthesized claims from their supporting artifacts.",
+      "supportingEvidence": [
+        {
+          "artifactId": "art-002",
+          "exactQuote": "The synthesis is structured into an EvidenceBundle, separating claims from evidence."
+        }
+      ]
+    }
+  ],
+  "stalenessWarnings": [
+    {
+      "artifactId": "art-002",
+      "reason": "The referenced document (v1/design.md) has been deprecated in favor of v2 architecture.",
+      "newerVersionUri": "file:///v2/docs/design/source-grounded-second-brain-synthesis.md"
+    }
+  ],
+  "contradictions": [
+    {
+      "newClaimId": "c3d4e5f6-a7b8-9012-3456-789abcdef012",
+      "existingMemoryId": "e5f6a7b8-c9d0-1234-5678-9abcdef01234",
+      "description": "New claim states LlmFactory must be used, but an old memory item from 2024 states DefaultLlmService is the standard approach."
+    }
+  ]
+}

--- a/v2/examples/second-brain/memory-promotion-decision.example.json
+++ b/v2/examples/second-brain/memory-promotion-decision.example.json
@@ -1,0 +1,7 @@
+{
+  "bundleId": "a1b2c3d4-e5f6-7890-1234-56789abcdef0",
+  "status": "Escalated",
+  "ixScore": 0.65,
+  "reasoning": "Bundle contains grounded claims that successfully passed grammar validation. However, the presence of a contradiction candidate (Claim c3d4e5f6-a7b8-9012-3456-789abcdef012 vs Memory e5f6a7b8-c9d0-1234-5678-9abcdef01234) and a staleness warning on artifact art-002 requires human resolution before promotion. IX score was reduced due to conflicting historical memory.",
+  "requiresHumanReview": true
+}

--- a/v2/tests/Tars.Tests/RouterTests.fs
+++ b/v2/tests/Tars.Tests/RouterTests.fs
@@ -63,7 +63,11 @@ type RouterTests(output: ITestOutputHelper) =
 
             // Act 1
             do! bus.PublishAsync(msg1)
-            do! Task.Delay(500) // Allow processing
+
+            let mutable retries1 = 50
+            while not received1 && retries1 > 0 do
+                do! Task.Delay(100)
+                retries1 <- retries1 - 1
 
             // Assert 1
             Assert.True(received1, "Agent 1 should have received the message")
@@ -84,7 +88,11 @@ type RouterTests(output: ITestOutputHelper) =
 
             // Act 2
             do! bus.PublishAsync(msg2)
-            do! Task.Delay(500)
+
+            let mutable retries2 = 50
+            while not received2 && retries2 > 0 do
+                do! Task.Delay(100)
+                retries2 <- retries2 - 1
 
             // Assert 2
             Assert.False(received1, "Agent 1 should NOT have received the message")
@@ -142,7 +150,11 @@ type RouterTests(output: ITestOutputHelper) =
 
             // Act
             do! bus.PublishAsync(msg)
-            do! Task.Delay(500)
+
+            let mutable retriesIntent = 50
+            while not received && retriesIntent > 0 do
+                do! Task.Delay(100)
+                retriesIntent <- retriesIntent - 1
 
             // Assert
             Assert.True(received, "Agent should have received the message via Intent routing")

--- a/v2/tests/Tars.Tests/RouterTests.fs
+++ b/v2/tests/Tars.Tests/RouterTests.fs
@@ -63,11 +63,7 @@ type RouterTests(output: ITestOutputHelper) =
 
             // Act 1
             do! bus.PublishAsync(msg1)
-
-            let mutable retries1 = 50
-            while not received1 && retries1 > 0 do
-                do! Task.Delay(100)
-                retries1 <- retries1 - 1
+            do! Task.Delay(500) // Allow processing
 
             // Assert 1
             Assert.True(received1, "Agent 1 should have received the message")
@@ -88,11 +84,7 @@ type RouterTests(output: ITestOutputHelper) =
 
             // Act 2
             do! bus.PublishAsync(msg2)
-
-            let mutable retries2 = 50
-            while not received2 && retries2 > 0 do
-                do! Task.Delay(100)
-                retries2 <- retries2 - 1
+            do! Task.Delay(500)
 
             // Assert 2
             Assert.False(received1, "Agent 1 should NOT have received the message")
@@ -150,11 +142,7 @@ type RouterTests(output: ITestOutputHelper) =
 
             // Act
             do! bus.PublishAsync(msg)
-
-            let mutable retriesIntent = 50
-            while not received && retriesIntent > 0 do
-                do! Task.Delay(100)
-                retriesIntent <- retriesIntent - 1
+            do! Task.Delay(500)
 
             // Assert
             Assert.True(received, "Agent should have received the message via Intent routing")


### PR DESCRIPTION
Implementation of issue #102 to design the source-grounded synthesis and evidence-bundle promotion flow for the TARS second-brain harness.

**Changes made:**
- Created `v2/docs/design/source-grounded-second-brain-synthesis.md` documenting the bounded source set flow, promotion rules for IX/Seldon/Demerzel, and staleness/contradiction handling.
- Created `v2/docs/contracts/evidence-bundle.contract.md` defining JSON schemas and F# equivalents for `SourceSet`, `SourceReference`, `EvidenceBundle`, `GroundedClaim`, `StalenessWarning`, `ContradictionCandidate`, and `MemoryPromotionDecision`.
- Added examples for evidence bundles and memory promotion decisions (`v2/examples/second-brain/evidence-bundle.example.json`, `v2/examples/second-brain/memory-promotion-decision.example.json`) demonstrating multi-claim tracking and escalation due to staleness and contradiction markers.
- Verified zero build/test breakages in `v2/` via `dotnet test`.

---
*PR created automatically by Jules for task [7229427448536904912](https://jules.google.com/task/7229427448536904912) started by @spareilleux*