### PR TITLE
docs: add cost and complexity notes for second-brain patterns

### DIFF
--- a/docs/research/external-second-brain-patterns.md
+++ b/docs/research/external-second-brain-patterns.md
@@ -16,6 +16,7 @@ PARA organizes information based on its **actionability**.
 Agents often struggle with "context overflow." PARA provides a heuristic for what should be in the immediate context (Projects) versus long-term retrieval (Resources/Archives).
 - **Adopt:** GitHub issues/PRs as "Projects"; `docs/` as "Resources"; `archive/` or old git history as "Archives".
 - **Agentic Mapping:** TARS context windows should prioritize "Project" data.
+- **Cost/Complexity:** Low. Primarily a process-based improvement for context window management.
 
 ## 2. Zettelkasten (Slip-Box)
 **Origin:** Niklas Luhmann
@@ -27,6 +28,7 @@ Knowledge is broken down into **atomic notes** (Zettels). Each note contains one
 Modern LLMs excel at synthesis but struggle with huge, monolithic documents. Atomic, linked knowledge allows for precise RAG (Retrieval-Augmented Generation).
 - **Adopt:** Provenance-rich, atomic memory units.
 - **Agentic Mapping:** Tars.Evolution extraction should produce atomic "belief" or "fact" nodes rather than large text blobs.
+- **Cost/Complexity:** Medium. Requires extra agent steps for atomization and extraction during the ingestion pipeline.
 
 ## 3. Obsidian-style Local Markdown + Backlinks
 **Origin:** Obsidian.md / General PKM community
@@ -38,6 +40,7 @@ Modern LLMs excel at synthesis but struggle with huge, monolithic documents. Ato
 Text-based, human-readable formats ensure transparency and auditability for agentic memory.
 - **Adopt:** Markdown/JSON files that remain inspectable by humans. Avoid "black box" vector databases as the sole source of truth.
 - **Agentic Mapping:** Streeling University's "pages" or "departments" should be readable files.
+- **Cost/Complexity:** Low. Uses standard filesystem and text search tools; minimal infra overhead.
 
 ## 4. Logseq-style Outliner / Graph Workflows
 **Origin:** Logseq
@@ -49,6 +52,7 @@ An outliner that treats every bullet point as a block. Focuses on daily journali
 Agents process information well in structured, hierarchical formats. The "Daily Note" pattern is excellent for capturing agent traces and logs.
 - **Adopt:** Block-level referencing and daily trace logs.
 - **Agentic Mapping:** GA Trace Bridge uses this pattern to ingest agent activity.
+- **Cost/Complexity:** Medium-High. Block-level indexing increases metadata overhead and retrieval complexity compared to file-level RAG.
 
 ## 5. Readwise-style Capture / Highlight / Review / Export
 **Origin:** Readwise.io
@@ -60,6 +64,7 @@ Automates the capture of highlights from various sources (Kindle, web, podcasts)
 "Capture is not enough." Simply scraping data into a vector store doesn't equate to learning.
 - **Adopt:** Mandatory review/promotion pipeline.
 - **Agentic Mapping:** Tars.Evolution's 7-step pipeline (Inspect -> Extract ... -> Persist).
+- **Cost/Complexity:** Medium. Human-in-the-loop or high-confidence agent review steps add latency but prevent "memory rot."
 
 ## 6. NotebookLM-style Source-Grounded Synthesis
 **Origin:** Google
@@ -71,6 +76,7 @@ An AI-native interface where the LLM is strictly constrained to a user-provided 
 Mitigates hallucinations by ensuring every claim is backed by a specific artifact.
 - **Adopt:** Strict source-grounding and citation requirements.
 - **Agentic Mapping:** Seldon's teaching behavior (must cite governance artifacts).
+- **Cost/Complexity:** Low. Primarily a prompting and validation constraint with low runtime overhead.
 
 ## 7. GraphRAG (Knowledge-Graph RAG)
 **Origin:** Microsoft / General AI Research
@@ -82,6 +88,7 @@ Combines vector search with a knowledge graph. It builds a hierarchical graph of
 Useful for understanding the "landscape" of a large codebase or governance framework.
 - **Adopt:** Community/Graph summaries for global context.
 - **Agentic Mapping:** Demerzel's cross-repo health reports and "metasync" checks.
