### PR TITLE
docs(agents): add Jules PR watchdog notes

### DIFF
--- a/docs/agents/jules-pr-watchdog-workflow-draft.md
+++ b/docs/agents/jules-pr-watchdog-workflow-draft.md
@@ -1,0 +1,90 @@
+# Jules PR Watchdog Workflow Draft
+
+This draft describes the workflow that should later be copied into `.github/workflows/jules-pr-watchdog.yml` after review.
+
+## Events
+
+- PR metadata changed
+- PR review submitted
+- PR conversation comment changed
+- CI workflow completed
+- scheduled fallback every 30 minutes
+- manual dispatch
+
+## Permissions
+
+- read repository contents
+- read pull requests
+- read Actions status
+- write labels and comments on issues/PRs
+
+## Candidate selection
+
+1. If the event is tied to a PR, inspect that PR.
+2. On schedule, list open PRs whose body contains the Jules footer.
+3. Skip PRs that do not contain the Jules footer.
+
+## State labels
+
+The workflow owns these labels:
+
+- `jules-waiting`
+- `jules-updated`
+- `needs-human-review`
+- `needs-agent-revision`
+- `ready-to-merge`
+- `stale-jules-pr`
+- `duplicate-agent-pr`
+
+Before applying a new state, remove the other state labels.
+
+## Classification rules
+
+| Rule | New state |
+| --- | --- |
+| Known requested fix still missing | `needs-agent-revision` |
+| CI/checks failed or cancelled | `needs-agent-revision` |
+| PR has changed since last observed state | `jules-updated` |
+| Checks complete and PR looks mergeable | `ready-to-merge` |
+| Checks complete but review still needed | `needs-human-review` |
+| No PR movement for stale window | `stale-jules-pr` |
+| PR superseded by another PR for same issue | `duplicate-agent-pr` |
+
+## Known targeted check for #115/#129
+
+Detect workflow code that looks for:
+
+```text
+docs/agents/skills/name.md
+```
+
+when it should prefer:
+
+```text
+docs/agents/skills/name.skill.md
+```
+
+If this mismatch is present, use `needs-agent-revision`.
+
+## Comment policy
+
+Comment only when the state label changes.
+
+Comment shape:
+
+```text
+Jules PR watchdog: state changed from <old> to <new>. Reason: <reason>.
+```
+
+No comment is emitted for unchanged state.
+
+## Safe boundaries
+
+The watchdog must not:
+
+- merge PRs;
+- approve PRs;
+- change PR branch contents;
+- start new Jules tasks;
+- run high-frequency polling;
+- replace maintainer/Demerzel review.

--- a/docs/agents/jules-pr-watchdog.md
+++ b/docs/agents/jules-pr-watchdog.md
@@ -1,0 +1,97 @@
+# Jules PR Watchdog
+
+## Purpose
+
+The Jules PR watchdog makes AFK cloud-agent work easier to observe after delegation. The existing `jules-auto-delegate.yml` workflow starts work when an issue receives `ready-for-agent`; this watchdog tracks the PR that Jules opens and classifies useful state transitions.
+
+The watchdog is conservative:
+
+- no automatic merge;
+- no automatic approval;
+- no PR-branch checkout;
+- comments only when state changes;
+- labels are used as the primary state surface.
+
+## Trigger model
+
+The first implementation is event-first with a low-frequency scheduled fallback.
+
+Candidate triggers:
+
+- `pull_request_target` for PR metadata changes;
+- `pull_request_review` for submitted reviews;
+- `issue_comment` for PR conversation changes;
+- `workflow_run` for completed CI workflows;
+- `schedule` every 30 minutes;
+- `workflow_dispatch` for manual refresh.
+
+The workflow performs metadata inspection only.
+
+## Jules PR detection
+
+A PR is treated as a Jules PR when its body contains the standard Jules footer:
+
+```text
+PR created automatically by Jules
+```
+
+This keeps the watchdog scoped to AFK cloud-agent PRs.
+
+## State labels
+
+The watchdog owns these mutually exclusive labels:
+
+| Label | Meaning |
+| --- | --- |
+| `jules-waiting` | The PR exists but still needs agent, CI, or review movement. |
+| `jules-updated` | The PR changed and needs a fresh look. |
+| `needs-human-review` | The PR is ready for maintainer review. |
+| `needs-agent-revision` | A detectable issue remains and the agent should revise it. |
+| `ready-to-merge` | Checks look green and no watchdog blocker is detected; a human still decides. |
+| `stale-jules-pr` | The PR has not moved for the configured stale window. |
+| `duplicate-agent-pr` | The PR appears superseded by another agent PR. |
+
+The watchdog removes older state labels before applying a new state label.
+
+## Transition policy
+
+The watchdog comments only when the state label changes. This avoids noisy polling while keeping an audit trail.
+
+Examples:
+
+- `jules-waiting -> needs-agent-revision` when checks fail or a targeted issue is detected;
+- `jules-waiting -> jules-updated` when a new commit arrives;
+- `jules-updated -> ready-to-merge` when checks are green and no watchdog blocker remains;
+- `jules-waiting -> stale-jules-pr` when no meaningful movement is detected within the stale window.
+
+## Targeted check: skill file suffix
+
+For the #115/#129 line of work, the watchdog can detect one specific known issue: workflow code that looks for `docs/agents/skills/<skill>.md` while the merged skill files use `docs/agents/skills/<skill>.skill.md`.
+
+This check only sets `needs-agent-revision`; it does not modify the PR.
+
+## Boundaries
+
+The watchdog is an observability helper, not a maintainer.
+
+It does not:
+
+- merge PRs;
+- approve PRs;
+- change reviews;
+- change agent branches;
+- start new agent tasks;
+- run as a high-frequency poller.
+
+## Relationship to the AFK loop
+
+The watchdog complements the dispatch queue and PR hygiene policies:
+
+```text
+ready-for-agent
+  -> Jules delegation
+  -> PR opened
+  -> watchdog classification
+  -> maintainer review
+  -> merge or revise
+```

--- a/examples/agents/jules-watchdog-state.example.json
+++ b/examples/agents/jules-watchdog-state.example.json
@@ -1,0 +1,35 @@
+{
+  "watchdog_version": "1.0.0",
+  "repository": "GuitarAlchemist/tars",
+  "pull_request": 129,
+  "source": "jules-pr-watchdog",
+  "previous_state": "jules-waiting",
+  "current_state": "needs-agent-revision",
+  "state_changed": true,
+  "observed_at": "2026-06-28T13:45:00Z",
+  "signals": {
+    "is_jules_pr": true,
+    "head_sha_changed": false,
+    "checks_state": "missing",
+    "mergeable": false,
+    "known_targeted_check_failed": true,
+    "stale_window_exceeded": false
+  },
+  "detected_issue": {
+    "kind": "skill_suffix_mismatch",
+    "expected_path_shape": "docs/agents/skills/name.skill.md",
+    "observed_path_shape": "docs/agents/skills/name.md",
+    "next_state": "needs-agent-revision"
+  },
+  "labels_removed": [
+    "jules-waiting"
+  ],
+  "labels_added": [
+    "needs-agent-revision"
+  ],
+  "comment_policy": "comment-only-on-state-change",
+  "review_gate": {
+    "merge_by_watchdog": false,
+    "human_review_required": true
+  }
+}


### PR DESCRIPTION
Adds the reviewed notes and examples for #132.

Files:
- docs/agents/jules-pr-watchdog.md
- docs/agents/jules-pr-watchdog-workflow-draft.md
- examples/agents/jules-watchdog-state.example.json

Fixes #132.