### PR TITLE
docs: add teach skill and learning architecture

### DIFF
--- a/v2/docs/teaching/seldon-streeling-teach-architecture.md
+++ b/v2/docs/teaching/seldon-streeling-teach-architecture.md
@@ -1,0 +1,141 @@
+# `/teach`, Seldon, Streeling, IX, and Demerzel
+
+## Purpose
+
+This document defines how the `/teach` skill connects to the broader GuitarAlchemist learning architecture.
+
+`/teach` is not a standalone teaching toy. It is the user-facing entry point for a learning loop across Streeling, Seldon, IX, TARS, and Demerzel.
+
+## Architecture split
+
+```text
+Streeling
+  owns the curriculum, concept graph, prerequisites, source artifacts, and learning paths.
+
+TARS /teach
+  owns the interactive command, session flow, and user-facing learning experience.
+
+Seldon
+  owns adaptive teaching behavior, assessment, retry, escalation, and learning-state updates.
+
+IX
+  owns mastery metrics, weak-area detection, spaced-review signals, and learning analytics.
+
+Demerzel
+  consumes decision-readiness signals for important architecture/governance decisions.
+```
+
+## Flow
+
+```text
+Streeling concept path
+-> TARS /teach session
+-> Seldon assessment and adaptation
+-> IX mastery metrics
+-> TARS learning-state artifact
+-> Demerzel readiness signal when relevant
+```
+
+## Streeling responsibilities
+
+Streeling should provide:
+
+```text
+concept_id
+concept_name
+prerequisites
+source_artifacts
+related_project_decisions
+common_misconceptions
+quiz_seed_material
+next_concepts
+```
+
+Examples of concepts:
+
+- abstraction wall;
+- evidence ladder;
+- verification horizon;
+- anti-rubber-stamp review;
+- Goodhart risk;
+- causal scorecards;
+- computational argumentation;
+- human decision gates.
+
+## Seldon responsibilities
+
+Seldon should manage:
+
+- lesson adaptation;
+- quick-check generation;
+- teach-back scoring;
+- scenario exam prompts;
+- retry plans;
+- misconception tracking;
+- escalation when a concept remains weak;
+- learning-state update candidates.
+
+Seldon should not auto-promote a concept as mastered from confidence alone.
+
+## IX responsibilities
+
+IX should produce interpretable learning metrics:
+
+```text
+retrieval_success_rate
+teach_back_quality
+scenario_transfer_score
+misconception_recurrence
+spaced_review_due_count
+concept_mastery_delta
+decision_readiness_signal
+```
+
+Metrics are evidence, not authority.
+
+A high quiz score alone is not mastery.
+
+## TARS responsibilities
+
+TARS should:
+
+- run the `/teach` session;
+- maintain the session artifact;
+- connect lessons to second-brain concepts;
+- link teachings to relevant repo artifacts;
+- surface weak concepts before important decisions;
+- let the maintainer choose learning goals.
+
+## Demerzel responsibilities
+
+Demerzel may ask whether the maintainer has enough concept readiness for a high-impact decision.
+
+Examples:
+
+```text
+Architecture boundary change -> ask if relevant concept has been taught
+Metric-driven decision -> ask if Goodhart concept is understood
+Review routing change -> ask if anti-rubber-stamp concept is understood
+```
+
+Demerzel must not block all decisions on learning metrics.
+
+The signal is advisory and should be shown with evidence.
+
+## Student-maintainer model
+
+The maintainer is treated as a learner for complex governance and architecture concepts.
+
+This does not reduce authority. It improves decision quality.
+
+```text
+The system teaches before asking for high-impact judgment.
+```
+
+## Non-goals
+
+- Do not turn `/teach` into passive docs generation.
+- Do not require a lesson before every decision.
+- Do not shame or punish weak scores.
+- Do not treat quiz score as decision authority.
+- Do not store unnecessary personal data.

