### PR TITLE
feat(afk): inject declared cloud-agent skills into Jules prompts (#115)

### DIFF
--- a/.github/scripts/afk-inject-skills.sh
+++ b/.github/scripts/afk-inject-skills.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# afk-inject-skills.sh — skill-injection hook for the Jules AFK prompt path (issue #115).
+#
+# The Jules lane of the AFK router (.github/workflows/afk-router.yml) delegates by
+# applying the `jules` label; Jules then reads the *issue thread* as its prompt. This
+# hook lets an issue *declare* which cloud-agent skills apply, resolves them against a
+# small allowlist under docs/agents/skills/, and posts the matching skill docs as a
+# single governed comment so they become part of what Jules reads.
+#
+# Declaration (either form, unioned):
+#   1. YAML in the issue body:      agent_skills:
+#                                     - docs-only-contract
+#                                     - evidence-bundle
+#   2. Labels:                      skill:docs-only-contract
+#
+# Safety invariants (see docs/agents/skills/README.md):
+#   - Never reads arbitrary paths from issue content. Declared names are sanitized to
+#     ^[a-z0-9-]+$ and can only ever resolve to docs/agents/skills/<name>.skill.md,
+#     which must already exist. Anything else (path traversal, unknown skill) is dropped.
+#   - The allowlist is derived from the *.skill.md files actually present in the repo,
+#     so it can never point outside the curated skill library.
+#   - If no valid skill is declared, the script exits 0 without commenting — current
+#     behavior is preserved (backward compatible).
+#   - This hook only injects context; it never applies/removes labels, never triggers,
+#     and does not touch the halt gate or the PAT preflight (those stay in the workflow).
+#
+# Environment:
+#   REPO         owner/name of the repo             (required unless AFK_INJECT_DRYRUN=1)
+#   ISSUE        issue number                        (required unless AFK_INJECT_DRYRUN=1)
+#   GH_TOKEN     token used for `gh issue comment`   (required unless AFK_INJECT_DRYRUN=1)
+#   ISSUE_BODY   override issue body (skips gh read; used for tests/dry-run)
+#   ISSUE_LABELS override labels, one per line       (used for tests/dry-run)
+#   AFK_INJECT_DRYRUN=1  print the assembled prompt to stdout instead of posting it
+#
+# Exit codes: 0 = injected or nothing-to-do (both are success). Non-zero only on a
+# genuine failure (e.g. `gh` unavailable when a post was required).
+set -euo pipefail
+# noglob: declared names are untrusted issue content that we word-split below; a token
+# like `*` must never undergo pathname expansion. The allowlist check uses direct
+# `-f` file tests (not globs), so disabling globbing here is safe.
+set -f
+
+SKILL_DIR="docs/agents/skills"
+
+# --- gather inputs -----------------------------------------------------------------
+body="${ISSUE_BODY-}"
+labels="${ISSUE_LABELS-}"
+if [ -z "${body}${labels}" ] && [ "${AFK_INJECT_DRYRUN:-0}" != "1" ]; then
+  body=$(gh issue view "$ISSUE" --repo "$REPO" --json body --jq '.body // ""')
+  labels=$(gh issue view "$ISSUE" --repo "$REPO" --json labels --jq '.labels[].name')
+fi
+
+# --- collect declared skill names --------------------------------------------------
+# (a) the `agent_skills:` YAML list in the body: the list header followed by `- name`
+#     lines, stopping at the first line that is neither blank nor a `-` list item.
+declared=$(printf '%s\n' "$body" | awk '
+  /^[[:space:]]*agent_skills:[[:space:]]*$/ { grab=1; next }
+  grab==1 {
+    if ($0 ~ /^[[:space:]]*-[[:space:]]*[^[:space:]]/) {
+      line=$0; sub(/^[[:space:]]*-[[:space:]]*/, "", line); sub(/[[:space:]].*$/, "", line); print line
+    } else if ($0 ~ /^[[:space:]]*$/) {
+      next
+    } else { grab=0 }
+  }
+')
+
+# (b) `skill:<name>` labels.
+label_skills=$(printf '%s\n' "$labels" | sed -n 's/^skill:\(.*\)$/\1/p')
+
+# --- resolve against the allowlist -------------------------------------------------
+# Allowlist = basenames of the *.skill.md files that actually exist. A declared name
+# is accepted only if it is [a-z0-9-]+ AND docs/agents/skills/<name>.skill.md exists.
+selected=""
+seen=" "
+for raw in $declared $label_skills; do
+  name=$(printf '%s' "$raw" | tr -d '[:space:]')
+  case "$name" in
+    *[!a-z0-9-]*|"" ) continue ;;   # reject anything outside the safe charset
+  esac
+  case "$seen" in *" $name "*) continue ;; esac   # dedupe
+  if [ -f "$SKILL_DIR/$name.skill.md" ]; then
+    selected="$selected $name"
+    seen="$seen$name "
+  else
+    echo "::notice::afk-inject-skills: dropping undeclared/unknown skill '$name' (no $SKILL_DIR/$name.skill.md)" >&2
+  fi
+done
+selected=$(printf '%s' "$selected" | sed 's/^ *//')
+
+if [ -z "$selected" ]; then
+  echo "::notice::afk-inject-skills: no allowlisted skills declared — preserving default behavior" >&2
+  # Emit an empty selection marker so the workflow can record it in evidence if it wants.
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then echo "selected=" >> "$GITHUB_OUTPUT"; fi
+  exit 0
+fi
+
+# --- assemble the prompt comment ---------------------------------------------------
+comment=$(
+  printf '### 🧩 Declared cloud-agent skills (auto-injected)\n\n'
+  printf 'This issue declared the skills below (via `agent_skills:` and/or `skill:*` labels). '
+  printf 'They are reproduced here from `%s/` so the cloud agent applies them while working this issue. '
+  printf 'Follow every skill contract; report the requested evidence in the PR body.\n\n' "$SKILL_DIR"
+  printf 'Selected skills:'
+  for name in $selected; do printf ' `%s`' "$name"; done
+  printf '\n'
+  for name in $selected; do
+    printf '\n<details>\n<summary><code>%s.skill.md</code></summary>\n\n' "$name"
+    cat "$SKILL_DIR/$name.skill.md"
+    printf '\n</details>\n'
+  done
+)
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "selected=$(printf '%s' "$selected" | tr ' ' ',')" >> "$GITHUB_OUTPUT"
+fi
+
+if [ "${AFK_INJECT_DRYRUN:-0}" = "1" ]; then
+  printf '%s\n' "$comment"
+  exit 0
+fi
+
+printf '%s' "$comment" | gh issue comment "$ISSUE" --repo "$REPO" --body-file -
+echo "::notice::afk-inject-skills: injected skills [$(printf '%s' "$selected" | tr ' ' ',')] into issue #$ISSUE"

