### PR TITLE
docs(design): design research-to-issue factory for agent delegation (#98)

### DIFF
--- a/docs/design/research-to-issue-factory.md
+++ b/docs/design/research-to-issue-factory.md
@@ -1,0 +1,62 @@
+# Research-to-Issue Factory Design
+
+- **Status:** Draft
+- **Area:** Runtime / Technology Watch
+- **Owner:** TARS Cortex
+- **Version:** 1.0.0
+
+## Goal
+Design the research-to-issue factory that turns validated research digests and Streeling findings into agent-ready GitHub issue drafts.
+
+The factory supports delegation to AI agents by producing clear, bounded, evidence-backed issues with acceptance criteria, non-goals, cost/risk policy, and AFK readiness metadata.
+
+## Candidate Input Artifacts
+The factory processes the following input artifacts:
+- `ResearchDigest`
+- `ThesisDigest`
+- `ResearchFinding`
+- `HarnessImprovementProposal`
+- `Streeling EvidenceBundle`
+- `IX scorecard`
+- `Seldon learning assessment`
+
+## Candidate Output Artifact
+The factory produces an `IssueDraft` artifact.
+
+### Minimum Issue Fields
+The `IssueDraft` must contain the following minimum fields:
+- `title`
+- `repository`
+- `parent_issue`
+- `related_issues`
+- `issue_meta`
+- `problem_statement`
+- `goal`
+- `context`
+- `evidence_required`
+- `work_breakdown`
+- `acceptance_criteria`
+- `non_goals`
+- `risk_policy`
+- `budget_policy`
+- `afk_readiness`
+- `routing`
+
+## Candidate Routing Rules
+Issues are routed to the appropriate repository based on the following rules:
+- **TARS:** harness, closures, grammar contracts, runtime, second brain
+- **IX:** algorithms, evals, DuckDB analytics, scoring, retrieval metrics
+- **Demerzel:** governance, budget, approval, escalation, AIW gates
+- **GA:** product/music/guitar domain scenarios and user-facing validation
+
+## Governance Gates
+- **Low-risk documentation issue:** May be created after validation.
+- **Medium-risk design issue:** May be drafted or created with explicit trace.
+- **High-risk implementation issue:** Draft only unless approved.
+- **Agent Code Changes:** Any issue that could trigger agent code changes must include tests and stop conditions.
+
+## Non-goals
+- Do not create issues without evidence/provenance.
+- Do not auto-assign agents without governance policy.
+- Do not implement GitHub mutation in this story.
+- Do not let novelty alone override risk/cost gates.

--- a/examples/technology-watch/agent-delegation-plan.example.json
+++ b/examples/technology-watch/agent-delegation-plan.example.json
@@ -1,0 +1,49 @@
+{
+  "plan_id": "plan-2024-001",
+  "issue_id": "GuitarAlchemist/ix#205",
+  "delegation_target": "jules",
+  "context": {
+    "source_digest": "digest-2024-001",
+    "rationale": "Implement policy-guided MCTS pruning as per ResearchDigest digest-2024-001."
+  },
+  "governance": {
+    "risk_level": "high",
+    "approval_required": true,
+    "halt_conditions": [
+      "Test failure in MCTS loop",
+      "Performance regression > 5%"
+    ],
+    "budget": {
+      "tier": "free-local",
+      "max_cost_usd": 0,
+      "max_runner_minutes": 120
+    }
+  },
+  "tasks": [
+    {
+      "id": "task-1",
+      "description": "Port MLP evaluator to Rust in IX engine.",
+      "status": "pending"
+    },
+    {
+      "id": "task-2",
+      "description": "Integrate MLP evaluator with MCTS loop.",
+      "status": "pending"
+    },
+    {
+      "id": "task-3",
+      "description": "Benchmark MCTS with and without policy-guided pruning.",
+      "status": "pending"
+    }
+  ],
+  "verification": {
+    "required_tests": [
+      "tests/mcts_pruning_tests.rs",
+      "benches/mcts_benchmark.rs"
+    ],
+    "success_criteria": [
+      "All tests pass.",
+      "Benchmark shows >= 20% speedup."
+    ]
+  }
+}

--- a/examples/technology-watch/issue-draft-2.example.json
+++ b/examples/technology-watch/issue-draft-2.example.json
@@ -1,0 +1,58 @@
+{
+  "title": "[Demerzel] Implement Static Verification for Agent Plans",
+  "repository": "GuitarAlchemist/demerzel",
+  "parent_issue": "GuitarAlchemist/demerzel#88",
+  "related_issues": ["GuitarAlchemist/tars#90"],
+  "issue_meta": {
+    "level": "story",
+    "area": "governance",
+    "priority": "P0",
+    "complexity": "H",
+    "risk": "high",
+    "afk": {
+      "readiness": "ready",
+      "max_autonomy": "draft",
+      "reason": "High-risk implementation issue requires explicit review before execution."
+    }
+  },
+  "problem_statement": "Unconstrained autonomous agent swarms can formulate plans that violate governance and safety invariants, leading to unbounded escalation.",
+  "goal": "Integrate formal static verification methods to enforce constitutional constraints on TARS agent plans before execution.",
+  "context": "Based on thesis-2024-002 ('Autonomous Governance in Multi-Agent Systems'), static policy analysis can prevent 90% of unintended escalations. This is critical for Demerzel's governance mission.",
+  "evidence_required": [
+    "grammar_definition",
+    "static_checker_design",
+    "formal_verification_tests"
+  ],
+  "work_breakdown": [
+    "1. Define a verifiable plan grammar mapping to TARS actions.",
+    "2. Implement `ConstitutionalStaticChecker` in Demerzel core.",
+    "3. Add pre-execution hook in TARS to query Demerzel's checker.",
+    "4. Add unit tests for invariant violations and false positives."
+  ],
+  "acceptance_criteria": [
+    "A formal grammar for agent plans is defined.",
+    "The static checker successfully flags plans violating invariant rules.",
+    "TARS agents halt execution if Demerzel rejects the plan.",
+    "All new tests pass successfully."
+  ],
+  "non_goals": [
+    "Do not implement dynamic/runtime monitoring in this issue.",
+    "Do not support arbitrary, non-TARS agents at this time."
+  ],
+  "risk_policy": {
+    "level": "high",
+    "mitigation": "Requires core maintainer approval. Must include extensive negative tests."
+  },
+  "budget_policy": {
+    "tier": "free-local",
+    "max_cost_usd": 0,
+    "max_runner_minutes": 120
+  },
+  "afk_readiness": "draft",
+  "routing": {
+    "lane": "feature",
+    "preferred_workers": [
+      "claude-code-local"
+    ]
+  }
+}

--- a/examples/technology-watch/issue-draft.example.json
+++ b/examples/technology-watch/issue-draft.example.json
@@ -1,0 +1,58 @@
+{
+  "title": "[TARS] Implement Reasoning-Trace Visualization Dashboard",
+  "repository": "GuitarAlchemist/tars",
+  "parent_issue": "GuitarAlchemist/tars#150",
+  "related_issues": ["GuitarAlchemist/tars#145", "GuitarAlchemist/tars#148"],
+  "issue_meta": {
+    "level": "story",
+    "area": "runtime",
+    "priority": "P1",
+    "complexity": "M",
+    "risk": "medium",
+    "afk": {
+      "readiness": "ready",
+      "max_autonomy": "draft",
+      "reason": "Medium risk design requires explicit trace."
+    }
+  },
+  "problem_statement": "Human-in-the-loop operators lack visibility into the internal monologue and reasoning steps of TARS agents, leading to lower trust and harder debugging.",
+  "goal": "Implement a UI component in the TARS dashboard to display streaming reasoning traces and task execution details.",
+  "context": "Based on digest-2024-003 ('Visualizing Internal Monologues', arXiv:2406.1234), displaying reasoning traces increases human trust by 60%.",
+  "evidence_required": [
+    "design_mockups",
+    "streaming_api_contract",
+    "ui_component_tests"
+  ],
+  "work_breakdown": [
+    "1. Extend `Tars.Interface.Web` to include a new 'Reasoning' tab.",
+    "2. Implement backend endpoint in `Tars.Cortex` to stream reasoning tokens.",
+    "3. Build frontend folding/unfolding logic for nested sub-tasks.",
+    "4. Add unit and integration tests for the new UI and streaming API."
+  ],
+  "acceptance_criteria": [
+    "The reasoning tab is visible in the TARS dashboard.",
+    "Reasoning tokens from `Tars.Cortex` stream in real-time.",
+    "Sub-tasks can be expanded and collapsed in the UI.",
+    "All new tests pass successfully."
+  ],
+  "non_goals": [
+    "Do not implement full historical log persistence in this issue.",
+    "Do not alter the core reasoning logic of TARS agents."
+  ],
+  "risk_policy": {
+    "level": "medium",
+    "mitigation": "Requires design review before implementation. Ensure streaming endpoint is rate-limited."
+  },
+  "budget_policy": {
+    "tier": "free-local",
+    "max_cost_usd": 0,
+    "max_runner_minutes": 60
+  },
+  "afk_readiness": "draft",
+  "routing": {
+    "lane": "feature",
+    "preferred_workers": [
+      "claude-code-local"
+    ]
+  }
+}


### PR DESCRIPTION
This PR implements GitHub issue #98: [Story][TARS-V2][P0] Design research-to-issue factory for agent-ready GitHub delegation.

### Changes
- Designed the research-to-issue factory which processes artifacts like `ResearchDigest` into `IssueDraft`s with defined routing and governance checks (`docs/design/research-to-issue-factory.md`).
- Authored two mock `IssueDraft` JSON examples (`issue-draft.example.json`, `issue-draft-2.example.json`) containing all necessary issue components (title, repository, acceptance criteria, budget policy, risk etc).
- Authored a mock agent delegation plan example (`agent-delegation-plan.example.json`).

### Pre-commit checklist
- [x] Verified tests in `v2/` (`dotnet build && dotnet test`) pass successfully.
- [x] No code regressions. Pure documentation/design additions.
- [x] Received #Correct# rating from automated code reviewer.

---
*PR created automatically by Jules for task [4080445632528561260](https://jules.google.com/task/4080445632528561260) started by @spareilleux*