### PR TITLE
feat(afk): add Claude workflow (anthropics/claude-code-action) — completes Jules+Codex+Claude

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,19 +1,5 @@
 name: Claude
 
-# Makes `@claude` mentions actionable. Unlike Jules and Codex (autonomous SaaS
-# apps that act on a label/comment by themselves), Claude's GitHub integration
-# only responds when this anthropics/claude-code-action workflow runs it. This is
-# what lets the AFK router's `worker:claude` path actually trigger Claude — the
-# router comments `@claude` (as the PAT owner) and this workflow does the work.
-#
-# Public-repo safety: gated to OWNER/MEMBER/COLLABORATOR, so a stranger commenting
-# `@claude` on a public issue cannot trigger Claude (and burn the API key). The
-# AFK router posts as the PAT owner (OWNER), so router-driven `@claude` passes.
-#
-# Requires the ANTHROPIC_API_KEY secret. Governance: the AFK halt-gate lives in
-# the router, which won't post `@claude` while halted; direct collaborator
-# `@claude` is a deliberate human action.
-
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,41 @@
+name: Claude
+
+# Makes `@claude` mentions actionable. Unlike Jules and Codex (autonomous SaaS
+# apps that act on a label/comment by themselves), Claude's GitHub integration
+# only responds when this anthropics/claude-code-action workflow runs it. This is
+# what lets the AFK router's `worker:claude` path actually trigger Claude — the
+# router comments `@claude` (as the PAT owner) and this workflow does the work.
+#
+# Public-repo safety: gated to OWNER/MEMBER/COLLABORATOR, so a stranger commenting
+# `@claude` on a public issue cannot trigger Claude (and burn the API key). The
+# AFK router posts as the PAT owner (OWNER), so router-driven `@claude` passes.
+#
+# Requires the ANTHROPIC_API_KEY secret. Governance: the AFK halt-gate lives in
+# the router, which won't post `@claude` while halted; direct collaborator
+# `@claude` is a deliberate human action.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: |
+      contains(github.event.comment.body, '@claude') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Why

Verification showed the AFK workflow works with **Jules ✅ and Codex ✅** (both autonomous apps), but **`@claude` got no response** — Claude's GitHub integration only acts when an `anthropics/claude-code-action` workflow runs it, and none existed. So the router's `worker:claude` path was a silent no-op.

## What

`claude.yml` — `anthropics/claude-code-action@v1` on `issue_comment` / `pull_request_review_comment`, firing on `@claude`. **Gated to OWNER/MEMBER/COLLABORATOR** so a stranger can't trigger Claude on this public repo (the router posts `@claude` as the PAT owner, so it passes).

This makes the multi-agent router a true trio: Jules (label) + Codex (`@codex`) + Claude (`@claude`).

## Needs

- **`ANTHROPIC_API_KEY`** secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)