### PR TITLE
Add repo-readable cloud-agent skills for AFK delegation

### DIFF
--- a/docs/agents/skills/README.md
+++ b/docs/agents/skills/README.md
@@ -1,0 +1,23 @@
+# Cloud-Agent Skill Library
+
+This directory contains repo-readable skills that cloud agents (e.g., Jules, Codex) can follow when working Away From Keyboard (AFK) from GitHub issues.
+
+Since cloud agents cannot access local TARS skills or local MCP state, this explicit library serves as their primary operational guide.
+
+## Available Skills
+
+- `docs-only-contract`: Use when writing or modifying documentation, architecture design records (ADRs), or JSON schemas without changing runtime code.
+- `evidence-bundle`: Use when gathering context or compiling evidence for a specific task or research finding.
+- `governed-delegation`: Use when preparing tasks for execution by agents under strict governance constraints.
+
+## Skill Structure
+
+Each skill in this library defines:
+- **When to use it:** The scenario where the skill applies.
+- **Allowed files/surfaces:** The specific directories or file types the skill permits modifying.
+- **Required checks:** Validations the agent must perform during execution.
+- **Stop conditions:** Triggers that should immediately halt execution.
+- **Evidence expected in PR body:** Requirements for documenting the PR.
+- **Common failure modes:** Pitfalls to avoid.
+
+For an example of skill selection, see `examples/agents/skill-selection.example.json`.

--- a/docs/agents/skills/docs-only-contract.skill.md
+++ b/docs/agents/skills/docs-only-contract.skill.md
@@ -1,0 +1,31 @@
+# Skill: Docs-Only Contract
+
+## When to use it
+Use this skill when the assigned issue explicitly requires updating, creating, or refactoring documentation, Markdown files, architectural decision records (ADRs), JSON schemas, or other non-executable artifacts. It is intended for changes that must not affect runtime behavior.
+
+## Allowed files/surfaces
+- `docs/**/*.md`
+- `examples/**/*.json`
+- `*.md` at the repository root
+- `docs/contracts/**/*.md`
+- Do **not** modify `v2/**/*.fs`, `v2/**/*.cs`, or any other source code files.
+
+## Required checks
+- Ensure changes are structurally valid (e.g., proper JSON syntax, correct Markdown formatting).
+- Verify that links and references to other documentation or code are accurate.
+- If modifying contracts or schemas, confirm they match any examples provided in the issue.
+
+## Stop conditions
+- Halt immediately if you find yourself modifying executable code, build scripts, or CI/CD pipelines.
+- Halt if you are requested to perform actions outside the allowed file surfaces.
+- Halt if the `governance/state/afk-halt.json` marker is present.
+
+## Evidence expected in the PR body
+- Summary of the documentation changes made.
+- Confirmation that no runtime code was modified.
+- Links to relevant issues and references.
+
+## Common failure modes
+- Accidentally including unrelated source code changes in the PR.
+- Introducing malformed JSON or broken Markdown links.
+- Straying beyond the scope of the assigned issue.

--- a/docs/agents/skills/evidence-bundle.skill.md
+++ b/docs/agents/skills/evidence-bundle.skill.md
@@ -1,0 +1,29 @@
+# Skill: Evidence Bundle
+
+## When to use it
+Use this skill when you need to gather, compile, or synthesize evidence to support a claim, finding, or task execution. This is essential for maintaining a source-grounded second brain.
+
+## Allowed files/surfaces
+- `docs/knowledge/**/*.md`
+- `examples/**/*.json` (specifically those defining evidence bundles or claims)
+- `docs/research/**/*.md`
+
+## Required checks
+- Ensure all claims made are backed by explicit source references.
+- Include necessary metadata, such as provenance, confidence levels, and staleness markers.
+- Verify that the compiled evidence strictly follows the defined contract (e.g., `docs/contracts/evidence-bundle.contract.md`).
+
+## Stop conditions
+- Halt if you cannot find authoritative sources for a claim.
+- Halt if you are instructed to hallucinate or fabricate evidence.
+- Halt if the `governance/state/afk-halt.json` marker is present.
+
+## Evidence expected in the PR body
+- A summary of the claims synthesized and the sources used.
+- A checklist indicating that provenance and confidence metadata have been properly populated.
+- References to any related knowledge base artifacts.
+
+## Common failure modes
+- Making assertions without verifiable citations or provenance.
+- Failing to properly format the evidence bundle according to the JSON contract.
+- Ignoring staleness constraints, leading to outdated claims.

