### PR TITLE
docs(afk): define cloud-agent backpressure and locking model

### DIFF
--- a/docs/contracts/afk-dispatch-queue.contract.md
+++ b/docs/contracts/afk-dispatch-queue.contract.md
@@ -1,0 +1,85 @@
+# Contract: AFK Dispatch Queue
+
+## Status
+
+Draft.
+
+## Purpose
+
+This contract describes the queue, admission, backpressure, and locking state for the AFK cloud-agent loop.
+
+The first implementation may derive this state from GitHub issues, labels, and pull requests. A later scheduler may materialize it as JSON.
+
+## Entities
+
+### AfkDispatchQueue
+
+| Field | Type | Description |
+|---|---|---|
+| `queue_id` | string | Stable queue identifier. |
+| `repo` | string | Repository owner/name. |
+| `generated_at` | RFC3339 timestamp | When this queue snapshot was produced. |
+| `global_wip_limit` | integer | Maximum open cloud-agent PRs. |
+| `open_cloud_agent_prs` | integer | Current open cloud-agent PR count. |
+| `lanes` | array of `AfkLaneState` | Lane-specific capacity and occupancy. |
+| `locks` | array of `AfkLock` | Exact active locks. |
+| `probabilistic_indexes` | array of `ProbabilisticConflictIndex` | Optional pre-filter indexes. |
+| `pending_decisions` | array of `BackpressureDecision` | Recent admission decisions. |
+
+### AfkLaneState
+
+| Field | Type | Description |
+|---|---|---|
+| `lane` | enum | `contract`, `evidence`, `policy`, `workflow`, `runtime`, `experiment`. |
+| `wip_limit` | integer | Maximum concurrent work for this lane. |
+| `open_prs` | integer | Current open PRs in this lane. |
+| `queued_issues` | integer | Issues waiting for admission. |
+| `priority` | integer | Lower number means higher priority. |
+
+### AfkLock
+
+| Field | Type | Description |
+|---|---|---|
+| `lock_id` | string | Stable lock id. |
+| `kind` | enum | `issue`, `surface`, `lane`, `repo`. |
+| `resource` | string | Locked resource key, such as `issue:GuitarAlchemist/tars#118`. |
+| `owner` | string | Agent, workflow, PR, or maintainer holding the lock. |
+| `owner_pr` | string | Optional PR URL or number. |
+| `acquired_at` | RFC3339 timestamp | When the lock was acquired. |
+| `expires_at` | RFC3339 timestamp or null | Optional lease expiration. |
+| `release_policy` | string | When the lock should be released. |
+
+### ProbabilisticConflictIndex
+
+| Field | Type | Description |
+|---|---|---|
+| `index_id` | string | Stable index id. |
+| `kind` | enum | `bloom_filter`, `counting_bloom_filter`, `cuckoo_filter`. |
+| `scope` | string | What the index summarizes. |
+| `false_positive_rate` | number | Expected false-positive rate. |
+| `authoritative` | boolean | Must be false. |
+| `exact_check_required` | boolean | Must be true. |
+
+Probabilistic structures may only say “there may be a conflict”. They must never be used to prove that a lock is free.
+
+### BackpressureDecision
+
+| Field | Type | Description |
+|---|---|---|
+| `decision_id` | string | Stable decision id. |
+| `issue` | string | Issue being evaluated. |
+| `decision` | enum | `admit`, `defer_backpressure`, `defer_lock_conflict`, `reject_policy`, `halted`. |
+| `reason` | string | Human-readable reason. |
+| `observed_open_prs` | integer | Open cloud-agent PRs at decision time. |
+| `global_wip_limit` | integer | Limit used by the decision. |
+| `conflicting_locks` | array of string | Lock ids or resource keys that caused a conflict. |
+| `retry_after` | string or null | Optional retry hint. |
+
+## Invariants
+
+- An issue may have at most one open cloud-agent PR.
+- A workflow lane may have at most one open workflow-change PR unless explicitly approved.
+- Runtime lane dispatch is disabled by default unless an issue explicitly carries approval metadata.
+- Bloom filters and other probabilistic structures are never authoritative.
+- Governance halt overrides all admission decisions.
+- Human/Demerzel review remains mandatory before merge.

