### PR TITLE
Map V1 AgenticTraceCapture fields to AIW episode artifacts

### DIFF
--- a/v2/docs/legacy/v1-trace-to-aiw-episode.md
+++ b/v2/docs/legacy/v1-trace-to-aiw-episode.md
@@ -1,0 +1,14 @@
+# V1 AgenticTraceCapture to AIW Episode Mapping
+
+This document provides a concrete mapping from legacy V1 `AgenticTraceCapture` concepts to the modern AIW/TARS episode artifacts.
+
+## Mapping Targets
+
+| V1 `AgenticTraceCapture` Concept | Modern AIW/TARS Artifact | Description |
+| :--- | :--- | :--- |
+| **Session / Metadata** | `aiw-episode.json` | The core episode metadata, including IDs, timestamps, and overall status. |
+| **Costs and Tokens** | `budget-ledger.json` | Detailed tracking of token usage, compute time, and financial cost (e.g., `cost_usd`). |
+| **LLM Interactions** | Provider trace | Raw inputs, outputs, and latencies from the underlying model provider. |
+| **Verification** | Test log summary | Aggregated results from test suites and CI runs during the episode. |
+| **Modifications** | Diff summary | The unified diff or patch representing the code changes made. |
+| **Termination** | Stop/escalation reason | The exact reason the episode ended (e.g., success, error, max steps, budget exceeded). |

--- a/v2/examples/tars-v1-agent-trace.example.json
+++ b/v2/examples/tars-v1-agent-trace.example.json
@@ -1,0 +1,26 @@
+{
+  "artifact_type": "AgenticTraceCapture",
+  "version": "1.0",
+  "episode_id": "ep-98765-v1",
+  "mapped_to": "aiw-episode.json",
+  "budget": {
+    "cost_usd": 0.0,
+    "tier": "free-local",
+    "mapped_to": "budget-ledger.json"
+  },
+  "provider_trace": {
+    "provider": "ollama-local",
+    "prompt_tokens": 150,
+    "completion_tokens": 45,
+    "latency_ms": 850
+  },
+  "test_log_summary": {
+    "status": "passed",
+    "total_tests": 820,
+    "passed": 820,
+    "failed": 0
+  },
+  "diff_summary": "1 file changed, 25 insertions(+), 0 deletions(-)",
+  "stop_reason": "goal_achieved",
+  "escalation_reason": null
+}


### PR DESCRIPTION
Maps legacy V1 `AgenticTraceCapture` concepts to modern AIW/TARS episode artifacts as requested in #80.

Creates:
- `v2/docs/legacy/v1-trace-to-aiw-episode.md`
- `v2/examples/tars-v1-agent-trace.example.json`

---
*PR created automatically by Jules for task [14348475315115475320](https://jules.google.com/task/14348475315115475320) started by @spareilleux*