--- a/docs/agents/skills/governed-delegation.skill.md
+++ b/docs/agents/skills/governed-delegation.skill.md
@@ -1,0 +1,30 @@
+# Skill: Governed Delegation
+
+## When to use it
+Use this skill when preparing or executing tasks that involve delegating work to agents under strict governance, policy constraints, and bounds defined in the TARS ecosystem.
+
+## Allowed files/surfaces
+- `docs/governance/**/*.md`
+- `docs/plans/**/*.md`
+- `.github/workflows/**/*.yml` (only if explicitly allowed by issue instructions)
+- GitHub issues/PR descriptions and bodies.
+
+## Required checks
+- Ensure all delegations adhere to the `research-driven-agent-delegation-policy.md`.
+- Verify that limits such as `max_cost_usd` and `max_runtime_minutes` are explicitly defined.
+- Confirm that required approval gates (e.g., `requires_human_approval`, `requires_demerzel_gate`) are properly set and acknowledged.
+
+## Stop conditions
+- Halt if the task risk level is mismatched with the permitted delegation level.
+- Halt if explicit constraints (like budgets or allowed files) are missing.
+- Halt if the `governance/state/afk-halt.json` marker is present.
+
+## Evidence expected in the PR body
+- Confirmation that the delegation request conforms to governance policies.
+- A summary of the enforced bounds (cost, time, risk level).
+- Links to relevant governance documentation.
+
+## Common failure modes
+- Delegating a high-risk task without defining appropriate approval gates.
+- Missing explicit stop conditions or rollback procedures in the delegation plan.
+- Overriding or ignoring existing Demerzel governance rules.

--- a/examples/agents/skill-selection.example.json
+++ b/examples/agents/skill-selection.example.json
@@ -1,0 +1,18 @@
+{
+  "request_id": "req-987654",
+  "issue_number": 114,
+  "selected_skill": "docs-only-contract",
+  "justification": "The issue explicitly requests creating a documentation-only cloud-agent skill library without modifying runtime code. The docs-only-contract skill strictly enforces these boundaries and ensures no executable files are touched.",
+  "execution_plan": [
+    "Read the issue description to understand the required skills.",
+    "Draft the README.md to list available skills.",
+    "Create the individual skill markdown files following the required structure.",
+    "Create a skill-selection example JSON file.",
+    "Review changes against the docs-only-contract constraints before submitting."
+  ],
+  "governance_bounds": {
+    "risk_level": "low",
+    "requires_tests": false,
+    "max_runtime_minutes": 10
+  }
+}


### PR DESCRIPTION
This PR adds a documentation-only cloud-agent skill library designed for cloud agents like Jules or Codex. Because these agents run AFK and do not have access to local TARS skills or local MCP state, they need an explicit, repo-readable library of skills to constrain and direct their operations safely.

Changes introduced:
- Created `docs/agents/skills/README.md` to document the skill library.
- Added `docs-only-contract` skill to restrict documentation changes.
- Added `evidence-bundle` skill to govern compiling source-grounded evidence.
- Added `governed-delegation` skill to enforce governance and constraint limits when delegating to AI agents.
- Provided an example skill selection payload at `examples/agents/skill-selection.example.json`.

Resolves issue #114.

---
*PR created automatically by Jules for task [3332843540915973631](https://jules.google.com/task/3332843540915973631) started by @spareilleux*