### PR TITLE
[Story][TARS-V2][P1] Expose second-brain memory safely through MCP resources and A2A artifacts

### DIFF
--- a/v2/docs/design/second-brain-mcp-a2a-exposure.md
+++ b/v2/docs/design/second-brain-mcp-a2a-exposure.md
@@ -1,0 +1,60 @@
+# Second-Brain MCP and A2A Exposure Design
+
+- **Status:** Draft
+- **Area:** Runtime / Memory
+- **Owner:** TARS Cortex
+- **Version:** 1.0.0
+
+## Purpose
+This document defines how TARS safely exposes its second-brain memory through the Model Context Protocol (MCP) and Agent-to-Agent (A2A) artifacts. The design prioritizes privacy, provenance, and safety to prevent data leakage and unbounded context growth while making the harness's knowledge usable by external clients and autonomous sub-agents.
+
+## 1. Candidate MCP Surfaces
+The MCP server will expose explicit read-only boundaries by default. The following resources, prompts, and tools are designed to surface targeted context without overwhelming the client.
+
+### Resources
+- `resources/list_second_brain_collections`: Returns metadata about available knowledge scopes (e.g., `traces`, `patterns`, `issues`, `docs`).
+- `resources/read_memory_item/{id}`: Returns a specific memory object by its unique identifier (e.g., UUID or Hash).
+
+### Prompts
+- `prompts/get_context_assembly`: A system-level prompt that instructs the model on how to interpret and cite memory items when reasoning. It ensures the model treats memories as "context candidates" rather than absolute ground truth.
+
+### Tools
+- `tools/search_memory`: Searches the second brain based on a query string and a mandatory `scope` parameter to limit the blast radius. Returns a bounded array of results.
+- `tools/explain_memory_provenance`: Given a memory ID, returns its lineage, creation timestamp, author (digester_id), and original source hash.
+
+## 2. Candidate A2A Artifacts
+A2A (Agent-to-Agent) artifacts are serialized structures shared between TARS and external components (like IX, ga, Demerzel). They must be highly structured and strictly scoped.
+
+- **MemoryBrief**: A short, high-density summary of a specific topic, intended to fit within strict token budgets.
+- **ContextPack**: A bundled collection of relevant memory items, explicitly bounded by relevance score and scope, typically generated as a response to an agent's `tools/search_memory` call.
+- **DecisionBrief**: A record of a past decision, including the rationale, alternatives considered, and outcome.
+- **TraceSummary**: A condensed version of a full execution trace (e.g., from GA), highlighting key actions and results without the verbosity of raw logs.
+- **ReplayReport**: An artifact containing the state necessary to reproduce or simulate a past execution.
+- **IXScorecard**: A performance or metric scorecard specifically formatted for consumption by the IX skill engine.
+
+## 3. Consent and Scope Requirements
+To enforce safety and privacy across the ecosystem, the following constraints must govern all memory exposures:
+
+### Scope Limitation
+- Memory is *never* exposed globally or fully.
+- All retrieval operations (`tools/search_memory`, A2A artifact generation) must require an explicit scope (e.g., `scope="repository-docs"` or `scope="ga-traces"`).
+
+### Provenance and Staleness
+- Every exposed memory item must include its provenance (source hash, digester ID) and a staleness marker (e.g., `last_verified_date`, `is_stale` flag).
+- Seldon (the teaching persona) and other consumers must use this metadata to weigh the reliability of the information.
+
+### Redaction and Privacy
+- Private data and secrets must be redacted or entirely omitted before transmission.
+- A "Privacy Level" or classification label (e.g., `public`, `internal`, `restricted`) should be enforced at the memory extraction layer.
+
+### Mutation Approval
+- The first pass is strictly **read-only**.
+- Any future tool-driven memory mutations (e.g., `tools/update_memory`) must require an explicit, signed contract and human-in-the-loop (or Demerzel tribunal) approval.
+
+### Contextual Candor
+- Memory search results are explicitly labeled as "context candidates." Agents must be instructed not to treat retrieved memory as unassailable truth but as historical context subject to verification.
+
+## 4. Implementation Guidelines
+- **Format:** All A2A artifacts must be JSON-first.
+- **F# Compatibility:** Design data structures to map cleanly to F# immutable records and discriminated unions.
+- **Errors:** Invalid scopes or unauthorized access should return standard MCP error codes mapped to F# `Result.Error`.

