### PR TITLE
feat(afk): wire the skill-injection hook into the Jules lane

### DIFF
--- a/.github/workflows/afk-router.yml
+++ b/.github/workflows/afk-router.yml
@@ -99,6 +99,14 @@ jobs:
           echo "proceed=true" >> "$GITHUB_OUTPUT"
           echo "::notice::AFK routing issue #${ISSUE} to ${AGENT}"
 
+      - name: Inject declared skills into the Jules prompt (issue #115)
+        if: steps.gate.outputs.proceed == 'true' && steps.gate.outputs.agent == 'jules'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: bash .github/scripts/afk-inject-skills.sh
+
       - name: Trigger the agent (PAT-attributed so the agent doesn't ignore it)
         if: steps.gate.outputs.proceed == 'true'
         env:


### PR DESCRIPTION
## Summary

Completes #115: one step added to `afk-router.yml` calling `afk-inject-skills.sh` (merged in #177), gated on `proceed == 'true' && agent == 'jules'`, placed **before** the `jules` label is applied so declared skill docs are already in the issue thread when Jules starts reading. This is the wiring the delegation bot couldn't push itself (App permission on `.github/workflows/`).

Known limitation, deliberate: the dead-letter sweep re-routes without injection — revisit only if swept issues start declaring skills.

## Scope

In scope:
- One step in the `delegate` job of `.github/workflows/afk-router.yml`

Out of scope:
- The hook itself (#177), the sweep job

## Review mode

Mode:
- fast-review

Reason:
- One gated step invoking a reviewed, allowlist-hardened script; no-op for issues that declare nothing.

Risks / rollback:
- None (no declaration ⇒ no comment) / git revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih

---
_Generated by [Claude Code](https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih)_