### PR TITLE
fix(afk): self-heal jules label + dead-letter sweep in AFK router (ga mirror)

### DIFF
--- a/.github/workflows/afk-router.yml
+++ b/.github/workflows/afk-router.yml
@@ -30,6 +30,12 @@ name: Auto-delegate to AFK agent
 on:
   issues:
     types: [labeled]
+  # Dead-letter sweep: issues labeled ready-for-agent before this workflow
+  # existed (or while it was broken) never produce a `labeled` event again.
+  # The daily sweep (and manual dispatch) re-routes them.
+  workflow_dispatch:
+  schedule:
+    - cron: '17 6 * * *'
 
 permissions:
   contents: read
@@ -39,7 +45,7 @@ jobs:
   delegate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ github.event.label.name == 'ready-for-agent' }}
+    if: ${{ github.event_name == 'issues' && github.event.label.name == 'ready-for-agent' }}
     steps:
       - name: Checkout (read the governance halt marker)
         uses: actions/checkout@v4
@@ -103,6 +109,11 @@ jobs:
         run: |
           case "$AGENT" in
             jules)
+              # Self-heal: the label must exist before gh can apply it (the ga
+              # mirror failed with "'jules' not found"); --force also repairs
+              # color/description if the label was auto-created bare.
+              gh label create jules --repo "$REPO" --color 1A73E8 \
+                --description "Delegate this issue to Google Jules" --force
               gh issue edit "$ISSUE" --repo "$REPO" --add-label jules
               echo "Delegated issue #${ISSUE} to Jules (\`jules\` label, PAT-attributed)." ;;
             codex)
@@ -114,3 +125,63 @@ jobs:
             *)
               echo "::error::unknown agent '$AGENT'"; exit 1 ;;
           esac
+
+  # Dead-letter sweep: re-route open ready-for-agent issues that never got
+  # delegated. Only the Jules default lane is swept (detectable by the absence
+  # of the `jules` label); worker:codex / worker:claude lanes are comment-
+  # triggered and are skipped to avoid duplicate @-mentions — re-apply the
+  # ready-for-agent label on those to re-trigger them manually.
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Checkout (read the governance halt marker)
+        uses: actions/checkout@v4
+
+      - name: Governance halt-gate + preflight
+        id: gate
+        env:
+          HAS_PAT: ${{ secrets.PAT_TOKEN != '' }}
+        run: |
+          MARKER="governance/state/afk-halt.json"
+          if [ -f "$MARKER" ]; then
+            EXPIRES=$(jq -r '.expires_at // empty' "$MARKER" 2>/dev/null || true)
+            HALTED=true
+            if [ -n "$EXPIRES" ]; then
+              NOW=$(date -u +%s)
+              EXP=$(date -u -d "$EXPIRES" +%s 2>/dev/null || echo 0)
+              if [ "$EXP" -gt 0 ] && [ "$NOW" -ge "$EXP" ]; then
+                HALTED=false
+              fi
+            fi
+            if [ "$HALTED" = "true" ]; then
+              echo "::notice::AFK delegation halted by governance marker — skipping sweep"
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          if [ "$HAS_PAT" != "true" ]; then
+            echo "::warning::PAT_TOKEN not configured — skipping sweep"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Sweep undelegated ready-for-agent issues (PAT-attributed)
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create jules --repo "$REPO" --color 1A73E8 \
+            --description "Delegate this issue to Google Jules" --force
+          SWEPT=0
+          for ISSUE in $(gh issue list --repo "$REPO" --state open \
+              --label ready-for-agent --json number,labels \
+              --jq '.[] | select([.labels[].name] | any(. == "jules" or . == "worker:codex" or . == "worker:claude") | not) | .number'); do
+            gh issue edit "$ISSUE" --repo "$REPO" --add-label jules
+            echo "::notice::Swept issue #${ISSUE} to Jules (dead-letter re-route)"
+            SWEPT=$((SWEPT+1))
+          done
+          echo "::notice::Sweep complete — ${SWEPT} issue(s) re-routed"


### PR DESCRIPTION
## Summary

Mirror of the router fix proven in `ga` ([ga#494](https://github.com/GuitarAlchemist/ga/pull/494), merged): the ga router's first real run failed with `'jules' not found` because the `jules` label had never been created there. tars happens to have the label already, but carries the same latent fragility and the same dead-letter blind spot (issues labeled `ready-for-agent` before the router existed never produce a `labeled` event again).

## Linked issue(s)

Parent / issue:
- Follow-up to GuitarAlchemist/ga#494 (merged)

Related:
- ADR 0004 (jules-action path abandoned; PAT-attributed label triggers)

## Scope

In scope:
- `gh label create jules --force` before each Jules delegation (idempotent create + color/description repair)
- `schedule` (daily 06:17 UTC) + `workflow_dispatch` triggers and a `sweep` job re-routing open `ready-for-agent` issues lacking the `jules` label
- Guard the existing `delegate` job with `github.event_name == 'issues'`

Out of scope:
- `worker:codex` / `worker:claude` lanes in the sweep (comment-triggered; sweeping would duplicate @-mentions)
- Any change to routing logic, governance gates, or agent-blackbox

## Boundary contract

Namespace affected:
- `.github/workflows/afk-router.yml` only

Contract changed:
- [x] no

Expected dependencies touched:
- `PAT_TOKEN` secret (already required), `governance/state/afk-halt.json` gate (honored by the sweep)

Dependencies intentionally avoided:
- No new labels, docs, or policy edits

Derived state kept derived:
- [x] yes

Boundary notes:
- Delegation stays PAT-attributed; agents open PRs, never merge.

## Business value

Outcome supported:
- AFK delegation can't silently strand labeled issues in tars

How this PR helps:
- Same two failure modes removed as in ga: missing label (hard failure) and pre-router labels (silent dead letter).

## Review mode

Mode:
- fast-review

Reason:
- Byte-for-byte mirror of the reviewed, merged ga change, adapted to this file's comments.

Human question, if any:
- None

Safe default:
- Merge; revert restores previous behavior.

## Evidence

Changed files:
- `.github/workflows/afk-router.yml` (+75/−1)

Checks:
- YAML validated locally; source change merged and live in ga (`b21e839`)

Manual review notes:
- The delegate job is unchanged apart from the event-name guard and the self-heal lines.

Risks:
- Low; worst case the sweep no-ops

Rollback / reversibility:
- Fully reversible via git revert

## Acceptance criteria

- [x] Scope is narrow and reviewable.
- [x] Boundary impact is explicit.
- [x] Evidence is sufficient for the selected review mode.
- [x] Non-goals are respected.
- [ ] Linked issue has hierarchy and business value.
- [x] Follow-up issues are created if scope was split. (none needed)

## Post-merge learning

Retrospective needed?
- [x] no

Pattern / anti-pattern candidate:
- Pattern: fix proven in one repo mirrored at the same pinned semantics in the sibling

Memory update needed?
- [x] no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih

---
_Generated by [Claude Code](https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih)_