--- a/v2/docs/teaching/teach-skill.md
+++ b/v2/docs/teaching/teach-skill.md
@@ -1,0 +1,160 @@
+# TARS `/teach` Skill
+
+## Purpose
+
+`/teach` is the interactive learning channel for the human maintainer.
+
+It turns project concepts into active learning sessions with explanation, retrieval practice, quiz, teach-back, applied scenarios, feedback, and mastery tracking.
+
+The goal is durable understanding, not passive explanation.
+
+## Core idea
+
+```text
+The human maintainer is not a rubber stamp.
+The human maintainer is a student-maintainer for concepts that affect architecture, governance, and high-impact decisions.
+```
+
+## Ecosystem roles
+
+```text
+Streeling = curriculum, concept graph, learning paths, source artifacts
+TARS /teach = interactive teaching command and user experience
+Seldon = adaptive tutoring engine, assessment, retry, escalation
+IX = mastery metrics, weak-area detection, spaced-review signals
+Demerzel = decision-readiness signal for high-impact choices
+Human = student-maintainer
+```
+
+## Command surface
+
+```text
+/teach <topic>
+/teach <topic> --level beginner|intermediate|advanced
+/teach <topic> --quick-check
+/teach <topic> --quiz
+/teach <topic> --exam
+/teach <topic> --teach-back
+/teach <topic> --review-missed
+/teach <topic> --spaced-review
+```
+
+## Teaching loop
+
+```text
+select concept
+-> explain
+-> worked example
+-> active recall
+-> quiz
+-> teach-back
+-> applied scenario
+-> feedback
+-> mastery update
+-> next review recommendation
+```
+
+## Lesson structure
+
+Every lesson should include:
+
+- concept id;
+- concept name;
+- why it matters for the project;
+- short explanation;
+- concrete repo example;
+- counterexample;
+- common misconception;
+- one applied exercise;
+- quick-check questions;
+- teach-back prompt;
+- mastery rubric;
+- next concept links;
+- source artifacts to read.
+
+## Assessment modes
+
+```text
+quick_check      = 1-3 questions
+quiz             = 5-10 questions
+teach_back       = user explains concept in their own words
+scenario_exam    = apply concept to a project decision
+review_missed    = revisit weak areas
+spaced_review    = later recall prompt
+```
+
+## Mastery rubric
+
+```text
+0 = not introduced
+1 = recognizes term
+2 = can explain basic idea
+3 = can apply to a project example
+4 = can critique edge cases
+5 = can teach it back and use it in decisions
+```
+
+A quiz score alone is not mastery.
+
+Mastery requires some combination of:
+
+- recall;
+- explanation;
+- applied use;
+- counterexample recognition;
+- scenario transfer;
+- teach-back quality.
+
+## Initial curriculum
+
+```text
+Module 1 — AFK operating model
+Module 2 — Abstraction wall and evidence ladder
+Module 3 — Verification horizon
+Module 4 — Goodhart and anti-metric gaming
+Module 5 — Anti-rubber-stamp human review
+Module 6 — Demerzel objective stack
+Module 7 — TARS intent verification
+Module 8 — IX causal and argumentation support
+Module 9 — Architecture decision gates
+Module 10 — Post-merge retrospectives and compounding learning
+```
+
+## Session output contract
+
+A `/teach` session should produce a structured learning artifact:
+
+```text
+lesson_id
+topic
+level
+concept_ids
+questions_asked
+answers_summary
+misconceptions_detected
+mastery_before
+mastery_after
+mastery_delta
+next_review_due_optional
+recommended_next_topics
+project_artifacts_to_read
+```
+
+## Decision readiness
+
+For high-impact architecture or governance decisions, Demerzel may ask whether the relevant concepts have been introduced and understood.
+
+This must be a readiness signal, not an automatic permission system.
+
+```text
+learning_state informs decision readiness
+learning_state does not replace human authority
+```
+
+## Non-goals
+
+- No punitive grading.
+- No fake mastery based on passive reading.
+- No endless quiz spam.
+- No automatic architecture decision based on quiz score.
+- No private personal data beyond explicit learning-state artifacts chosen by the maintainer.