--- a/docs/design/afk-cloud-agent-backpressure.md
+++ b/docs/design/afk-cloud-agent-backpressure.md
@@ -1,0 +1,154 @@
+# AFK Cloud-Agent Backpressure and Locks
+
+## Purpose
+
+The AFK cloud-agent loop needs two related controls:
+
+1. **Backpressure**: limit how much work is admitted into the cloud-agent pipeline.
+2. **Locks**: prevent two agents from modifying the same issue, lane, or surface at the same time.
+
+Backpressure protects review capacity. Locks protect correctness and reduce merge churn.
+
+## Current risk
+
+The current `ready-for-agent` flow can fan out quickly:
+
+```text
+ready-for-agent label
+  -> workflow
+  -> Jules/Codex
+  -> PR
+  -> CI / QA / review
+```
+
+Without admission control, this can create too many open PRs, duplicate work for the same issue, stale branches, and agents touching the same files.
+
+## Backpressure model
+
+```text
+issue_ready_signal
+  -> admission controller
+  -> queue / policy decision
+  -> lock acquisition
+  -> cloud-agent dispatch
+  -> PR opened
+  -> CI / blackbox / QA verdict
+  -> review queue
+  -> merge / revise / close duplicate
+  -> lock release
+  -> metrics feedback
+```
+
+## Initial hard limits
+
+The first implementation should be intentionally conservative:
+
+| Control | Initial value | Reason |
+|---|---:|---|
+| Global open cloud-agent PR limit | 5 | Keeps review queue human-sized. |
+| Open PRs per issue | 1 | Prevents duplicate agent work on the same issue. |
+| Workflow-change PRs | 1 | Prevents competing edits to automation. |
+| Runtime-change PRs | 0 by default | Runtime work needs explicit approval. |
+
+## Lock types
+
+### Issue lock
+
+Only one open PR may claim a given issue number.
+
+Lock key:
+
+```text
+issue:GuitarAlchemist/tars#118
+```
+
+### Surface lock
+
+A surface is a coarse-grained repo area such as:
+
+```text
+.github/workflows/
+docs/contracts/
+docs/design/
+docs/agents/
+examples/agents/
+v2/src/
+v2/tests/
+```
+
+Lock key examples:
+
+```text
+surface:.github/workflows
+surface:docs/contracts
+surface:v2/tests
+```
+
+### Lane lock
+
+A lane groups work by policy intent:
+
+```text
+lane:contract
+lane:evidence
+lane:policy
+lane:workflow
+lane:runtime
+```
+
+Workflow and runtime lanes should have the strictest concurrency.
+
+## Exact locks vs probabilistic filters
+
+Locks must be exact and authoritative. A Bloom filter can be useful as a fast pre-filter, but it must never be the source of truth because false positives are possible.
+
+Recommended pattern:
+
+```text
+candidate work
+  -> probabilistic conflict pre-filter
+  -> exact GitHub PR/issue/label check
+  -> lock decision
+```
+
+Bloom filters are acceptable for:
+
+- quickly detecting that a surface might already be touched;
+- reducing API calls before exact checks;
+- summarizing large historical conflict sets;
+- local/offline schedulers where occasional false positives only delay work.
+
+Bloom filters are not acceptable for:
+
+- deciding that a lock is free;
+- deciding that a PR is safe to merge;
+- releasing locks;
+- replacing GitHub issue/PR state.
+
+## Admission outcomes
+
+| Outcome | Meaning |
+|---|---|
+| `admit` | Dispatch an agent. |
+| `defer_backpressure` | Too many open PRs; retry after review queue shrinks. |
+| `defer_lock_conflict` | Another PR already claims the issue or surface. |
+| `reject_policy` | Task violates governance, risk, or allowed surfaces. |
+| `halted` | Governance halt marker is active. |
+
+## Release conditions
+
+Locks are released when the PR is:
+
+- merged;
+- closed as duplicate;
+- closed as not planned;
+- superseded by a higher-priority PR;
+- explicitly abandoned by the maintainer.
+
+## Next implementation steps
+
+1. Add admission control to `.github/workflows/jules-auto-delegate.yml`.
+2. Count open cloud-agent PRs before dispatch.
+3. Check whether the current issue already has an open PR.
+4. Add a PR hygiene policy for stale/duplicate agent work.
+5. Later, add surface-level locks using labels or a queue-state artifact.