--- a/v2/docs/security/second-brain-threat-model.md
+++ b/v2/docs/security/second-brain-threat-model.md
@@ -1,0 +1,54 @@
+# Second-Brain Threat Model
+
+- **Status:** Draft
+- **Area:** Security / Memory
+- **Owner:** TARS Cortex
+- **Version:** 1.0.0
+
+## Purpose
+This document outlines the threat model for exposing the TARS second brain via the Model Context Protocol (MCP) and A2A interfaces. It identifies potential attack vectors, privacy risks, and details the necessary mitigations to ensure safe, read-only defaults.
+
+## 1. Threat Scenarios
+
+### T1: Unbounded Queries (Denial of Service / Context Overflow)
+- **Description:** A client or compromised agent requests a massive slice of memory (e.g., querying for all traces without a filter), either maliciously or accidentally. This can exhaust context windows, cause expensive API usage (if passed to an LLM), or lead to system OOM (Out Of Memory).
+- **Mitigation:**
+  - All memory extraction and search endpoints must enforce hard pagination limits (e.g., `limit=10`).
+  - Search tools must require an explicit, narrow `scope` parameter.
+  - Implement token-estimation before dispatching A2A artifacts (e.g., `ContextPack`).
+
+### T2: Secret Exfiltration / Privacy Leakage
+- **Description:** Sensitive information (API keys, user data, proprietary prompts) inadvertently ingested into the second brain is exposed via MCP reads or searches.
+- **Mitigation:**
+  - All memory items must have a data classification level. By default, MCP read operations filter out anything not explicitly marked `public` or `safe`.
+  - A pre-ingestion redaction layer should strip known secret patterns.
+  - The first pass implementation of MCP tools is explicitly **read-only**, meaning attackers cannot use the tool surface to *insert* new extraction payloads.
+
+### T3: Prompt Injection via Contaminated Memory
+- **Description:** An attacker places malicious text in an external system (e.g., a GitHub issue) that gets ingested into the second brain. Later, when an agent retrieves that memory via `tools/search_memory`, the text acts as a prompt injection payload against the retrieving agent.
+- **Mitigation:**
+  - Memory retrieved via MCP is treated strictly as **data**, not instructions.
+  - The `prompts/get_context_assembly` prompt must explicitly instruct the LLM to sandbox the retrieved content and not treat it as executable commands.
+  - Strict provenance tracking (`source_hash`, `digester_id`) ensures that if a contamination occurs, the source can be blacklisted.
+
+### T4: Unauthorized Mutation
+- **Description:** An agent or connected MCP client attempts to delete, overwrite, or corrupt memory records without authorization.
+- **Mitigation:**
+  - The exposed MCP interface for the second brain is structurally **read-only**.
+  - Any future write operations must pass through Demerzel's governance framework (e.g., requiring tribunal approval or an explicit signed A2A contract).
+  - TARS grammar validation must reject unapproved mutation commands at the parser level.
+
+### T5: Hallucination Amplification (Stale or False Context)
+- **Description:** Agents act confidently on retrieved memory that is outdated, contradicted by newer data, or was poorly generated initially.
+- **Mitigation:**
+  - Mandatory staleness markers (`last_verified_date`) and confidence scores must accompany every retrieved memory object.
+  - Agents must use `tools/explain_memory_provenance` when a critical decision relies on a piece of memory, allowing them to assess its validity.
+
+## 2. Safe Defaults Summary
+To adhere to the GuitarAlchemist ecosystem's security posture, the following safe defaults are applied unconditionally:
+
+1. **Deny-by-Default Visibility:** Memory items without explicit clearance metadata are hidden from external tools.
+2. **Read-Only Surface:** No mutation tools are exposed in the initial design.
+3. **Mandatory Scoping:** A `scope` parameter is universally required for search/list operations.
+4. **Token Caps:** Hard limits on the size of returned `ContextPack` and `search_memory` arrays.
+5. **Provenance Transparency:** No memory is ever returned without its origin ID and timestamp attached.