--- a/docs/agents/skills/README.md
+++ b/docs/agents/skills/README.md
@@ -14,3 +14,91 @@ Cloud agents cannot access local TARS skills or local MCP state. However, they c
 ## Usage
 
 Cloud agents should parse the `issue_meta` block in the GitHub issue body and use these definitions to guide their approach, ensuring that they respect project constraints, execute required checks, and provide the expected evidence in the pull request body.
+
+## Declaring skills on an issue
+
+An issue can declare which of the skills above apply. The AFK router resolves the
+declaration against the allowlist (below) and injects the matching skill docs into the
+Jules prompt path (see "Injection hook"). Two equivalent forms — they are unioned and
+de-duplicated:
+
+1. **YAML in the issue body** (preferred — travels with the issue):
+
+   ```yaml
+   agent_skills:
+     - docs-only-contract
+     - evidence-bundle
+   ```
+
+2. **Labels** (useful when triaging without editing the body):
+
+   ```text
+   skill:docs-only-contract
+   skill:evidence-bundle
+   ```
+
+If nothing is declared, the router behaves exactly as before — no comment is posted and
+no behavior changes (backward compatible).
+
+## Allowlist (skill-selection rules)
+
+The allowlist is **derived from the files that exist here**, never from issue content:
+
+- A declared name is accepted only if it matches `^[a-z0-9-]+$` **and**
+  `docs/agents/skills/<name>.skill.md` exists. Currently that means:
+  `docs-only-contract`, `evidence-bundle`, `governed-delegation`, `anti-ball-of-mud`.
+- Supporting docs without a `.skill.md` suffix (e.g. `codebase-design-vocabulary.md`)
+  are intentionally **not** selectable — they are references, not skill contracts.
+- Any name that fails the charset check (path traversal like `../../etc/passwd`,
+  absolute paths, spaces) or does not resolve to an existing `*.skill.md` file is
+  dropped with a `::notice::` and never read.
+
+## Injection hook
+
+`.github/scripts/afk-inject-skills.sh` implements the hook. Given an issue's body and
+labels it: collects declared names → filters to the allowlist → posts a **single**
+governed comment reproducing the selected skill docs so Jules reads them as part of the
+issue thread (Jules's prompt is the issue thread — the Jules lane delegates by label,
+not by an API prompt). Run it in dry-run to preview:
+
+```bash
+AFK_INJECT_DRYRUN=1 ISSUE_BODY="$(gh issue view 115 --json body --jq .body)" \
+  ISSUE_LABELS="$(gh issue view 115 --json labels --jq '.labels[].name')" \
+  bash .github/scripts/afk-inject-skills.sh
+```
+
+### Workflow wiring
+
+The hook is called from the Jules lane of `.github/workflows/afk-router.yml`, **after**
+the halt-gate + PAT preflight and only when routing to Jules, so neither guard is
+touched:
+
+```yaml
+      - name: Inject declared skills into the Jules prompt (issue #115)
+        if: steps.gate.outputs.proceed == 'true' && steps.gate.outputs.agent == 'jules'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: bash .github/scripts/afk-inject-skills.sh
+```
+
+> The `GH_TOKEN` here uses the default `github.token`: this step only *posts context*
+> that Jules reads, it does not *trigger* Jules, so it does not need the user-attributed
+> PAT (the label application in the next step remains PAT-attributed).
+
+### Safety notes
+
+- **No arbitrary path reads.** Declared names are sanitized and can only ever resolve to
+  `docs/agents/skills/<name>.skill.md`. Public commenters cannot point the hook at any
+  other file.
+- **Allowlist-gated.** Only the curated `*.skill.md` files are selectable.
+- **Halt gate & PAT preflight intact.** The hook runs downstream of both and changes
+  neither; it never applies/removes labels and never merges.
+- **Backward compatible.** No declaration ⇒ no comment ⇒ current behavior.
+- **Evidence.** The step exports `selected=<comma-list>` on `$GITHUB_OUTPUT`, so the
+  selected skills can be surfaced in run logs / PR evidence.
+
+See `examples/agents/skill-selection.example.json` for a worked selection and
+`examples/agents/skill-injection.example.json` for a worked injection (including how
+hostile input is dropped).

