### PR TITLE
feat(afk): Inject declared cloud-agent skills into Jules prompt

### DIFF
--- a/.github/workflows/jules-auto-delegate.yml
+++ b/.github/workflows/jules-auto-delegate.yml
@@ -91,11 +91,50 @@ jobs:
         run: |
           TITLE=$(gh issue view "$ISSUE" --repo "$REPO" --json title --jq '.title')
           BODY=$(gh issue view "$ISSUE" --repo "$REPO" --json body --jq '.body')
+          LABELS=$(gh issue view "$ISSUE" --repo "$REPO" --json labels)
+
+          # Extract skills from YAML block in body
+          BODY_YAML=$(echo "$BODY" | awk '/^```yaml/{flag=1; next} /^```/{flag=0} flag')
+          BODY_SKILLS=$(echo "$BODY_YAML" | awk '/^agent_skills:/{flag=1; next} /^[^ ]/{flag=0} flag && /^[ \t]+-[ \t]+/{sub(/^[ \t]+-[ \t]+/, ""); sub(/\r$/, ""); print}' || true)
+
+          # Extract skills from labels
+          LABEL_SKILLS=$(echo "$LABELS" | jq -r '.labels[].name' | grep '^skill:' | sed 's/^skill://' || true)
+
+          # Combine, deduplicate, and validate skills
+          ALL_SKILLS=$(echo -e "$BODY_SKILLS\n$LABEL_SKILLS" | sort -u | grep -v '^$' || true)
+
+          SKILL_DOCS=""
+          if [ -n "$ALL_SKILLS" ]; then
+            for SKILL in $ALL_SKILLS; do
+              # Strict allowlist: only alphanumeric, hyphen, underscore
+              if [[ "$SKILL" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+                SKILL_FILE="docs/agents/skills/${SKILL}.md"
+                if [ -f "$SKILL_FILE" ]; then
+                  SKILL_DOCS="${SKILL_DOCS}
+
+### Injected Agent Skills
+
+--- SKILL: ${SKILL} ---
+"
+                  SKILL_CONTENT=$(cat "$SKILL_FILE")
+                  SKILL_DOCS="${SKILL_DOCS}${SKILL_CONTENT}"
+                else
+                  echo "::warning::Requested agent skill not found: $SKILL_FILE"
+                fi
+              else
+                echo "::warning::Invalid skill format rejected: $SKILL"
+              fi
+            done
+          fi
+
           {
             echo "text<<JULES_EOF"
             echo "Implement GitHub issue #${ISSUE}: ${TITLE}"
             echo ""
             echo "$BODY"
+            if [ -n "$SKILL_DOCS" ]; then
+              printf "%s\n" "$SKILL_DOCS"
+            fi
             echo ""
             echo "Project conventions (this repo is TARS, an F# system; the working directory is v2/, not the repo root):"
             echo "- Follow CLAUDE.md and CONTEXT.md; read any relevant docs/adr/ before coding."

--- a/docs/agents/skills/README.md
+++ b/docs/agents/skills/README.md
@@ -1,0 +1,30 @@
+# Agent Skills
+
+This directory contains optional, modular instructions (skills) that can be dynamically injected into the AI agent's prompt during issue delegation.
+
+## Usage
+
+When creating an issue, you can declare which skills the agent should use. This helps keep the agent's context focused and relevant to the specific task.
+
+### Declaration Formats
+
+1. **YAML block in the issue body:**
+   ```yaml
+   agent_skills:
+     - docs-only-contract
+     - evidence-bundle
+   ```
+
+2. **Issue Labels:**
+   ```text
+   skill:docs-only-contract
+   skill:evidence-bundle
+   ```
+
+When the `jules-auto-delegate` workflow runs, it will scan both the YAML block and the labels, aggregate the requested skills, and append the content of the corresponding Markdown files from this directory to the agent's prompt.
+
+## Security & Constraints
+
+- The workflow uses a strict allowlist constraint: only alphanumeric/hyphen/underscore file names are processed.
+- Path traversal (e.g., `skill:../secrets`) is rejected by regex and limited strictly to this `docs/agents/skills/` directory.
+- Missing skills emit a warning but do not halt delegation.

--- a/examples/agents/skill-selection.example.json
+++ b/examples/agents/skill-selection.example.json
@@ -1,0 +1,14 @@
+{
+  "issue": {
+    "title": "Update research digest contracts",
+    "body": "We need to update the research digest contract to include `novelty_score`.\n\n```yaml\nissue_meta:\n  level: task\nagent_skills:\n  - docs-only-contract\n  - evidence-bundle\n```",
+    "labels": [
+      {"name": "ready-for-agent"},
+      {"name": "skill:docs-only-contract"}
+    ]
+  },
+  "expected_injected_skills": [
+    "docs-only-contract",
+    "evidence-bundle"
+  ]
+}


### PR DESCRIPTION
Fixes #115. Updates the Jules AFK delegation workflow to inject matching skill documentation directly into the prompt. Added parsing for body YAML (using `awk`) and labels (using `jq`), ensuring security with a strict allowlist regex. Also addresses CRLF normalization and correct multiline injection.

---
*PR created automatically by Jules for task [12666155328391937160](https://jules.google.com/task/12666155328391937160) started by @spareilleux*