--- a/examples/agents/afk-dispatch-queue.example.json
+++ b/examples/agents/afk-dispatch-queue.example.json
@@ -1,0 +1,63 @@
+{
+  "queue_id": "afk-cloud-agent-main",
+  "repo": "GuitarAlchemist/tars",
+  "generated_at": "2026-06-28T06:10:00Z",
+  "global_wip_limit": 5,
+  "open_cloud_agent_prs": 4,
+  "lanes": [
+    {
+      "lane": "contract",
+      "wip_limit": 2,
+      "open_prs": 1,
+      "queued_issues": 2,
+      "priority": 0
+    },
+    {
+      "lane": "workflow",
+      "wip_limit": 1,
+      "open_prs": 1,
+      "queued_issues": 1,
+      "priority": 1
+    },
+    {
+      "lane": "runtime",
+      "wip_limit": 0,
+      "open_prs": 0,
+      "queued_issues": 0,
+      "priority": 5
+    }
+  ],
+  "locks": [
+    {
+      "lock_id": "lock-issue-118",
+      "kind": "issue",
+      "resource": "issue:GuitarAlchemist/tars#118",
+      "owner": "workflow:afk-delegate",
+      "owner_pr": "GuitarAlchemist/tars#119",
+      "acquired_at": "2026-06-28T06:09:00Z",
+      "expires_at": null,
+      "release_policy": "release_on_pr_merge_or_close"
+    },
+    {
+      "lock_id": "lock-surface-workflows",
+      "kind": "surface",
+      "resource": "surface:.github/workflows",
+      "owner": "workflow:afk-delegate",
+      "owner_pr": "GuitarAlchemist/tars#119",
+      "acquired_at": "2026-06-28T06:09:00Z",
+      "expires_at": null,
+      "release_policy": "release_on_pr_merge_or_close"
+    }
+  ],
+  "probabilistic_indexes": [
+    {
+      "index_id": "possible-surface-conflicts-v1",
+      "kind": "bloom_filter",
+      "scope": "open_pr_changed_surfaces",
+      "false_positive_rate": 0.01,
+      "authoritative": false,
+      "exact_check_required": true
+    }
+  ],
+  "pending_decisions": []
+}

--- a/examples/agents/backpressure-decision.example.json
+++ b/examples/agents/backpressure-decision.example.json
@@ -1,0 +1,13 @@
+{
+  "decision_id": "decision-2026-06-28-001",
+  "issue": "GuitarAlchemist/tars#118",
+  "decision": "defer_lock_conflict",
+  "reason": "Issue already has an open cloud-agent PR and the workflow surface is locked by another PR.",
+  "observed_open_prs": 5,
+  "global_wip_limit": 5,
+  "conflicting_locks": [
+    "issue:GuitarAlchemist/tars#118",
+    "surface:.github/workflows"
+  ],
+  "retry_after": "after_conflicting_pr_closes"
+}


### PR DESCRIPTION
## Summary

Implements the design/contract/example layer for #118.

Adds:
- `docs/design/afk-cloud-agent-backpressure.md`
- `docs/contracts/afk-dispatch-queue.contract.md`
- `examples/agents/afk-dispatch-queue.example.json`
- `examples/agents/backpressure-decision.example.json`

## Decisions

- Backpressure and locks are separate controls:
  - backpressure limits admitted cloud-agent work;
  - locks prevent duplicate/conflicting work.
- Exact locks are authoritative.
- Bloom filters / probabilistic indexes may be used only as conflict pre-filters and must always be followed by exact checks.
- Governance halt and human/Demerzel review remain mandatory.

## Note

I attempted to wire a minimal gate into `.github/workflows/jules-auto-delegate.yml`, but the connector blocked the workflow-file update. This PR lands the policy/contract layer first so the workflow change can be reviewed/applied in a follow-up patch.

Fixes #118.