--- a/examples/agents/skill-injection.example.json
+++ b/examples/agents/skill-injection.example.json
@@ -1,0 +1,34 @@
+{
+  "scenario": "AFK router resolves declared skills for an issue routed to Jules, then injects the matching skill docs into the issue thread (Jules's prompt). Demonstrates the allowlist gate and safe handling of hostile input.",
+  "hook": ".github/scripts/afk-inject-skills.sh",
+  "input": {
+    "issue_body_excerpt": "agent_skills:\n  - docs-only-contract\n  - ../../etc/passwd\n  - not-a-real-skill",
+    "issue_labels": ["ready-for-agent", "worker:jules", "skill:evidence-bundle"]
+  },
+  "resolution": {
+    "declared_from_body": ["docs-only-contract", "../../etc/passwd", "not-a-real-skill"],
+    "declared_from_labels": ["evidence-bundle"],
+    "allowlist_rule": "name matches ^[a-z0-9-]+$ AND docs/agents/skills/<name>.skill.md exists",
+    "selected": ["docs-only-contract", "evidence-bundle"],
+    "dropped": {
+      "../../etc/passwd": "rejected: fails charset check (path traversal never reaches the filesystem)",
+      "not-a-real-skill": "rejected: no docs/agents/skills/not-a-real-skill.skill.md"
+    }
+  },
+  "prompt_injection_result": {
+    "action": "posts one issue comment titled '🧩 Declared cloud-agent skills (auto-injected)'",
+    "contents": "the full text of docs/agents/skills/docs-only-contract.skill.md and docs/agents/skills/evidence-bundle.skill.md, each in a collapsible <details> block",
+    "github_output": "selected=docs-only-contract,evidence-bundle"
+  },
+  "backward_compatibility": {
+    "scenario": "issue declares no agent_skills and carries no skill:* label",
+    "result": "hook exits 0, posts nothing, sets selected= (empty) — router behaves exactly as before"
+  },
+  "safety_notes": [
+    "Never reads arbitrary paths: declared names can only resolve to docs/agents/skills/<name>.skill.md.",
+    "Allowlist derived from *.skill.md files present in the repo, not from issue content.",
+    "Runs downstream of the governance halt-gate and PAT preflight; touches neither.",
+    "Injection uses github.token (posts context Jules reads); the Jules trigger label stays PAT-attributed.",
+    "Public commenters cannot select non-skill files or point the hook outside the skill library."
+  ]
+}


### PR DESCRIPTION
## Summary

Implements #115 (authored by the `@claude` delegation lane, run [28559235787](https://github.com/GuitarAlchemist/tars/actions/runs/28559235787), 6m34s — first successful run of the repaired lane). Adds an allowlist-gated skill-injection hook (`.github/scripts/afk-inject-skills.sh`): an issue can declare cloud-agent skills via `agent_skills:` YAML or `skill:*` labels, and the hook posts the matching skill docs from `docs/agents/skills/` as one governed comment on the Jules prompt path.

Reviewed file-by-file: safe-charset gate (`^[a-z0-9-]+$`), allowlist derived from the `*.skill.md` files that actually exist (no arbitrary path reads), `set -f` noglob hardening, dedupe, `AFK_INJECT_DRYRUN=1`, and no-declaration ⇒ no-op (backward compatible). Halt gate and PAT preflight untouched.

## Scope

In scope:
- `.github/scripts/afk-inject-skills.sh` (new hook)
- `docs/agents/skills/README.md` (declaration convention + wiring snippet)
- `examples/agents/skill-injection.example.json`

Out of scope:
- The one-line workflow wiring in `afk-router.yml` — the delegation bot cannot edit `.github/workflows/`; follows in the next PR

Fixes #115

## Review mode

Mode:
- focused-review (new script on the delegation path)

Evidence:
- Hostile-input handling verified by inspection (noglob + charset + `-f` existence test); dry-run mode available for local verification

Risks / rollback:
- Inert until wired into the workflow / git revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih

---
_Generated by [Claude Code](https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih)_