--- a/v2/examples/teaching/learning-state.example.json
+++ b/v2/examples/teaching/learning-state.example.json
@@ -1,0 +1,77 @@
+{
+  "version": "1.0",
+  "student_id": "maintainer-local",
+  "profile": {
+    "role": "student-maintainer",
+    "preferred_mode": "project-example-first",
+    "notes": "Learning state is explicit and local-first. Do not infer private personal data."
+  },
+  "concepts": [
+    {
+      "concept_id": "anti-rubber-stamp-review",
+      "concept_name": "Anti-Rubber-Stamp Human Review",
+      "source": {
+        "repo": "GuitarAlchemist/Demerzel",
+        "issues": [632, 634],
+        "docs": [
+          "docs/governance/human-review/anti-rubber-stamp-policy.md",
+          "docs/governance/human-review/review-mode-router.md"
+        ]
+      },
+      "attempt_count": 1,
+      "last_seen_at": "2026-07-01",
+      "quick_check_score": 0.8,
+      "quiz_score": 0.7,
+      "teach_back_score": 0.6,
+      "scenario_score": 0.5,
+      "misconceptions_detected": [
+        "human-in-the-loop means asking for confirmation on every action"
+      ],
+      "mastery_level_before": 1,
+      "mastery_level_after": 3,
+      "mastery_delta": 2,
+      "forgetting_risk": "medium",
+      "next_review_due_optional": "2026-07-08",
+      "recommended_next_concepts": [
+        "review-mode-router",
+        "verification-horizon",
+        "goodhart-risk"
+      ]
+    },
+    {
+      "concept_id": "goodhart-risk",
+      "concept_name": "Goodhart and Anti-Metric Gaming",
+      "source": {
+        "repo": "GuitarAlchemist/.github",
+        "issues": [26]
+      },
+      "attempt_count": 0,
+      "last_seen_at": null,
+      "quick_check_score": null,
+      "quiz_score": null,
+      "teach_back_score": null,
+      "scenario_score": null,
+      "misconceptions_detected": [],
+      "mastery_level_before": 0,
+      "mastery_level_after": 0,
+      "mastery_delta": 0,
+      "forgetting_risk": "unknown",
+      "next_review_due_optional": null,
+      "recommended_next_concepts": []
+    }
+  ],
+  "session_history": [
+    {
+      "lesson_id": "teach-anti-rubber-stamp-001",
+      "topic": "anti-rubber-stamp-review",
+      "mode": "teach-back",
+      "completed_at": "2026-07-01",
+      "summary": "Learner can explain why too many confirmations create approval fatigue; needs more scenario practice."
+    }
+  ],
+  "interpretation_notes": [
+    "Scores are learning signals, not authority signals.",
+    "A high quiz score alone is not mastery.",
+    "Decision readiness requires applied understanding and human judgment."
+  ]
+}

