### PR TITLE
docs: design governed Codex dispatch seam (#116)

### DIFF
--- a/docs/design/governed-codex-dispatch.md
+++ b/docs/design/governed-codex-dispatch.md
@@ -1,0 +1,34 @@
+# Governed Codex Dispatch Design
+
+## Overview
+This document defines the architectural seam and process for dispatching Codex for cloud-agent work within the TARS repository. The goal is to bring Codex into the same governed, review-gated, and halt-gated workflow as other agent paths (such as the Jules AFK path), ensuring that execution is safe, predictable, and fully reviewed before changes are merged.
+
+## Workflow
+
+The governed workflow for triggering Codex is as follows:
+
+1. **Explicit Maintainer Trigger:** A repository maintainer or collaborator applies the `codex-ready` label to an issue. Public comments or external triggers are ignored to prevent uncontrolled execution.
+2. **Governance Gate Check:** A GitHub Actions workflow (or equivalent CI automation) intercepts the label event and strictly checks the `governance/state/afk-halt.json` marker. If the halt marker is present, the workflow aborts immediately.
+3. **Policy and Allowlist Check:** The workflow reads the associated agent delegation policy (e.g., `codex-dispatch-policy.json`) and verifies that the requested task conforms to the allowed risk level, scope, and allowed surfaces.
+4. **Dispatch:** If all gates pass, the workflow either posts a bounded Codex trigger (via a secure webhook/API) or generates a `codex-task` artifact detailing the scope of work.
+5. **Execution:** Codex receives the task, executes the work within the bounded constraints (e.g., cost, time, surface limitations), and outputs a Draft Pull Request (or a detailed plan in the issue if `delegation_level` is lower). Direct merges to `main` are strictly prohibited.
+6. **Review and Merge Gate:** The Draft PR must pass all CI tests (e.g., `dotnet build` and `dotnet test`). Furthermore, the PR is gated by mandatory human review and Demerzel's automated governance checks before it can be merged.
+
+## Skills Provisioning
+
+To successfully complete tasks, Codex may require specific skills (e.g., those defined in #114 and #115). These skills are supplied to Codex as follows:
+- **Skill Injection:** Skills located in `.claude/skills/` (or a similar secure repository location) are dynamically injected into the system prompt or provided as bounded tool endpoints when the `codex-task` artifact is generated.
+- **Allowed Tools Check:** Codex is explicitly restricted to use only the tools defined in the `allowed_tools` list of the delegation policy. Banned tools (such as deployment scripts) remain inaccessible.
+
+## Fallback Behavior
+
+When Codex quota is unavailable or the service is unreachable, the system must degrade gracefully:
+- **Notification:** The workflow logs the failure and automatically posts a comment on the corresponding issue indicating that the Codex quota is exceeded or the service is temporarily unavailable.
+- **Re-queuing/Fallback:** The issue is labeled with `codex-quota-exceeded` (or similar) and transitioned back to a manual backlog state. Maintainers can re-trigger the workflow later once quota is restored, or a fallback agent (like Jules) may be suggested if appropriate.
+
+## Relationship to Jules AFK Path
+
+The Codex dispatch mechanism is designed to sit alongside the existing Jules AFK path (`ready-for-agent`). Both paths share the same underlying governance principles:
+- **Halt Gated:** Both respect `governance/state/afk-halt.json`.
+- **Review Gated:** Both require Draft PRs and mandatory human/Demerzel review.
+- **Trigger Distinctions:** Jules is triggered via `ready-for-agent` and auto-delegation workflows, while Codex is triggered specifically via the `codex-ready` label for targeted cloud-agent work. This clear separation allows maintainers to route work to the appropriate agent based on capability and cost considerations.

--- a/docs/security/cloud-agent-dispatch-threat-model.md
+++ b/docs/security/cloud-agent-dispatch-threat-model.md
@@ -1,0 +1,48 @@
+# Cloud-Agent Dispatch Threat Model
+
+## Overview
+This document outlines the threat model for dispatching cloud-agents (specifically Codex) within the TARS ecosystem. It details potential attack vectors, inherent risks, and the corresponding mitigations enforced by our governance and dispatch architecture.
+
+## Identified Threats & Attack Vectors
+
+### 1. Unauthorized Agent Triggering (The "Public Commenter" Threat)
+**Threat:** A malicious user or bot attempts to trigger Codex execution by posting comments on public issues, intending to consume quota, disrupt workflows, or attempt prompt injection.
+**Mitigation:**
+- Agent dispatch is completely decoupled from issue comments.
+- Codex execution is **only** triggered by the explicit application of the `codex-ready` label.
+- Only repository maintainers and authorized collaborators have the permissions to apply labels.
+
+### 2. Malicious Prompt Injection in Issue Body
+**Threat:** An attacker crafts an issue description with malicious instructions designed to trick the agent into deleting code, exfiltrating data, or executing banned tools.
+**Mitigation:**
+- **Bounded Execution:** Codex operates under strict tool allowlists and forbidden tool deny-lists (e.g., shell access is forbidden).
+- **Mandatory Draft PRs:** Codex cannot merge code directly. It is restricted to opening Draft PRs.
+- **Review Gating:** All agent-generated code must pass CI (`dotnet build`, `dotnet test`) and undergo mandatory human and Demerzel review before integration.
+
+### 3. Runaway Agent Execution
+**Threat:** The agent enters a recursive loop or performs excessively expensive operations, draining the financial budget or locking up CI resources.
+**Mitigation:**
+- Strict `max_runtime_minutes` and `max_cost_usd` boundaries are defined in the delegation policy.
+- Execution halts immediately if these thresholds are breached.
+
+### 4. Privilege Escalation or Modification of Governance Rules
+**Threat:** The agent attempts to modify governance policies (e.g., Demerzel rules) or circumvent its own constraints.
+**Mitigation:**
+- The delegation policy explicitly restricts the `files_or_surfaces_allowed` that the agent can modify.
+- High-risk areas (like `governance/` or `docs/contracts/`) require Demerzel meta-governance gate approval.
+
+### 5. Failure to Halt (The "Kill Switch" Bypass)
+**Threat:** System operators attempt to stop agent activity, but in-flight processes continue executing.
+**Mitigation:**
+- Absolute reliance on the `governance/state/afk-halt.json` marker.
+- The dispatch workflow checks this marker *before* triggering the agent, and the agent execution environment continuously polls or respects this marker to abort mid-flight if the halt state is activated.
+
+## Summary of Controls
+
+| Threat Vector | Primary Control | Secondary Control |
+|---------------|-----------------|-------------------|
+| Unauthorized Trigger | Maintainer-only Label (`codex-ready`) | - |
+| Prompt Injection | Draft PR output | Mandatory Human Review |
+| Runaway Execution | `max_runtime_minutes` / `max_cost_usd` limits | - |
+| Scope Violation | `files_or_surfaces_allowed` restrictions | Demerzel review gate |
+| Emergency Stop | `governance/state/afk-halt.json` | - |

--- a/examples/agents/codex-dispatch-policy.example.json
+++ b/examples/agents/codex-dispatch-policy.example.json
@@ -1,0 +1,34 @@
+{
+  "policy_name": "codex-cloud-agent-dispatch",
+  "delegation_level": "agent_candidate",
+  "risk_level": "medium",
+  "repo_target": "GuitarAlchemist/tars",
+  "files_or_surfaces_allowed": [
+    "v2/src/*",
+    "v2/tests/*",
+    "docs/design/*"
+  ],
+  "requires_tests": true,
+  "requires_human_approval": true,
+  "requires_demerzel_gate": false,
+  "max_runtime_minutes": 30,
+  "max_cost_usd": 1.0,
+  "allowed_tools": [
+    "read_file",
+    "list_files",
+    "write_file",
+    "run_in_bash_session",
+    "submit"
+  ],
+  "forbidden_tools": [
+    "deploy",
+    "delete_repository"
+  ],
+  "stop_conditions": [
+    "Cost exceeds max_cost_usd limit.",
+    "Execution time exceeds max_runtime_minutes limit.",
+    "Attempted modification outside allowed surfaces.",
+    "governance/state/afk-halt.json marker is present."
+  ],
+  "rollback_or_recovery": "Abort execution. Log failure to issue. Transition issue back to manual backlog if quota exceeded."
+}


### PR DESCRIPTION
This PR addresses issue #116 by designing a governed, review-gated dispatch mechanism for the Codex cloud-agent. It introduces a design document outlining the workflow, a threat model for Codex dispatch, and an example dispatch policy configuration.

Key additions:
- `docs/design/governed-codex-dispatch.md`: Defines the architectural seam, triggered explicitly via the `codex-ready` label, respecting the `afk-halt.json` marker, and requiring mandatory CI and Demerzel/human review. Includes fallback behavior for quota limits and skill provisioning mechanisms.
- `docs/security/cloud-agent-dispatch-threat-model.md`: Outlines threats (unauthorized triggers, prompt injection, runaway execution, etc.) and their mitigations.
- `examples/agents/codex-dispatch-policy.example.json`: A concrete example of a medium-risk Codex delegation policy matching the governance rules defined in `research-driven-agent-delegation-policy.md`.

---
*PR created automatically by Jules for task [10556833386076903853](https://jules.google.com/task/10556833386076903853) started by @spareilleux*