### PR TITLE
Add repo-readable cloud-agent skills for AFK delegation

### DIFF
--- a/docs/agents/skills/README.md
+++ b/docs/agents/skills/README.md
@@ -1,0 +1,15 @@
+# Cloud-Agent Skill Library
+
+This directory contains explicit skills for cloud agents (like Jules or Codex) when working AFK (Away From Keyboard) from GitHub issues.
+
+Cloud agents cannot access local TARS skills or local MCP state. However, they can reliably read repo files and issue bodies. This repo-readable skill library provides standardized behavior patterns that cloud agents must follow when executing delegated issues.
+
+## Available Skills
+
+- **Docs-Only Contract** (`docs-only-contract.skill.md`): Used for documentation-only updates, enforcing that no runtime behavior is changed.
+- **Evidence Bundle** (`evidence-bundle.skill.md`): Used for grounding claims and design decisions in explicitly referenced source material.
+- **Governed Delegation** (`governed-delegation.skill.md`): Used for navigating the Demerzel governance constraints and respecting AFK halt markers.
+
+## Usage
+
+Cloud agents should parse the `issue_meta` block in the GitHub issue body and use these definitions to guide their approach, ensuring that they respect project constraints, execute required checks, and provide the expected evidence in the pull request body.

--- a/docs/agents/skills/docs-only-contract.skill.md
+++ b/docs/agents/skills/docs-only-contract.skill.md
@@ -1,0 +1,28 @@
+# Skill: Docs-Only Contract
+
+## When to use
+Use this skill when the GitHub issue's `issue_meta` explicitly states `reason: "documentation-only..."`, or when the task solely involves creating, updating, or correcting documentation, diagrams, or examples without altering runtime functionality.
+
+## Allowed files/surfaces
+- `*.md` files (e.g., `README.md`, `CLAUDE.md`, `CONTEXT.md`, files in `docs/`).
+- JSON/YAML files only if they are explicitly marked as examples (e.g., `examples/**/*.json`) or non-runtime configuration.
+- **Forbidden:** Any F# source files (`*.fs`, `*.fsproj`), Rust source files (`*.rs`), or CI/CD workflow definitions (`.github/workflows/*.yml`) unless explicitly requested as part of a doc update.
+
+## Required checks
+1. **Scope Check:** Verify that no runtime logic or system configuration is modified.
+2. **Formatting Check:** Ensure standard Markdown formatting, broken link avoidance, and compliance with project terminology defined in `CONTEXT.md`.
+3. **Build Check:** Ensure that any example code blocks provided in the documentation are syntactically valid. Run `dotnet build` from `v2/` to ensure you haven't accidentally broken the build.
+
+## Stop conditions
+- Stop when the required documentation files have been created or modified as specified in the issue.
+- Stop immediately if you find yourself needing to modify an F# (`*.fs`) file to complete the documentation.
+
+## Evidence expected in the PR body
+- A checklist of the documentation files modified.
+- A statement confirming that no runtime code was altered.
+- Links to the rendered documentation (if applicable).
+
+## Common failure modes
+- Accidentally editing a `.fs` file to fix a typo discovered during documentation writing, thus violating the "docs-only" constraint.
+- Failing to build and test the repo, assuming that documentation changes cannot break the build.
+- Missing updates to `CONTEXT.md` or `CLAUDE.md` if new terminology is introduced.

--- a/docs/agents/skills/evidence-bundle.skill.md
+++ b/docs/agents/skills/evidence-bundle.skill.md
@@ -1,0 +1,30 @@
+# Skill: Evidence Bundle
+
+## When to use
+Use this skill when completing tasks that require source-grounded claims, such as creating research digests, technology-watch proposals, or any architectural design decisions. It must be used when `issue_meta.evidence_required` includes items that need concrete source backing, or when working on the second-brain memory objects.
+
+## Allowed files/surfaces
+- `docs/contracts/`
+- `docs/design/`
+- `examples/technology-watch/`
+- `examples/second-brain/`
+- Any explicitly targeted knowledge management files mentioned in the issue.
+
+## Required checks
+1. **Provenance Check:** Ensure every major claim or digest is explicitly linked to a source (e.g., via `source_uri`, `source_hash`, or `provenance` metadata).
+2. **Contract Compliance:** Ensure the created evidence bundles match the strict schema requirements (e.g., JSON-first, includes structural metadata like confidence and privacy level) as defined in `docs/contracts/`.
+3. **Fact Separation:** Verify that LLM-generated claims are explicitly separated from factual source evidence, and that staleness markers and contradiction candidates are properly defined if applicable.
+
+## Stop conditions
+- Stop when all required evidence files (JSON/MD) have been created and correctly reference their sources.
+- Stop if the source material required for grounding cannot be accessed or verified.
+
+## Evidence expected in the PR body
+- Links to the newly created or updated evidence bundle JSON/MD files.
+- A summary of the provenance sources used for the claims.
+- A confirmation statement that no claims lack a source linkage.
+
+## Common failure modes
+- Generating hallucinatory claims without linking them to specific, verifiable source evidence (`source_uri` or `source_hash`).
+- Failing to include mandatory metadata fields (like `digester_id`, `digestion_timestamp`) required by the TARS V2 second-brain memory object contracts.
+- Embedding plain text reasoning inside JSON files instead of adhering to the structured data contract.

