### PR TITLE
ci: fix Demerzel auto-update push race + add self-hosted CI lane

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,9 +10,39 @@ on:
     branches: [ "main" ]
 
 jobs:
+  # Required gate (branch protection requires this `build` check). GitHub-hosted
+  # so it always runs even if the self-hosted runner is offline — the fallback.
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+      working-directory: v2
+    - name: Build
+      run: dotnet build --no-restore
+      working-directory: v2
+    - name: Test
+      run: dotnet test --no-build --verbosity normal
+      working-directory: v2
+
+  # Self-hosted lane (AW-STEF, labels: self-hosted, Windows, X64). Informational —
+  # NOT a required check, so an offline/cold runner can't block merges; `build`
+  # above stays the gate. setup-dotnet makes this self-sufficient (installs the
+  # SDK if absent). Promote to required only once it's proven stable.
+  build-selfhosted:
+
+    runs-on: [self-hosted, Windows, X64]
+    timeout-minutes: 30
+    # Don't fail other jobs / the run's required status on self-hosted hiccups.
+    continue-on-error: true
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/submodule-auto-update.yml
+++ b/.github/workflows/submodule-auto-update.yml
@@ -66,6 +66,9 @@ jobs:
         run: |
           BEHIND=${{ steps.check.outputs.behind }}
           git commit -m "chore: update Demerzel submodule ($BEHIND commits)"
+          # Reconcile with any concurrent main advance before pushing (avoids the
+          # same non-fast-forward race as the PR path).
+          git pull --rebase origin main
           git push origin main
           echo "### Auto-updated Demerzel submodule ($BEHIND commits)" >> $GITHUB_STEP_SUMMARY
 
@@ -78,7 +81,19 @@ jobs:
           BEHIND=${{ steps.check.outputs.behind }}
           CURRENT=${{ steps.check.outputs.current }}
           LATEST=${{ steps.check.outputs.latest }}
-          BRANCH="chore/update-demerzel-$(date +%Y%m%d)"
+
+          # Idempotent: skip if an update PR is already open. This is what was
+          # failing — the schedule fires 4x/day and the old daily branch name
+          # (chore/update-demerzel-YYYYMMDD) was reused, so later runs pushed to
+          # an existing diverged branch -> non-fast-forward rejection + dup PRs.
+          EXISTING=$(gh pr list --state open --search "chore: update Demerzel submodule in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "### Demerzel update PR #$EXISTING already open — skipping" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          # Unique branch (target sha + run id) never collides with a prior run.
+          BRANCH="chore/update-demerzel-${LATEST}-${{ github.run_id }}"
 
           git checkout -b "$BRANCH"
           git commit -m "chore: update Demerzel submodule ($BEHIND commits)"


### PR DESCRIPTION
## #2 — "ensure local runners work"

Grounding found: **AW-STEF** (self-hosted, Windows, X64) is **online but unused** by any workflow, and the **Demerzel auto-update workflow was failing** — not a runner issue, a git push race.

### 1. Fix the failing Demerzel auto-update
`submodule-auto-update.yml` reused a **daily** branch name (`chore/update-demerzel-YYYYMMDD`) across the 6-hourly schedule → the 2nd+ run/day pushed to an existing diverged branch → `! [rejected] (non-fast-forward)`. Now:
- **Skip if an update PR is already open** (no dup PRs)
- **Unique branch** (`target-sha + run-id`) — never collides
- Rebase-before-push on the small-update path too

### 2. Add the self-hosted CI lane
`dotnet.yml` gains `build-selfhosted` on `[self-hosted, Windows, X64]`:
- **`continue-on-error` + non-required** → an offline/cold AW-STEF can't block merges
- GitHub-hosted **`build` stays the required gate/fallback**
- `setup-dotnet` makes it self-sufficient (installs SDK if absent)
- Promote to required once proven stable

## Note
The self-hosted lane will only go green if AW-STEF has the workspace + can run `dotnet`. Since it's `continue-on-error`, a first-run failure is informational, not blocking — we'll see from its first run whether the runner needs `.NET 10` setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)