### PR TITLE
docs(teach): drop deleted triage-reasoning doc from lesson source artifacts

### DIFF
--- a/v2/docs/teaching/lessons/review-mode-router.md
+++ b/v2/docs/teaching/lessons/review-mode-router.md
@@ -7,7 +7,7 @@ lesson_id: "teach-review-mode-router-001"
 concept_id: "review-mode-router"
 concept_name: "Review Mode Router"
 level: intermediate
-source_artifacts: ["docs/triage/methodology-guard-triage-reasoning.md", "v2/examples/teaching/sessions/teach-anti-rubber-stamp-001.md"]
+source_artifacts: ["v2/examples/teaching/sessions/teach-anti-rubber-stamp-001.md"]
 prerequisites: ["anti-rubber-stamp-review"]
 next_concepts: ["verification-horizon", "goodhart-risk"]
 ```


### PR DESCRIPTION
## Summary

One-line metadata fix in the just-merged #172 lesson pack: `review-mode-router.md` cited `docs/triage/methodology-guard-triage-reasoning.md` as a source artifact — that draft was deleted earlier today in #171, so the reference is dead.

## Linked issue(s)

Parent / issue:
- Follow-up to #172 (lesson pack, merged) and #171 (doc deletion, merged)

Related:
- tars#166 (closed by #172)

## Scope

In scope:
- Remove the dead path from the lesson's `source_artifacts` YAML list

Out of scope:
- Any content change to the lessons

## Boundary contract

Namespace affected:
- `v2/docs/teaching/` only

Contract changed:
- [x] no

Expected dependencies touched:
- None

Dependencies intentionally avoided:
- All

Derived state kept derived:
- [x] yes

Boundary notes:
- None

## Business value

Outcome supported:
- No dead references reintroduced the same day the cleanup happened

How this PR helps:
- Keeps lesson metadata grep-truthful.

## Review mode

Mode:
- fast-review

Reason:
- One line, docs metadata.

Human question, if any:
- None

Safe default:
- Merge.

## Evidence

Changed files:
- `v2/docs/teaching/lessons/review-mode-router.md` (−1 path in a YAML list)

Checks:
- Repo-wide grep: no other reference to the deleted doc remains

Manual review notes:
- None

Risks:
- None

Rollback / reversibility:
- git revert

## Acceptance criteria

- [x] Scope is narrow and reviewable.
- [x] Boundary impact is explicit.
- [x] Evidence is sufficient for the selected review mode.
- [x] Non-goals are respected.

## Post-merge learning

Retrospective needed?
- [x] no

Pattern / anti-pattern candidate:
- None

Memory update needed?
- [x] no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih

---
_Generated by [Claude Code](https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih)_