+- **Cost/Complexity:** Highest. Requires extensive pre-processing (entity/relationship extraction) and persistent graph infrastructure.
 
 ## 8. Tana-style Agentic Workspace
 **Origin:** Tana.inc
@@ -93,3 +100,4 @@ Knowledge is "agentic." Notes are not just text; they are "Supertags" (objects w
 Memory becomes valuable when it drives action. A "note" about a bug should *be* the bug-fix workflow.
 - **Adopt:** Memory-to-action mappings; structured data (JSON/YAML) over pure prose.
 - **Agentic Mapping:** WoT DSL (`.trsx`) where thought-steps are executable actions.
+- **Cost/Complexity:** Medium-High. Requires strict schema enforcement and integration with orchestration runners.

--- a/docs/research/second-brain-pattern-adaptation-matrix.md
+++ b/docs/research/second-brain-pattern-adaptation-matrix.md
@@ -2,16 +2,16 @@
 
 This matrix maps external Personal Knowledge Management (PKM) patterns to the TARS/IX/Demerzel/Streeling/Seldon ecosystem.
 
-| pattern | core_idea | what_to_adopt | what_to_reject | TARS_mapping | IX_mapping | Demerzel_mapping | Streeling_mapping | risk | first_tracer_bullet |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| **PARA** | Organize by actionability | Active work belongs in Issues/PRs | Over-categorization of "Resource" folders | Context window prioritization | MCTS task pruning | Governance focus areas | Departmental organization | Stale "Archives" cluttering search | Auto-move closed Issues to `archive.md` |
-| **Zettelkasten** | Atomic, linked notes | Atomic memory units with provenance | Manual ID management (use UUID/Content Hash) | `Tars.Evolution` extraction | Skill atomicity | Policy cross-references | Course module granularity | Fragmented context | Extract 3 atomic facts from one GA trace |
-| **Obsidian** | Local Markdown + Backlinks | Inspectable, local-first files | Proprietary plugins/binary formats | DSL and `docs/` storage | Trace visualization | Readable policy audit | Departmental wiki pages | Format drift over time | `diag docs` check for broken links |
-| **Logseq** | Daily outliner / Graph | Daily trace logs as source of truth | Indentation-as-logic (prefer explicit DSL) | GA Trace Bridge | MCTS trial logs | Daily governance reports | Research cycle logs | Large graph traversal cost | Convert one `trace.yaml` to bulleted log |
-| **Readwise** | Capture -> Review -> Promote | Mandatory promotion pipeline | Passive "hoarding" of data | `Tars.Evolution` pipeline | Skill refinement | Policy evolution | Knowledge harvesting | "Learning" without validation | Implement "Review Required" flag on new facts |
-| **NotebookLM** | Source-grounded synthesis | Mandatory citations for every claim | Global model weights as truth | LLM grounding checks | Verifiable skill claims | Constitutional grounding | Evidence bundles | citation hallucinations | Seldon rejects claim if citation is missing |
-| **GraphRAG** | Hierarchical graph summaries | Global corpus summaries | Pure vector search for global queries | `diag reasoning` overview | Skill-tree topology | Cross-repo health map | Departmental summaries | Graph construction overhead | Generate summary for one Streeling department |
-| **Tana** | Agentic workspace / Tags | Memory-to-action (Supertags) | Manual tag management | WoT DSL (`.trsx`) | Executable skills | Policy-as-code | Actionable research | Brittle schema definitions | Map one "Bug" tag to a TARS fix workflow |
+| pattern | cost | core_idea | what_to_adopt | what_to_reject | TARS_mapping | IX_mapping | Demerzel_mapping | Streeling_mapping | risk | first_tracer_bullet |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **PARA** | Low | Organize by actionability | Active work belongs in Issues/PRs | Over-categorization of "Resource" folders | Context window prioritization | MCTS task pruning | Governance focus areas | Departmental organization | Stale "Archives" cluttering search | Auto-move closed Issues to `archive.md` |
+| **Zettelkasten** | Med | Atomic, linked notes | Atomic memory units with provenance | Manual ID management (use UUID/Content Hash) | `Tars.Evolution` extraction | Skill atomicity | Policy cross-references | Course module granularity | Fragmented context | Extract 3 atomic facts from one GA trace |
+| **Obsidian** | Low | Local Markdown + Backlinks | Inspectable, local-first files | Proprietary plugins/binary formats | DSL and `docs/` storage | Trace visualization | Readable policy audit | Departmental wiki pages | Format drift over time | `diag docs` check for broken links |
+| **Logseq** | Med-High | Daily outliner / Graph | Daily trace logs as source of truth | Indentation-as-logic (prefer explicit DSL) | GA Trace Bridge | MCTS trial logs | Daily governance reports | Research cycle logs | Large graph traversal cost | Convert one `trace.yaml` to bulleted log |
+| **Readwise** | Med | Capture -> Review -> Promote | Mandatory promotion pipeline | Passive "hoarding" of data | `Tars.Evolution` pipeline | Skill refinement | Policy evolution | Knowledge harvesting | "Learning" without validation | Implement "Review Required" flag on new facts |
+| **NotebookLM** | Low | Source-grounded synthesis | Mandatory citations for every claim | Global model weights as truth | LLM grounding checks | Verifiable skill claims | Constitutional grounding | Evidence bundles | citation hallucinations | Seldon rejects claim if citation is missing |
+| **GraphRAG** | Highest | Hierarchical graph summaries | Global corpus summaries | Pure vector search for global queries | `diag reasoning` overview | Skill-tree topology | Cross-repo health map | Departmental summaries | Graph construction overhead | Generate summary for one Streeling department |
+| **Tana** | Med-High | Agentic workspace / Tags | Memory-to-action (Supertags) | Manual tag management | WoT DSL (`.trsx`) | Executable skills | Policy-as-code | Actionable research | Brittle schema definitions | Map one "Bug" tag to a TARS fix workflow |
 
 ## Synthesis Notes
 
@@ -26,3 +26,22 @@ Readwise taught us that capture is easy, but retention is hard. The `Tars.Evolut
 
 ### 4. Graph vs. Vector
 While vector search is used for local retrieval, GraphRAG principles drive our "Global" understanding. Demerzel uses graph-like summaries to report on the state of the entire ecosystem.
+
+## Cost & Complexity Analysis
+
+### 1. Free/Local Feasibility
+Patterns like **PARA**, **Obsidian**, and **NotebookLM-style citation discipline** are low-cost because they rely on process and documentation standards rather than expensive compute. They are highly feasible for local-first development.
+
+### 2. Runner & Runtime Impact
+- **Low Impact:** Markdown-based retrieval and PARA-based context pruning.
+- **Medium Impact:** Zettelkasten-style atomization and Readwise-style review pipelines (requires additional agent passes).
+- **High Impact:** Logseq-style block referencing and GraphRAG. Graph construction and block-level indexing significantly increase runner latency and token usage.
+
+### 3. Storage and Indexing Overhead
+- **Text-only (Low):** PARA, Obsidian, Zettelkasten.
+- **Structured (Medium):** Tana-style supertags (JSON schema maintenance).
+- **Compute-Intensive (High):** GraphRAG requires persistent graph database or complex hierarchical index maintenance, which adds substantial overhead compared to simple vector search.
+
+### 4. Tracer Bullets vs. Future Work
+- **Cheap Tracer Bullets:** Implement "citation required" checks (NotebookLM) or "auto-archive" scripts (PARA). These prove the value with minimal infra.
+- **Heavier Work:** Building a full GraphRAG index or a Tana-like agentic workspace should remain as tracer-only experiments until the "cheap" process-driven improvements are exhausted and the cost is justified by performance gains.


### PR DESCRIPTION
This PR adds cost and complexity notes for the eight second-brain patterns discussed in the research documentation.

Changes include:
- A new `cost` column in the `Second-Brain Pattern Adaptation Matrix`.
- A "Cost & Complexity Analysis" section in the matrix document covering feasibility, runtime impact, storage, and tracer bullets.
- Specific cost/complexity notes for each pattern in the `External Second-Brain Patterns Review`.

The patterns covered are: PARA, Zettelkasten, Obsidian, Logseq, Readwise, NotebookLM, GraphRAG, and Tana.

Fixes #156

---
*PR created automatically by Jules for task [10141437986155217826](https://jules.google.com/task/10141437986155217826) started by @spareilleux*