### PR TITLE
feat(afk): inject declared agent skills into Jules prompts

### DIFF
--- a/.github/workflows/jules-auto-delegate.yml
+++ b/.github/workflows/jules-auto-delegate.yml
@@ -90,7 +90,43 @@ jobs:
           ISSUE: ${{ github.event.issue.number }}
         run: |
           TITLE=$(gh issue view "$ISSUE" --repo "$REPO" --json title --jq '.title')
-          BODY=$(gh issue view "$ISSUE" --repo "$REPO" --json body --jq '.body')
+          BODY=$(gh issue view "$ISSUE" --repo "$REPO" --json body --jq '.body' | tr -d '\r')
+          LABELS=$(gh issue view "$ISSUE" --repo "$REPO" --json labels --jq '.labels')
+
+          # Extract skills from issue body YAML (allowing agent_skills to be indented)
+          BODY_SKILLS=$(echo "$BODY" | awk '
+            BEGIN { in_yaml=0; in_skills=0 }
+            /^```yaml/ { in_yaml=1; next }
+            /^```/ { in_yaml=0; in_skills=0; next }
+            in_yaml && /^[ 	]*agent_skills:/ { in_skills=1; next }
+            in_yaml && /^[ 	]*[a-zA-Z_-]+:/ && !/^[ 	]*agent_skills:/ { in_skills=0; next }
+            in_skills && /^[ 	]+-[ 	]+/ {
+              sub(/^[ 	]+-[ 	]+/, "")
+              print $0
+            }
+          ')
+
+          # Extract skills from labels
+          LABEL_SKILLS=$(echo "$LABELS" | jq -r '.[].name | select(startswith("skill:")) | sub("^skill:"; "")')
+
+          # Combine and unique
+          ALL_SKILLS=$(echo -e "${BODY_SKILLS}\n${LABEL_SKILLS}" | grep -v '^$' | sort -u || true)
+
+          ALLOWED_SKILLS_DOCS=""
+          for skill in $ALL_SKILLS; do
+            clean_skill=$(echo "$skill" | tr -cd 'a-zA-Z0-9-')
+            if [ -n "$clean_skill" ] && [ "$clean_skill" = "$skill" ]; then
+              skill_file="docs/agents/skills/${clean_skill}.md"
+              if [ -f "$skill_file" ]; then
+                ALLOWED_SKILLS_DOCS="${ALLOWED_SKILLS_DOCS}
+
+--- Skill: ${skill} ---
+$(cat "$skill_file")
+"
+              fi
+            fi
+          done
+
           {
             echo "text<<JULES_EOF"
             echo "Implement GitHub issue #${ISSUE}: ${TITLE}"
@@ -103,6 +139,11 @@ jobs:
             echo "- LLM access always goes through LlmFactory.create(logger) — never instantiate DefaultLlmService directly."
             echo "- Warnings are errors (TreatWarningsAsErrors); code must compile clean."
             echo "- Tests live in tests/Tars.Tests/ (xUnit). Build and test from v2/: dotnet build && dotnet test."
+            if [ -n "$ALLOWED_SKILLS_DOCS" ]; then
+              echo ""
+              echo "--- Additional Agent Skills injected ---"
+              echo "$ALLOWED_SKILLS_DOCS"
+            fi
             echo ""
             echo "Open a pull request targeting main with the change. Keep it minimal and scoped to the issue. Ensure the build and tests pass before opening the PR."
             echo "JULES_EOF"

--- a/docs/agents/skills/README.md
+++ b/docs/agents/skills/README.md
@@ -1,0 +1,21 @@
+# Agent Skills
+
+This directory contains optional agent skills that can be declared in an issue body or labels to be injected into the agent prompt.
+
+## How to use
+
+In an issue body:
+
+```yaml
+agent_skills:
+  - docs-only-contract
+  - evidence-bundle
+```
+
+Or via labels:
+
+```text
+skill:docs-only-contract
+```
+
+When a matching issue is picked up by an agent, the skills will be added to the prompt automatically.

--- a/examples/agents/skill-selection.example.json
+++ b/examples/agents/skill-selection.example.json
@@ -1,0 +1,14 @@
+{
+  "issue_meta": {
+    "level": "task",
+    "agent_skills": [
+      "docs-only-contract",
+      "evidence-bundle"
+    ]
+  },
+  "labels": [
+    "skill:docs-only-contract",
+    "skill:evidence-bundle",
+    "ready-for-agent"
+  ]
+}


### PR DESCRIPTION
Implemented GitHub issue #115 to parse and inject specific agent skills into the prompt for Jules based on issue labels and body YAML content. Added the required `docs/agents/skills/README.md` and `examples/agents/skill-selection.example.json` files.

---
*PR created automatically by Jules for task [16589699950471634802](https://jules.google.com/task/16589699950471634802) started by @spareilleux*