--- a/v2/examples/second-brain/mcp-a2a/a2a-context-pack.example.json
+++ b/v2/examples/second-brain/mcp-a2a/a2a-context-pack.example.json
@@ -1,0 +1,22 @@
+{
+  "artifact_type": "ContextPack",
+  "version": "1.0",
+  "topic_summary": "Context routing optimizations and constraints",
+  "relevance_threshold": 0.8,
+  "bundle_size_tokens": 1450,
+  "items": [
+    {
+      "memory_id": "mem-7f3b-4c8d-9a1e",
+      "summary": "Large context models increase routing latency by 15%.",
+      "actionable": true,
+      "link": "mcp://resources/memory/mem-7f3b-4c8d-9a1e"
+    },
+    {
+      "memory_id": "mem-99zz-88yy-77xx",
+      "summary": "Caching token embeddings reduces MCTS evaluation time in IX.",
+      "actionable": true,
+      "link": "mcp://resources/memory/mem-99zz-88yy-77xx"
+    }
+  ],
+  "disclaimer": "These items are context candidates. Verify staleness before applying to production logic."
+}

--- a/v2/examples/second-brain/mcp-a2a/a2a-memory-brief.example.json
+++ b/v2/examples/second-brain/mcp-a2a/a2a-memory-brief.example.json
@@ -1,0 +1,15 @@
+{
+  "artifact_type": "MemoryBrief",
+  "version": "1.0",
+  "id": "brief-auth-fallback-2026",
+  "topic": "Authentication Fallback Mechanisms",
+  "content": "Historically, using a secondary OIDC provider caused a race condition in the TARS context assembly layer (Issue #45). The current policy dictates failing fast rather than attempting silent token refresh.",
+  "confidence_score": 0.95,
+  "last_verified_date": "2026-06-20T10:00:00Z",
+  "provenance_summary": "Synthesized from 3 GitHub issues and 1 architectural decision record.",
+  "privacy_level": "public",
+  "related_memory_ids": [
+    "mem-1234",
+    "mem-5678"
+  ]
+}

--- a/v2/examples/second-brain/mcp-a2a/mcp-tool-search-response.example.json
+++ b/v2/examples/second-brain/mcp-a2a/mcp-tool-search-response.example.json
@@ -1,0 +1,38 @@
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": {
+    "status": "success",
+    "scope_queried": "ga-traces",
+    "results_count": 2,
+    "limit_applied": 5,
+    "results": [
+      {
+        "memory_id": "mem-7f3b-4c8d-9a1e",
+        "type": "SemanticClaim",
+        "content": "The GA orchestrator experiences a 15% latency increase when routing to models with context > 64k tokens.",
+        "confidence": 0.88,
+        "is_stale": false,
+        "provenance": {
+          "source_hash": "sha256:d8a4f9b2...",
+          "digester_id": "tars-researcher-v1",
+          "timestamp": "2026-06-25T14:30:00Z"
+        },
+        "privacy_level": "internal"
+      },
+      {
+        "memory_id": "mem-1a2b-3c4d-5e6f",
+        "type": "DecisionRecord",
+        "content": "Disabled fallback routing to local models due to OOM errors on concurrent requests.",
+        "confidence": 1.0,
+        "is_stale": true,
+        "provenance": {
+          "source_hash": "sha256:b1c2d3e4...",
+          "digester_id": "tars-orchestrator",
+          "timestamp": "2026-05-10T09:15:00Z"
+        },
+        "privacy_level": "public"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #93 by implementing the documentation requirements for safely exposing second-brain memory.

- Defines safe MCP surfaces (`search_memory`, `explain_memory_provenance`) and A2A artifacts (`MemoryBrief`, `ContextPack`, etc.).
- Outlines strict consent, privacy, and scope limits.
- Provides a comprehensive threat model addressing unbounded queries, prompt injection, and unauthorized mutations.
- Includes JSON examples for tools and artifacts to guide future implementation.

---
*PR created automatically by Jules for task [6704763220124139882](https://jules.google.com/task/6704763220124139882) started by @spareilleux*