### PR TITLE
feat(afk): temporary API-key fallback for @claude lane + cost-safe review gate

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,12 +24,27 @@ jobs:
       id-token: write
 
     steps:
+      # Cost-safe: auto-review runs ONLY on the $0 subscription token. Without
+      # it, skip green instead of failing red on every PR — and never fall back
+      # to the pay-per-use ANTHROPIC_API_KEY here (this fires on every PR).
+      - name: Gate on subscription token presence
+        id: gate
+        env:
+          HAS_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+        run: |
+          if [ "$HAS_OAUTH" != "true" ]; then
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN not set — skipping auto-review (subscription-only lane)."
+          fi
+          echo "ok=$HAS_OAUTH" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
+        if: steps.gate.outputs.ok == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
+        if: steps.gate.outputs.ok == 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,11 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Subscription OAuth token ($0/call), never the pay-per-use ANTHROPIC_API_KEY.
-          # Set org-wide via: claude setup-token && gh secret set CLAUDE_CODE_OAUTH_TOKEN --org GuitarAlchemist
+          # Subscription OAuth token ($0/call) — preferred. Set org-wide via:
+          # claude setup-token && gh secret set CLAUDE_CODE_OAUTH_TOKEN --org GuitarAlchemist
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # TEMPORARY pay-per-use fallback (2026-07-01): remove once the OAuth
+          # token is provisioned, then revoke the key. This lane only fires on
+          # explicit @claude mentions from OWNER/MEMBER/COLLABORATOR, so spend
+          # is human-initiated and bounded.
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

Operator provisioned an org-level `ANTHROPIC_API_KEY` (pay-per-use) from mobile since the subscription OAuth token requires a terminal. Cost-conscious wiring:

- **`claude.yml` (@claude delegation lane)**: accepts `anthropic_api_key` as a **temporary** fallback. This lane only fires on explicit `@claude` mentions from OWNER/MEMBER/COLLABORATOR — spend is human-initiated and bounded. Marked for removal once `CLAUDE_CODE_OAUTH_TOKEN` exists.
- **`claude-code-review.yml` (fires on every non-draft PR)**: deliberately does NOT get the API key — a per-PR auto-review on pay-per-use would be an unbounded spend leak. Instead it now gates on the OAuth token and skips green instead of failing red on every PR while the token is absent.

## Scope

In scope:
- The two workflow auth blocks above

Out of scope:
- ga's claude.yml (same dead lane; will follow after this chain is validated on tars, or becomes moot once the OAuth token is set)

## Review mode

Mode:
- fast-review

Reason:
- Additive auth inputs + a skip gate; no behavior change when the OAuth token exists.

Risks / rollback:
- Bounded API spend on explicit @claude mentions only; revert restores OAuth-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih

---
_Generated by [Claude Code](https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih)_