### PR TITLE
fix(afk): checkout repo before claude-code-action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,6 +21,11 @@ jobs:
        github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'COLLABORATOR')
     steps:
+      # Required: the action's branch setup runs git against the workspace and
+      # fails with "not a git repository" without a checkout (run 28550132148).
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
       - uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Every `@claude` delegation on tars fails at branch setup with `fatal: not a git repository` ([run 28550132148](https://github.com/GuitarAlchemist/tars/actions/runs/28550132148), issues #115/#132): `claude.yml` invokes `anthropics/claude-code-action@v1` without checking out the repository first. ga's equivalent workflow has the checkout and works. One added step.

**Separate, operator-only blocker:** `CLAUDE_CODE_OAUTH_TOKEN` is empty at org level (visible in the claude-code-review run env), so even after this fix the action will stop at env validation until `claude setup-token` + `gh secret set CLAUDE_CODE_OAUTH_TOKEN --org GuitarAlchemist` is run — exactly as the comment inside this workflow documents.

## Scope

In scope:
- `actions/checkout@v4` (fetch-depth 1) before the action in `.github/workflows/claude.yml`

Out of scope:
- Secrets provisioning; claude-code-review.yml (same secret issue, no workflow bug found)

## Review mode

Mode:
- fast-review

Reason:
- One added step matching the working ga pattern; failure evidence in run logs.

Risks / rollback:
- None / git revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih

---
_Generated by [Claude Code](https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih)_