--- a/v2/examples/teaching/sessions/teach-anti-rubber-stamp-001.md
+++ b/v2/examples/teaching/sessions/teach-anti-rubber-stamp-001.md
@@ -1,0 +1,110 @@
+# `/teach` Session Example — Anti-Rubber-Stamp Review
+
+## Metadata
+
+```yaml
+lesson_id: teach-anti-rubber-stamp-001
+concept_id: anti-rubber-stamp-review
+date: 2026-07-01
+mode:
+  - quick-check
+  - teach-back
+student_role: student-maintainer
+```
+
+## Prompt
+
+```text
+/teach anti-rubber-stamp-review --quick-check --teach-back
+```
+
+## Questions
+
+1. Why can asking the human to approve everything make decisions worse?
+2. Which review mode fits a docs-only, reversible, known-safe PR?
+3. Which review mode fits a decision that changes the architecture boundary between TARS and IX?
+4. What is the difference between fast-review and focused-review?
+5. Teach-back: explain anti-rubber-stamp review as if teaching another maintainer.
+
+## Student answers summary
+
+```text
+1. Asking the human for everything causes blind approval.
+2. Use a docs-only/safe mode.
+3. Use an important architecture decision mode.
+4. Fast review is surface-level for low-risk items.
+5. Anti-rubber-stamp means the AI should verify that decisions are not applied blindly, and that a human or another agent weighed pros and cons using verifiable facts and logic.
+```
+
+## Evaluation
+
+```yaml
+mastery_level: 3
+mastery_delta: 2
+status: concept assimilated; routing vocabulary should be strengthened
+```
+
+## Strong points
+
+- Correctly identified blind approval as the key risk.
+- Correctly recognized low-risk docs work as lightweight review.
+- Correctly recognized architecture boundary changes as important decisions.
+- Good teach-back emphasis on evidence, logic, and weighing pros/cons.
+
+## Weak areas
+
+- Exact review-mode names should be reinforced:
+  - `fast-review`
+  - `focused-review`
+  - `decision-gate`
+- The concept should be framed as routing before the decision, not only checking after the decision.
+
+## Misconception detected
+
+```text
+Anti-rubber-stamp review is only a post-decision verification step.
+```
+
+Correction:
+
+```text
+Anti-rubber-stamp review primarily routes work before the human is asked:
+classify, batch, fast-review, focused-review, decision-gate, or escalate-review.
+```
+
+## Improved teach-back
+
+```text
+The anti-rubber-stamp principle prevents the human from mechanically approving every AI action. The system should first classify the decision type: low-risk, targeted judgment, or major architecture/governance decision. The human should only be asked when their judgment can materially change the result. Important decisions must expose options, risks, verifiable evidence, and the reasoning behind the recommendation.
+```
+
+## Next recommended concept
+
+```text
+review-mode-router
+```
+
+Goal:
+
+```text
+Memorize the six review modes and apply them to real project scenarios.
+```
+
+## Learning-state update candidate
+
+```json
+{
+  "concept_id": "anti-rubber-stamp-review",
+  "mastery_level_before": 1,
+  "mastery_level_after": 3,
+  "mastery_delta": 2,
+  "misconceptions_detected": [
+    "Anti-rubber-stamp review is only a post-decision verification step."
+  ],
+  "recommended_next_concepts": [
+    "review-mode-router",
+    "verification-horizon",
+    "goodhart-risk"
+  ]
+}
+```

--- a/v2/templates/teaching/lesson-template.md
+++ b/v2/templates/teaching/lesson-template.md
@@ -1,0 +1,94 @@
+# `/teach` Lesson Template
+
+## Metadata
+
+```yaml
+lesson_id: ""
+concept_id: ""
+concept_name: ""
+level: beginner|intermediate|advanced
+source_artifacts: []
+prerequisites: []
+next_concepts: []
+```
+
+## Why this matters
+
+Explain why this concept matters for TARS, IX, Demerzel, GA, or AFK work.
+
+## Short explanation
+
+Keep the explanation short and concrete.
+
+## Project example
+
+Show the concept using a real project artifact, issue, PR, policy, or repo boundary.
+
+## Counterexample
+
+Show a plausible incorrect use of the concept.
+
+## Common misconception
+
+Describe one misconception the learner may have.
+
+## Worked example
+
+Walk through one example step by step.
+
+## Active recall
+
+Ask the learner to recall the concept without looking back.
+
+```text
+Question:
+
+Expected answer shape:
+```
+
+## Quick check
+
+1.
+2.
+3.
+
+## Teach-back prompt
+
+Ask the learner to explain the concept in their own words.
+
+```text
+Explain this concept as if you were teaching it to another maintainer.
+```
+
+## Scenario exam
+
+Give a realistic project decision and ask the learner to apply the concept.
+
+```text
+Scenario:
+
+Decision to make:
+
+What concept applies?
+What evidence is needed?
+What would be a bad decision?
+```
+
+## Mastery rubric
+
+```text
+0 = not introduced
+1 = recognizes term
+2 = can explain basic idea
+3 = can apply to a project example
+4 = can critique edge cases
+5 = can teach it back and use it in decisions
+```
+
+## Feedback notes
+
+- Misconceptions detected:
+- Strong points:
+- Weak areas:
+- Suggested next review:
+- Suggested next concept:


### PR DESCRIPTION
Docs/templates/examples only.

Adds the first-pass `/teach` skill contract and connects it to Seldon, Streeling, IX, and Demerzel.

Related: #164, #95, GuitarAlchemist/ix#217.