### PR TITLE
feat(afk): cost-safe @claude auth + auto-review workflow (#159)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,42 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    # Cost-safe: fire once per PR (opened / marked ready / reopened), not per push.
+    # `synchronize` is intentionally omitted so a busy PR doesn't multiply review runs.
+    types: [opened, reopened, ready_for_review]
+
+# Cost-safe: at most one review run per PR at a time; new events cancel the in-flight one.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    # Cost-safe: skip draft PRs — review runs when the PR is marked ready_for_review.
+    if: github.event.pull_request.draft == false
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Subscription OAuth token ($0/call), never the pay-per-use ANTHROPIC_API_KEY.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,4 +24,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Subscription OAuth token ($0/call), never the pay-per-use ANTHROPIC_API_KEY.
+          # Set org-wide via: claude setup-token && gh secret set CLAUDE_CODE_OAUTH_TOKEN --org GuitarAlchemist
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Part of GuitarAlchemist/tars#159 (cost-safe AI agent harness rollout). Covers the two **tars** per-repo tasks from that issue.

- **`claude.yml`** — switch `@claude` auth from pay-per-use `ANTHROPIC_API_KEY` → subscription `CLAUDE_CODE_OAUTH_TOKEN` ($0/call). This fixes the issue's headline bug: tars' `@claude` path was a silent no-op (wrong key, and no secret was ever set).
- **`claude-code-review.yml`** (new) — cost-safe auto-review: fires on `opened|reopened|ready_for_review` only (drops `synchronize`), skips drafts, and uses `concurrency: cancel-in-progress` → one review per PR, not one per push.

## Cost design (per the issue)

- Subscription OAuth token everywhere, never per-call API key in CI.
- Auto-review does not fire per-push.
- `@claude` stays opt-in (mention-gated, OWNER/MEMBER/COLLABORATOR only).

## Gating dependency

⚠️ These workflows authenticate against the **`CLAUDE_CODE_OAUTH_TOKEN`** secret, which must be set org-wide before they work:
`claude setup-token` → `gh secret set CLAUDE_CODE_OAUTH_TOKEN --org GuitarAlchemist`. Until then the OAuth path has no credential.

## Test plan

- [x] All workflow YAML parses (validated with `yaml.safe_load`).
- [ ] Org secret `CLAUDE_CODE_OAUTH_TOKEN` set.
- [ ] Live: post a test `@claude` mention on tars → confirm it responds (was silent before).
- [ ] Live: open a PR → confirm auto-review fires once (not per push) and skips while draft.

## Not in this PR

`jules-auto-delegate.yml` is intentionally omitted for tars — the existing `afk-router.yml` already implements the identical label-gated delegation loop; a second workflow would double-trigger on `ready-for-agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqmsdJ4PgpQHV37vys5Erb)_