### PR TITLE
docs(agents): port Matt Pocock anti-ball-of-mud skill for AFK agents (#135)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,25 @@ Risk policy: [`agent-blackbox.policy.json`](./agent-blackbox.policy.json) (risk 
 
 The PR workflow at [`.github/workflows/agent-blackbox.yml`](./.github/workflows/agent-blackbox.yml) runs `analyze`, emits a risk report + harness audit + response-quality report, comments them on the PR, uploads artifacts, and calls `enforce --report` to fail PRs whose verdict is `block` unless the `agent-blackbox-reviewed` label has been applied by a human reviewer.
 
+## Repo-readable skill library
+
+AFK / cloud agents working from a GitHub issue use the repo-readable skills under
+[`docs/agents/skills/`](./docs/agents/skills/) (see its `README.md`). Of note for
+architecture work:
+
+- **Anti-Ball-of-Mud** ([`docs/agents/skills/anti-ball-of-mud.skill.md`](./docs/agents/skills/anti-ball-of-mud.skill.md)).
+  Invoke **before** feature/refactor work, or **whenever** an in-flight AFK task
+  shows architecture friction — touching many unrelated files, growing an
+  already-large module, duplicating a contract or scoring rule (especially one
+  that belongs in `ix`), threading a provider/LLM/network/FS call into core
+  runtime, or expressing a Demerzel rule as a local `if`. It detects entropy,
+  names **one** seam, keeps the change inside the rewrite budget, and **stops +
+  escalates** to human/Demerzel review when the decision is architectural. Use
+  the user-invoked `/anti-ball-of-mud` when a human asks for the scan; the
+  model-invoked `anti-ball-of-mud-guard` fires automatically as a backpressure
+  guard. It never rewrites code AFK — its deliverable is a report + one
+  human-gated PR.
+
 ## Review independence
 
 The loop is allowed to *propose* but not *self-certify*. Independence is enforced by four mechanisms — each one rated separately by `install-audit`:

--- a/docs/agents/skills/README.md
+++ b/docs/agents/skills/README.md
@@ -9,6 +9,7 @@ Cloud agents cannot access local TARS skills or local MCP state. However, they c
 - **Docs-Only Contract** (`docs-only-contract.skill.md`): Used for documentation-only updates, enforcing that no runtime behavior is changed.
 - **Evidence Bundle** (`evidence-bundle.skill.md`): Used for grounding claims and design decisions in explicitly referenced source material.
 - **Governed Delegation** (`governed-delegation.skill.md`): Used for navigating the Demerzel governance constraints and respecting AFK halt markers.
+- **Anti-Ball-of-Mud** (`anti-ball-of-mud.skill.md`): Detect architecture entropy before/within feature or refactor work, name **one** seam, keep the PR reviewable, and escalate architectural decisions to human/Demerzel review. TARS-native port of `mattpocock/skills`. Has a user-invoked mode (`/anti-ball-of-mud`) and a model-invoked guard (`anti-ball-of-mud-guard`). Supporting docs: `codebase-design-vocabulary.md`, `entropy-signal-catalog.md`, `matt-pocock-skills-mapping.md`. Example invocation + expected output under `examples/agents/anti-ball-of-mud*`.
 
 ## Usage
 

--- a/docs/agents/skills/anti-ball-of-mud.skill.md
+++ b/docs/agents/skills/anti-ball-of-mud.skill.md
@@ -1,0 +1,222 @@
+# Skill: Anti-Ball-of-Mud
+
+Adapted for TARS from `mattpocock/skills` (`improve-codebase-architecture`,
+`codebase-design`, `grilling`, `domain-modeling`, `to-issues`). This is the
+TARS-native, repo-readable, AFK-safe port — it teaches an agent to detect
+architecture entropy, name the seam, and create **backpressure** before AFK
+work makes the mud worse. It does **not** authorize broad autonomous refactors.
+
+> Mapping to the upstream skills is recorded in
+> [`matt-pocock-skills-mapping.md`](./matt-pocock-skills-mapping.md). The shared
+> design vocabulary is in
+> [`codebase-design-vocabulary.md`](./codebase-design-vocabulary.md).
+
+## Two ways to use this skill
+
+This skill has a **user-invoked** mode and a **model-invoked** mode. They share
+the same vocabulary and the same output shape, but differ in *who triggers them*
+and *how much latitude the agent has*.
+
+### User-invoked — `/anti-ball-of-mud`
+
+Use when a human explicitly asks the agent to scan a change, plan, or code area
+for architecture entropy **before** implementation.
+
+Expected behavior:
+
+- inspect the requested change or named code area;
+- produce a short entropy report (the eight-part output below);
+- offer **1–3 candidate seams**, ranked, with a recommendation;
+- if the choice between seams is architectural, **ask the human which to
+  explore** rather than picking silently;
+- never rewrite broadly without explicit approval.
+
+### Model-invoked — `anti-ball-of-mud-guard`
+
+Use **automatically** when an AFK task risks worsening architecture entropy. This
+is the guard rail, not the orchestration command. When a trigger fires mid-task,
+the agent stops feature work, records the friction, and produces the same
+eight-part output as a backpressure note.
+
+Triggers (any one is enough):
+
+- the change is about to touch **many unrelated files**;
+- you are adding logic to an **already-large orchestrator/module** instead of
+  behind a seam;
+- you are **duplicating** a contract, scoring rule, or analytics shape that
+  already exists (especially one that belongs in `ix`);
+- you are about to thread a **provider SDK call** (LLM / GitHub / network / FS)
+  into core runtime code instead of through an adapter;
+- you are about to add a **shortcut** because the proper seam is unclear;
+- a **Demerzel governance rule** is being re-expressed as a local `if` instead of
+  going through the existing gate.
+
+Expected behavior when a trigger fires:
+
+- **stop** and record the friction (do not push through);
+- propose **one narrow seam**;
+- keep the PR reviewable (respect the rewrite budget in `AGENTS.md`);
+- **escalate to human/Demerzel review** when the decision is architectural.
+
+## When to use
+
+Reach for this skill when an issue or in-flight AFK task shows architecture
+**friction** — not generic untidiness, but the specific entropy signals below.
+The aim is testability and AI-navigability: deep modules behind small interfaces,
+placed at clean **seams**, tested **through** their interface.
+
+This skill is *informed by* the repo's domain language:
+
+- read `CONTEXT.md` for the TARS ubiquitous language (it already names good seams:
+  **IxSkill**, **hermetic gate**, **fitness gate**, **tars_bridge**, …) — use
+  those names, don't invent new ones;
+- read the relevant ADRs in `docs/adr/` and **do not re-litigate** a decision an
+  ADR has already recorded; if a candidate contradicts an ADR, say so explicitly
+  and only surface it when the friction is real enough to reopen the ADR.
+
+## Allowed files/surfaces
+
+- **Read-only, anywhere:** any source under `v2/src/`, `CONTEXT.md`, `docs/adr/`,
+  `governance/`, examples — to gather evidence.
+- **Writable (this skill only writes here):** `*.md` under `docs/`, example
+  `*.json` / `*.md` under `examples/agents/`, and (only if explicitly requested)
+  a new ADR draft under `docs/adr/`.
+- **Forbidden:** editing F# (`*.fs`/`*.fsproj`), Rust (`*.rs`), CI workflows
+  (`.github/workflows/*.yml`), or any **one-way-door** / **blocked** path listed
+  in `AGENTS.md`. A *seam proposal* is a document, not a refactor — producing the
+  refactor is a separate, human-gated PR.
+
+## Architecture entropy signals
+
+Look for these concrete signals. They map directly to TARS surfaces — prefer a
+real example from this repo over an abstract one.
+
+- a large module mixing **unrelated responsibilities** (e.g. an orchestrator that
+  also does IO, provider calls, *and* ranking);
+- understanding one concept requires **bouncing across many shallow modules**;
+- the **interface is nearly as complex as the implementation** (a shallow module —
+  apply the deletion test);
+- **feature logic mixed with orchestration, IO, provider SDK calls, or UI**;
+- **stringly-typed routing** where a typed contract should exist (e.g. capability
+  dispatch by raw string instead of a discriminated union);
+- repeated **ad-hoc JSON shapes** with no schema/contract (compare to the
+  `examples/agents/*.example.json` and `docs/contracts/` conventions);
+- **shallow wrappers** that only rename complexity (fail the deletion test);
+- **hidden global mutable state**;
+- tightly-coupled modules **leaking across their seams**;
+- pure functions extracted **only for testability** while the real bug hides in
+  the orchestration that calls them (no **locality**);
+- **direct dependency on GitHub / LLM / filesystem / network from core runtime**
+  (TARS rule: LLM access always via `LlmFactory.create(logger)`, never a direct
+  `DefaultLlmService` — a bypass is an entropy signal);
+- **copy-pasted algorithms** or duplicate scoring/analytics logic that should
+  belong to **ix** (the ML/governance engine) rather than being reimplemented in
+  TARS;
+- **Demerzel governance rules scattered as local `if` statements** instead of
+  routed through the governance gate;
+- **tests that verify implementation details** instead of the intended
+  interface/seam.
+
+The full catalog, with TARS-specific examples and severity, is in
+[`entropy-signal-catalog.md`](./entropy-signal-catalog.md).
+
+## Required output (the eight-part report)
+
+When invoked, produce exactly these eight parts. Keep it short — a report, not an
+essay.
+
+1. **Entropy finding** — what looks muddy and why, citing the signal(s) above and
+   the concrete file(s).
+2. **Design vocabulary** — name the concepts in play using the
+   [vocabulary](./codebase-design-vocabulary.md): **module**, **interface**,
+   **depth**, **seam**, **adapter**, **locality**, **leverage**, **deletion
+   test**. Use the terms exactly; don't drift into "component / service / API /
+   boundary".
+3. **Proposed seam** — **one** boundary to introduce or strengthen. One seam, not
+   a rewrite plan.
+4. **Smallest safe change** — what fits in **one reviewable PR** under the rewrite
+   budget.
+5. **Files likely touched** — concrete paths if known.
+6. **Test surface** — how the seam can be tested **through its interface**
+   (replace, don't layer).
+7. **Risk / backpressure** — why the PR should **stop here** rather than continue.
+8. **Review gate** — the human/Demerzel approval needed before any broader
+   refactor.
+
+A worked example of this output, for a deliberately muddy change request, is in
+[`../../../examples/agents/anti-ball-of-mud.expected-output.md`](../../../examples/agents/anti-ball-of-mud.expected-output.md).
+
+## Required checks
+
+1. **Evidence-before-refactor.** Do not recommend a refactor without naming the
+   entropy signal and the file that exhibits it. A finding with no cited evidence
+   is a stop.
+2. **One-seam check.** The output proposes exactly one seam. If you find yourself
+   listing three seams to introduce *now*, you have a rewrite — split it.
+3. **Scope check.** Confirm no F#/Rust/workflow/one-way-door file is edited by
+   this skill. The deliverable is docs/examples, not code.
+4. **Vocabulary check.** Every architectural claim uses the
+   [codebase-design vocabulary](./codebase-design-vocabulary.md) exactly.
+
+## Stop conditions (AFK backpressure)
+
+Stop and escalate — do **not** push through — when any of these hold:
+
+- the seam needs **product or architecture judgment** (which of several valid
+  shapes is correct);
+- the smallest safe change still exceeds the **rewrite budget** in `AGENTS.md`
+  (max lines / lines-per-fix / diff budget) — split into multiple PRs;
+- the change would require editing a **one-way-door** path (`schemas/**`,
+  `contracts/**`, `migrations/**`, `**/*.sln`, `**/*.fsproj`,
+  `Directory.Build.props`) or a **blocked** path;
+- the fix implies **copying ix or Demerzel logic into TARS**, or adding a **new
+  provider/cloud dependency**;
+- `governance/state/afk-halt.json` exists and is active (see
+  [`governed-delegation.skill.md`](./governed-delegation.skill.md));
+- the task's `issue_meta.afk.max_autonomy` is exceeded by what the fix would need.
+
+When you stop, write the eight-part report as a **PR note or issue comment** and
+hand the architectural decision to a human or the Demerzel tribunal.
+
+## AFK constraints
+
+This skill is safe for AFK delegation. It must **not**:
+
+- do a broad repo rewrite, or auto-merge;
+- perform a large mechanical rename unless explicitly requested;
+- silently migrate architecture;
+- add a new provider/cloud dependency;
+- copy ix or Demerzel logic into TARS;
+- leave permanent repo artifacts from exploratory reports unless requested
+  (prefer a PR note / issue comment over committing an `architecture-review-*`
+  file).
+
+Prefer **docs / examples / contracts / tests** over speculative implementation.
+
+## Evidence expected in the PR body
+
+When this skill drives a PR (e.g. the docs deliverable, or a single approved
+seam), the PR body should contain:
+
+- the **eight-part report** (or a link to where it was recorded);
+- a statement that **no runtime F#/Rust/workflow code was modified** beyond the
+  one approved seam (if any);
+- the **review gate** invoked (human reviewer or Demerzel tribunal) for any
+  architectural decision;
+- confirmation that `governance/state/afk-halt.json` was checked and inactive.
+
+## Common failure modes
+
+- **Turning into a clean-code checklist.** Generic "rename this, extract that"
+  advice with no seam and no deletion test is out of scope — this skill is about
+  *one boundary*, named with the design vocabulary.
+- **Proposing a rewrite disguised as a seam.** Three new modules in one PR is a
+  rewrite. Stop at one seam and escalate.
+- **Skipping the evidence.** Recommending a refactor without citing the entropy
+  signal and the file — reviewers (and the Demerzel qa-tribunal) will reject it.
+- **Editing code to "just fix it".** The moment you open a `.fs` file to apply
+  the refactor under AFK autonomy, you have left the skill's lane.
+- **Re-litigating an ADR.** Suggesting a refactor that an existing ADR already
+  decided against, without flagging the conflict.
+- **Reinventing ix/Demerzel.** Re-implementing scoring/governance that already
+  lives in a sibling repo instead of routing to it through the existing seam.

--- a/docs/agents/skills/codebase-design-vocabulary.md
+++ b/docs/agents/skills/codebase-design-vocabulary.md
@@ -1,0 +1,107 @@
+# Codebase Design Vocabulary (TARS)
+
+Shared vocabulary for designing **deep modules** in TARS. Adapted from
+`mattpocock/skills` `codebase-design` for this repo's F# / WoT / promotion-pipeline
+surfaces. The [`anti-ball-of-mud.skill.md`](./anti-ball-of-mud.skill.md) skill uses
+these terms exactly — and so should you. Consistent language is the whole point;
+don't substitute "component", "service", "API", or "boundary".
+
+A deep module is **a lot of behaviour behind a small interface, placed at a clean
+seam, testable through that interface.** The aim is leverage for callers, locality
+for maintainers, and testability for everyone.
+
+## Glossary
+
+**Module** — anything with an interface and an implementation. Scale-agnostic: an
+F# function, a module, a project under `v2/src/`, or a tier-spanning slice. In
+TARS, `IxSkill` is a module; so is the whole promotion pipeline.
+_Avoid_: unit, component, service.
+
+**Interface** — everything a caller must know to use the module correctly: the
+type signature, but also invariants, ordering constraints, error modes
+(`Result<_,_>`), required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation** — what's inside a module. Distinct from **adapter**: a thing
+can be a small adapter with a large implementation (a Postgres-backed
+`PromotionIndex`) or a large adapter with a small implementation (an in-memory
+fake used in tests).
+
+**Depth** — leverage at the interface: how much behaviour a caller (or test) can
+exercise per unit of interface they must learn. A module is **deep** when a large
+amount of behaviour sits behind a small interface, **shallow** when the interface
+is nearly as complex as the implementation. In TARS, `IxSkill` is deep: one
+`run <skill>` call hides binary-vs-`cargo` resolution, provenance, and fallback.
+
+**Seam** _(Michael Feathers)_ — a place where you can alter behaviour **without
+editing in that place**; the *location* where a module's interface lives. Where
+to put the seam is its own decision, distinct from what goes behind it. TARS seams
+that already exist and have names in `CONTEXT.md`: **IxSkill** (TARS → ix),
+**tars_bridge** (ix → TARS), **MctsBridge** (Rust MCTS ↔ F# fallback), the
+**fitness gate** / **hermetic gate** (variant → accept/reject), and
+`LlmFactory.create` (TARS → any LLM provider).
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter** — a concrete thing that satisfies an interface at a seam. Describes
+*role* (which slot it fills), not substance (what's inside). The Rust `ix` binary
+and the F# `MctsSolver` are two adapters behind the same MCTS seam.
+
+**Leverage** — what callers get from depth: more capability per unit of interface
+learned. One implementation pays back across N call sites and M tests.
+
+**Locality** — what maintainers get from depth: change, bugs, knowledge, and
+verification concentrate in **one place** rather than spreading across callers.
+Fix once, fixed everywhere. A pure function extracted only for testability, while
+the real bug lives in the orchestration that calls it, has *bad* locality.
+
+## Deep vs shallow
+
+```
+Deep module (good)              Shallow module (avoid)
+┌──────────────────┐            ┌──────────────────────────────┐
+│  Small Interface │            │        Large Interface       │
+├──────────────────┤            ├──────────────────────────────┤
+│                  │            │   Thin Implementation        │
+│  Deep            │            │   (just passes through)      │
+│  Implementation  │            └──────────────────────────────┘
+│                  │
+└──────────────────┘
+```
+
+When shaping an interface, ask: can I reduce the number of methods? Simplify the
+parameters? Hide more complexity inside?
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module
+  may be internally composed of small, swappable parts — they just aren't part of
+  its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, it
+  was a pass-through (a shallow wrapper — delete it). If complexity reappears
+  across N callers, it was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the *same* seam.
+  If you need to test *past* the interface, the module is the wrong shape. (TARS:
+  the hermetic gate tests a variant through `dotnet test`, not by inspecting
+  internals.)
+- **One adapter = a hypothetical seam. Two adapters = a real one.** Don't
+  introduce a seam unless something actually varies across it. MctsBridge's seam
+  is real: it has two adapters (Rust `ix`, F# fallback).
+
+## Designing for testability
+
+1. **Accept dependencies, don't create them.** Pass the `ILlmService` /
+   `IChatClient` in; don't `new` a provider inside. (TARS rule: obtain it from
+   `LlmFactory.create(logger)`.)
+2. **Return results, don't produce side effects.** Prefer a function that returns
+   a `Selection.Performance` over one that mutates shared state.
+3. **Small surface area.** Fewer methods = fewer tests; fewer params = simpler
+   setup.
+
+## Rejected framings
+
+- **Depth as a ratio of implementation-lines to interface-lines** — rewards
+  padding the implementation. Use depth-as-leverage instead.
+- **"Interface" as the F#/TypeScript `interface` keyword or a type's public
+  members** — too narrow; interface here includes every fact a caller must know.
+- **"Boundary"** — overloaded with DDD's bounded context. Say **seam** or
+  **interface**.

--- a/docs/agents/skills/entropy-signal-catalog.md
+++ b/docs/agents/skills/entropy-signal-catalog.md
@@ -1,0 +1,48 @@
+# Architecture Entropy Signal Catalog (TARS)
+
+Concrete signals the [`anti-ball-of-mud`](./anti-ball-of-mud.skill.md) skill scans
+for. Each is a **specific** architectural smell, not generic untidiness. For each
+signal: what to look for, a TARS-grounded example, the design-vocabulary term it
+violates, and a default severity for AFK backpressure.
+
+Severity drives the stop decision:
+
+- **high** — stop AFK work and escalate; the fix needs a named seam and review.
+- **medium** — note the friction, propose one seam, keep going only if the seam
+  fits one reviewable PR.
+- **low** — record it; safe to leave for a dedicated micro-PR.
+
+| # | Signal | What to look for | TARS example | Violates | Severity |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Mixed responsibilities in one module | A file that does orchestration **and** IO **and** ranking | An orchestrator that also opens sockets and scores patterns | locality | high |
+| 2 | Bouncing across shallow modules | One concept spread over many tiny files, none deep | Following a request through 6 one-function modules to understand it | depth | medium |
+| 3 | Interface ≈ implementation | A wrapper whose interface is as complex as its body | A "manager" that just forwards each call with the same params | depth / deletion test | medium |
+| 4 | Feature logic mixed with IO/provider/UI | Business logic interleaved with side effects | Pattern-selection logic inline with HTTP calls | locality | high |
+| 5 | Stringly-typed routing | Dispatch on a raw string where a typed contract belongs | Capability dispatch by `match capName with "x" -> …` instead of a DU | interface | medium |
+| 6 | Ad-hoc JSON shapes | Repeated inline JSON with no schema/contract | New `{...}` payload shapes not backed by `docs/contracts/` or an `examples/*.json` | interface | medium |
+| 7 | Shallow wrapper | A rename that adds no behaviour | A `FooService` that delegates 1:1 to `Foo` | deletion test | low |
+| 8 | Hidden global mutable state | A `mutable`/static cache reached from many places | A module-level mutable dictionary mutated across call sites | locality | high |
+| 9 | Seam leakage | Tightly-coupled modules reaching into each other's internals | A caller pattern-matching on another module's private representation | seam | high |
+| 10 | Pure-for-testability, bug-in-orchestration | A pure helper extracted only to test, while the real bug is in the caller | Well-tested scoring fn, but the orchestration that feeds it is untested | locality | medium |
+| 11 | Core depends directly on GitHub/LLM/FS/network | A provider SDK call wired straight into core runtime | A direct `DefaultLlmService` (instead of `LlmFactory.create(logger)`); a raw `gh`/HTTP call in core | seam / adapter | high |
+| 12 | Duplicated scoring/analytics that belongs to ix | A copy-pasted algorithm reimplemented in TARS | Reimplementing `stats`/`bandit`/`grammar.weights` in F# instead of calling `IxSkill` | leverage | high |
+| 13 | Scattered Demerzel governance `if`s | Governance rules expressed as local conditionals | `if risk > x then block` inline instead of routing through the governance gate | seam | high |
+| 14 | Tests assert implementation details | Tests coupled to internals, not the interface | A test that inspects private state instead of crossing the module's seam | interface / test surface | medium |
+
+## How to use the catalog
+
+1. While inspecting the requested change, match each touched file against the
+   table. **Cite the row number and the file** in the eight-part report's
+   *Entropy finding* — a finding with no cited signal is not evidence.
+2. Take the **highest-severity** signal as the primary finding; secondary signals
+   can be listed but the report proposes **one** seam.
+3. If the highest severity is **high**, the default is **stop and escalate** —
+   the fix almost always needs architecture judgment and a review gate.
+
+## Relation to other TARS policy
+
+- Signals 11–13 overlap with `AGENTS.md` review-independence and the Agent
+  Blackbox policy. When a high-severity signal coincides with a **one-way-door**
+  or **blocked** path, the stop is mandatory.
+- Signal 11 directly encodes the TARS convention "LLM access always via
+  `LlmFactory.create(logger)`" from `CLAUDE.md`.

--- a/docs/agents/skills/matt-pocock-skills-mapping.md
+++ b/docs/agents/skills/matt-pocock-skills-mapping.md
@@ -1,0 +1,59 @@
+# Matt Pocock Skills → TARS Mapping
+
+This document records how the [`anti-ball-of-mud`](./anti-ball-of-mud.skill.md)
+skillset ports the **spirit and workflow shape** of
+[`mattpocock/skills`](https://github.com/mattpocock/skills) into TARS. It is a
+TARS-native adaptation, **not** a verbatim copy of the upstream course/repo
+content.
+
+Reference skill:
+[`improve-codebase-architecture/SKILL.md`](https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md).
+
+## Why adapt rather than copy
+
+`mattpocock/skills` frames skills as small, adaptable, composable practices for
+real engineering. It distinguishes:
+
+- **user-invoked skills** — explicit orchestration commands a human runs;
+- **model-invoked skills** — reusable discipline the agent reaches for when the
+  task fits.
+
+The upstream skills assume an interactive human at the keyboard (HTML reports
+opened in a browser, a multi-turn grilling conversation). TARS needs the same
+*discipline* in an **AFK / cloud-agent** setting, where the agent reads repo
+files and an issue body, cannot open a browser, and must create **backpressure**
+rather than ask unbounded follow-up questions. So we keep the vocabulary and the
+"detect mud → name the seam → keep the PR small" shape, and we drop the
+interactive/HTML machinery.
+
+## Concept mapping
+
+| Upstream (`mattpocock/skills`) | TARS adaptation | Notes |
+| --- | --- | --- |
+| `improve-codebase-architecture` — scan for deepening opportunities, present an HTML report, grill the chosen one | [`anti-ball-of-mud.skill.md`](./anti-ball-of-mud.skill.md) — detect entropy signals, emit an **eight-part text report**, propose **one** seam | No browser/HTML; output is repo-readable Markdown a cloud agent can write into a PR note. |
+| `codebase-design` — shared vocabulary (module, interface, depth, seam, adapter, locality, leverage; deletion test) | [`codebase-design-vocabulary.md`](./codebase-design-vocabulary.md) | Same terms, re-grounded in TARS seams (`IxSkill`, `MctsBridge`, hermetic gate, `LlmFactory`). |
+| `grilling` / `grill-with-docs` — structured questioning before committing to a design | The skill's **stop conditions** + **review gate** | AFK substitute for an open-ended interview: when the choice is architectural, **stop and escalate** to a human / Demerzel tribunal instead of grilling autonomously. |
+| `domain-modeling` — keep shared project language current | Pointers to `CONTEXT.md` + `docs/adr/` | The skill *reads* the ubiquitous language and refuses to re-litigate ADRs; it does not silently mutate the domain model AFK. |
+| `to-issues` — turn a plan into independently-grabbable vertical slices | The **micro-PR plan** ("smallest safe change", one seam, under the rewrite budget) | One reviewable slice, not a backlog of refactors. |
+| user-invoked vs model-invoked distinction | `/anti-ball-of-mud` (user) vs `anti-ball-of-mud-guard` (model) | Both share one vocabulary and one output shape; they differ in trigger and latitude. |
+
+## What we deliberately did **not** port
+
+- The **HTML report + Mermaid/CDN visualisation** machinery — an AFK cloud agent
+  has no browser and should not commit `architecture-review-*.html` artifacts.
+- The **multi-turn grilling loop** as an autonomous behavior — replaced by a
+  hard stop + escalation when the decision is architectural.
+- Any **course/marketing content** — out of scope and a stated non-goal.
+- A **full architecture-governance framework** — TARS already has Demerzel and
+  the Agent Blackbox policy; this skill *routes to* them, it does not replace them.
+
+## Provenance / non-goals (from issue #135)
+
+- Do **not** reproduce Matt Pocock course/repo content verbatim.
+- Do **not** implement a full architecture-governance framework.
+- Do **not** rewrite TARS modules as part of this skillset.
+- Do **not** turn this into a generic clean-code checklist.
+- Do **not** bypass human review for architectural decisions.
+- Keep it usable by **Codex / Ollama / local agents**, not Claude-only — which is
+  why the deliverable is repo-readable Markdown + JSON examples, with no
+  Claude-specific tooling required.

--- a/examples/agents/anti-ball-of-mud-skill-invocation.example.json
+++ b/examples/agents/anti-ball-of-mud-skill-invocation.example.json
@@ -1,0 +1,41 @@
+{
+  "scenario": "An AFK agent is dispatched on a 'add retry + telemetry to MctsBridge' issue. Mid-task it notices the change is about to thread an HTTP/provider call and duplicate ix scoring into core runtime, so the anti-ball-of-mud-guard fires.",
+  "skill": "anti-ball-of-mud",
+  "mode": "model-invoked",
+  "trigger": "anti-ball-of-mud-guard",
+  "issue_meta": {
+    "level": "task",
+    "area": "evolution",
+    "priority": "P1",
+    "afk": {
+      "readiness": "ready",
+      "max_autonomy": "pr",
+      "reason": "feature work on MctsBridge retry/telemetry"
+    }
+  },
+  "triggers_fired": [
+    "adding logic to an already-large module instead of behind a seam",
+    "duplicating scoring logic that belongs in ix",
+    "threading a provider/network call into core runtime"
+  ],
+  "entropy_signals": [
+    { "catalog_row": 12, "file": "v2/src/Tars.Evolution/MctsBridge.fs", "severity": "high", "note": "retry/telemetry reimplements bandit-style backoff already in ix" },
+    { "catalog_row": 11, "file": "v2/src/Tars.Evolution/MctsBridge.fs", "severity": "high", "note": "telemetry would add a direct network call to core runtime" }
+  ],
+  "report_ref": "examples/agents/anti-ball-of-mud.expected-output.md",
+  "decision": "stop_and_escalate",
+  "proposed_seams": 1,
+  "review_gate": "human_or_demerzel",
+  "afk_autonomy_respected": true,
+  "files_written": [
+    "PR note (no runtime .fs edited)"
+  ],
+  "execution_plan": [
+    "Check governance/state/afk-halt.json is inactive (governed-delegation).",
+    "Match touched files against entropy-signal-catalog.md; record rows 11 and 12 (both high).",
+    "Stop feature work; do NOT thread the call into MctsBridge.fs.",
+    "Emit the eight-part report (see report_ref) proposing one telemetry-adapter seam.",
+    "Escalate the architectural choice (where telemetry lives, whether retry calls ix) to a human / Demerzel reviewer.",
+    "Record the report as a PR note; do not commit an exploratory architecture-review artifact."
+  ]
+}

--- a/examples/agents/anti-ball-of-mud.expected-output.md
+++ b/examples/agents/anti-ball-of-mud.expected-output.md
@@ -1,0 +1,100 @@
+# Anti-Ball-of-Mud — Expected Output (worked example)
+
+This is the **eight-part report** the
+[`anti-ball-of-mud`](../../docs/agents/skills/anti-ball-of-mud.skill.md) skill
+produces, for the muddy change request described in
+[`anti-ball-of-mud-skill-invocation.example.json`](./anti-ball-of-mud-skill-invocation.example.json):
+*"add retry + telemetry to `MctsBridge`."*
+
+It is a teaching example — the file paths and code shape are illustrative, not a
+committed refactor. The point is the **shape** of the output: one cited finding,
+one named seam, one reviewable PR, and a hard stop with a review gate.
+
+---
+
+## 1. Entropy finding
+
+Adding retry/backoff and telemetry **directly inside**
+`v2/src/Tars.Evolution/MctsBridge.fs` triggers two high-severity catalog signals:
+
+- **Row 12 (duplicated scoring/analytics that belongs to ix):** the proposed
+  retry/backoff reimplements bandit-style backoff that already exists in `ix`
+  (`bandit`, `grammar.weights`). TARS would own a second copy of an algorithm the
+  ecosystem already has.
+- **Row 11 (core depends directly on network/provider):** the telemetry hook
+  would add a direct network call into core evolution runtime, bypassing any
+  adapter seam.
+
+`MctsBridge` is already a seam (Rust `ix` ↔ F# `MctsSolver` fallback, per
+`CONTEXT.md`). Bolting retry + telemetry inside it mixes **three** responsibilities
+into one module: MCTS dispatch, retry policy, and telemetry IO.
+
+## 2. Design vocabulary
+
+- **Module:** `MctsBridge` — currently a clean **deep** module (one `search` call
+  hides Rust-vs-F# selection).
+- **Interface:** `search(spec) -> derivation`. Adding retry/telemetry params would
+  make the **interface** nearly as complex as the implementation → drift toward
+  **shallow**.
+- **Seam:** retry and telemetry each want their **own seam**, not to be folded
+  into the MCTS seam.
+- **Adapter:** telemetry should sit behind a telemetry **adapter** (a no-op
+  adapter in tests, a real one in prod) — **two adapters = a real seam**.
+- **Locality / leverage:** keeping retry as a policy the bridge *accepts* (rather
+  than *creates*) keeps the bug surface local and reusable.
+
+## 3. Proposed seam
+
+**One** seam: a `Telemetry` interface that `MctsBridge` *accepts* as a dependency
+(default = no-op adapter). Retry/backoff is **delegated to `IxSkill`** rather than
+reimplemented — i.e. no new TARS algorithm, just route to the existing ix seam.
+
+## 4. Smallest safe change
+
+A single reviewable PR that:
+
+- introduces a tiny `ITelemetry` (or `Telemetry` record-of-functions) interface
+  with a no-op default;
+- threads it into `MctsBridge.search` as an accepted dependency;
+- leaves retry/backoff to a follow-up that calls `IxSkill`, **not** to this PR.
+
+No new provider dependency; no copied ix logic; stays under the rewrite budget.
+
+## 5. Files likely touched
+
+- `v2/src/Tars.Evolution/MctsBridge.fs` (accept the telemetry dependency)
+- a new small `Telemetry` module under `v2/src/Tars.Core/`
+- `tests/Tars.Tests/` (a test that asserts the no-op adapter is exercised through
+  the interface)
+
+## 6. Test surface
+
+Test **through the interface**: inject a recording telemetry adapter, run
+`search`, assert the expected events crossed the seam. No inspection of
+`MctsBridge` internals — the interface is the test surface.
+
+## 7. Risk / backpressure — why this PR stops here
+
+- Whether retry should call `ix` (and *which* ix skill) is an **architectural
+  choice**, not a mechanical edit — it needs product/architecture judgment.
+- Reimplementing backoff in TARS would duplicate ix (high-severity row 12) — a
+  one-way-ish coupling decision that must not happen AFK.
+- Folding telemetry IO into core runtime (row 11) would degrade the `MctsBridge`
+  seam; the no-op-adapter approach is the minimum that avoids that.
+
+**Decision: stop after the telemetry seam. Do not add retry in this PR.**
+
+## 8. Review gate
+
+The retry-routing decision (call ix vs. local backoff, and where telemetry is
+emitted) is escalated to a **human reviewer / Demerzel tribunal** before any
+broader change. Per `AGENTS.md`, the producing agent cannot self-certify an
+architectural decision; a fresh reviewer must approve the seam direction.
+
+---
+
+### AFK note
+
+`governance/state/afk-halt.json` was checked and is inactive. No runtime `.fs`
+file was edited by the skill itself — this report was recorded as a PR note, and
+the single approved seam (if accepted) would land as its own human-reviewed PR.


### PR DESCRIPTION
Closes #135

TARS-native, repo-readable, **AFK-safe** port of the spirit and workflow shape of
[`mattpocock/skills`](https://github.com/mattpocock/skills) (`improve-codebase-architecture`,
`codebase-design`, `grilling`, `domain-modeling`, `to-issues`). The deliverable is
a small, sharp agent skill that detects architecture entropy, names **one** seam,
keeps the PR reviewable, and creates **backpressure** before AFK work makes the mud
worse.

**Scope: docs / examples only.** No runtime F#/Rust/workflow files were modified
(per `issue_meta.afk.max_autonomy: pr` and `reason: docs/examples/tests only`).
`governance/state/afk-halt.json` was checked and is **inactive/absent**.

## Files
- `docs/agents/skills/anti-ball-of-mud.skill.md` — the skill (new)
- `docs/agents/skills/codebase-design-vocabulary.md` — deep-module vocabulary, TARS-grounded (new)
- `docs/agents/skills/entropy-signal-catalog.md` — 14 TARS entropy signals with severity (new)
- `docs/agents/skills/matt-pocock-skills-mapping.md` — explicit upstream→TARS mapping (new)
- `examples/agents/anti-ball-of-mud-skill-invocation.example.json` — example invocation (new)
- `examples/agents/anti-ball-of-mud.expected-output.md` — worked muddy-change output (new)
- `docs/agents/skills/README.md` — lists the new skill (edited)
- `AGENTS.md` — "Repo-readable skill library" section: when to invoke (edited)

## `evidence_required` coverage
- **matt_pocock_skills_mapping** — `matt-pocock-skills-mapping.md`: per-skill table + what was deliberately not ported.
- **anti_ball_of_mud_skill_doc** — `anti-ball-of-mud.skill.md`: user-invoked `/anti-ball-of-mud` vs model-invoked `anti-ball-of-mud-guard`, eight-part required output.
- **codebase_design_vocabulary** — `codebase-design-vocabulary.md`: module/interface/depth/seam/adapter/locality/leverage + deletion test, re-grounded in TARS seams (IxSkill, MctsBridge, hermetic gate, LlmFactory).
- **entropy_signal_catalog** — `entropy-signal-catalog.md`: 14 concrete signals (mixed responsibilities, stringly-typed routing, ad-hoc JSON, core→provider deps, duplicate ix scoring, scattered Demerzel `if`s, tests asserting internals…) with severity.
- **narrow_seam_proposal** — skill output part 3 ("one seam, not a rewrite") + worked single-seam example in `anti-ball-of-mud.expected-output.md`.
- **micro_pr_plan** — skill output part 4 ("smallest safe change", under the rewrite budget) + the expected-output example's one-PR plan.
- **stop_condition** — skill "Stop conditions (AFK backpressure)" section: architectural judgment, rewrite-budget overflow, one-way-door/blocked paths, ix/Demerzel copy, active afk-halt, max_autonomy exceeded.
- **human_or_demerzel_review_gate** — skill output part 8 + stop-condition escalation; the worked example routes the architectural decision to a human / Demerzel tribunal.

## Notes
- Kept usable by Codex/Ollama/local agents (repo-readable Markdown + JSON, no Claude-only tooling).
- No ix/Demerzel logic copied into TARS; no new provider/cloud dependency; no exploratory artifacts committed.
- JSON example validated as parseable; all internal cross-directory links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