--- a/docs/agents/skills/governed-delegation.skill.md
+++ b/docs/agents/skills/governed-delegation.skill.md
@@ -1,0 +1,30 @@
+# Skill: Governed Delegation
+
+## When to use
+Use this skill when processing an issue delegated to a cloud agent (e.g., Jules or Codex) to ensure the agent explicitly acknowledges and complies with the Demerzel governance constraints, including respecting AFK (Away From Keyboard) halt markers and checking limits on scope and risk.
+
+## Allowed files/surfaces
+- Checking `governance/state/afk-halt.json` (read-only)
+- Reading `docs/governance/` (read-only)
+- `issue_meta` in the GitHub issue description.
+- PR body generation.
+
+## Required checks
+1. **Halt Marker Check:** Before beginning any code changes, verify that the `governance/state/afk-halt.json` file does NOT exist, or if it does, that its `expires_at` date has passed. If an active halt is detected, execution must stop immediately.
+2. **Autonomy Limit Check:** Verify that the task does not exceed the `max_autonomy` specified in the `issue_meta` (e.g., if it states `max_autonomy: pr`, do not attempt to merge or push directly to main).
+3. **Risk Profile Check:** Confirm that the work aligns with the risk constraints documented in the governance policies.
+
+## Stop conditions
+- Stop and gracefully report failure (via an issue comment or PR note) if `governance/state/afk-halt.json` is present and active.
+- Stop if the requested task violates Demerzel governance rules (e.g., requesting unreviewed merges).
+- Stop when the task is complete and a PR has been opened, adhering to the `max_autonomy` boundary.
+
+## Evidence expected in the PR body
+- A statement confirming that `governance/state/afk-halt.json` was checked and found to be inactive or absent.
+- A statement confirming adherence to the `max_autonomy` limit specified in the issue.
+- A checklist of any specific governance policies observed.
+
+## Common failure modes
+- Ignoring the `governance/state/afk-halt.json` file and executing the task during an ecosystem-wide halt.
+- Proceeding to merge a pull request or push directly to the main branch when `max_autonomy` is limited to `pr`.
+- Failing to document the governance check in the final PR body, leading to rejection by the Demerzel qa-tribunal.

--- a/examples/agents/skill-selection.example.json
+++ b/examples/agents/skill-selection.example.json
@@ -1,0 +1,39 @@
+{
+  "scenario": "Agent evaluates issue #114 to determine which skills to apply based on issue_meta.",
+  "issue_meta": {
+    "level": "task",
+    "area": "runtime",
+    "priority": "P0",
+    "afk": {
+      "readiness": "ready",
+      "max_autonomy": "pr",
+      "reason": "documentation-only cloud-agent skill library; no runtime behavior change"
+    },
+    "evidence_required": [
+      "skill_library_docs",
+      "skill_selection_example",
+      "governance_notes"
+    ]
+  },
+  "skill_selection": {
+    "docs-only-contract": {
+      "selected": true,
+      "reason": "The issue reason explicitly states 'documentation-only cloud-agent skill library; no runtime behavior change'."
+    },
+    "governed-delegation": {
+      "selected": true,
+      "reason": "The issue is delegated for AFK processing and specifies 'max_autonomy: pr'. Governance constraints must be respected."
+    },
+    "evidence-bundle": {
+      "selected": false,
+      "reason": "Although evidence is required ('evidence_required' block), this specific task does not require formal source-grounded research digests or second-brain schema compliance. However, the PR body must provide the requested evidence items."
+    }
+  },
+  "execution_plan": [
+    "Verify afk-halt.json is inactive (Governed Delegation).",
+    "Create docs/agents/skills/ README and skill files (Docs-Only Contract).",
+    "Create this skill selection example.",
+    "Verify no F# files are modified.",
+    "Open PR with a checklist of created docs, confirmation of no runtime changes, and evidence of governance check."
+  ]
+}


### PR DESCRIPTION
Added a cloud-agent skill library in `docs/agents/skills/` to provide explicit, repo-readable skills for autonomous cloud agents working AFK.

This includes:
- `docs/agents/skills/README.md`: Index and introduction.
- `docs/agents/skills/docs-only-contract.skill.md`: Constraints for documentation updates.
- `docs/agents/skills/evidence-bundle.skill.md`: Requirements for grounding claims in evidence.
- `docs/agents/skills/governed-delegation.skill.md`: Governance checks (e.g., AFK halt marker, autonomy limits).
- `examples/agents/skill-selection.example.json`: Example showing how an agent might select these skills based on issue metadata.

Fixes #114.

---
*PR created automatically by Jules for task [14067508146159111677](https://jules.google.com/task/14067508146159111677) started by @spareilleux*