### PR TITLE
feat(afk): add Jules PR watchdog for cloud-agent observability (#132)

### DIFF
--- a/.github/scripts/jules-pr-watchdog.sh
+++ b/.github/scripts/jules-pr-watchdog.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# jules-pr-watchdog.sh — classify a Jules-authored PR into a single watchdog state (issue #132).
+#
+# The AFK router (.github/workflows/afk-router.yml) gets cloud-agent work started, but once
+# Jules opens a PR maintainers still have to poll it manually for new commits, CI changes,
+# mergeability, requested-fix follow-through, staleness, and fan-out duplicates. This script
+# is the finer-grained observer: given one PR, it reads the currently-observable signals,
+# classifies the PR into exactly one state from the #132 vocabulary, prints that classification
+# as JSON (machine-readable), and reflects it as a namespaced `jules-state:<state>` label.
+#
+# It is deliberately conservative:
+#   - It NEVER merges and NEVER approves — it only labels, and comments on one transition.
+#   - It comments ONLY on the critical CI-failure transition, once per failing head SHA
+#     (idempotent via a hidden marker), per the issue's minimal-noise requirement.
+#   - It NEVER bypasses Demerzel/human review — `ready-to-merge` is an observation, not an act.
+#   - It respects the governance halt marker `governance/state/afk-halt.json` (present+unexpired
+#     => the watchdog stands down and makes no changes), mirroring the afk-router gate.
+#   - It only touches PRs it recognizes as Jules-authored (see JULES_AUTHOR_PATTERN / `jules`).
+#
+# State artifacts (#136) and the HTML dashboard (#137) are intentionally out of scope: this
+# script is transition detection/classification only. It writes no durable state; "new commit"
+# is carried by the `pull_request.synchronize` trigger and staleness by the PR's own updatedAt.
+#
+# Environment:
+#   REPO         owner/name of the repo                                   (required)
+#   PR           pull-request number to classify                          (required)
+#   GH_TOKEN     token for `gh` (needs pull-requests + issues: write)      (required)
+#   EVENT_NAME   triggering event ("synchronize"|"review"|"schedule"|...)  (optional, hints only)
+#   STALE_DAYS   days of no PR activity before `stale-jules-pr`            (optional, default 3)
+#   EXPECT_PATH  if a changes-requested review targeted this path, the     (optional)
+#                latest commits must touch it to count the fix as addressed
+#   JULES_AUTHOR_PATTERN  case-insensitive login substring marking Jules   (optional, default "jules")
+#
+# Exit codes: 0 on success or benign no-op (halt gate, not-a-jules-PR, PR closed). Non-zero
+# only on a genuine failure (missing required env, `gh` failure on a required call).
+set -euo pipefail
+
+: "${REPO:?REPO is required}"
+: "${PR:?PR is required}"
+STALE_DAYS="${STALE_DAYS:-3}"
+EXPECT_PATH="${EXPECT_PATH:-}"
+EVENT_NAME="${EVENT_NAME:-}"
+JULES_AUTHOR_PATTERN="${JULES_AUTHOR_PATTERN:-jules}"
+
+# All watchdog state labels, namespaced under `jules-state:` (matches the repo's
+# `worker:*` / `skill:*` / `agent:*` label conventions). This is also the mutually
+# exclusive set the script rotates through — applying one removes the others.
+STATE_LABELS=(
+  "jules-state:jules-waiting"
+  "jules-state:jules-updated"
+  "jules-state:needs-human-review"
+  "jules-state:needs-agent-revision"
+  "jules-state:ready-to-merge"
+  "jules-state:stale-jules-pr"
+  "jules-state:duplicate-agent-pr"
+)
+
+log() { echo "::notice::[jules-watchdog] $*"; }
+
+# --- Governance halt gate (mirrors .github/workflows/afk-router.yml) ----------------------
+# Present + unexpired marker => the watchdog stands down and makes no labels/comments.
+halted() {
+  local marker="governance/state/afk-halt.json"
+  [ -f "$marker" ] || return 1
+  local expires now exp
+  expires=$(jq -r '.expires_at // empty' "$marker" 2>/dev/null || true)
+  if [ -n "$expires" ]; then
+    now=$(date -u +%s)
+    exp=$(date -u -d "$expires" +%s 2>/dev/null || echo 0)
+    if [ "$exp" -gt 0 ] && [ "$now" -ge "$exp" ]; then
+      log "afk-halt marker present but expired ($expires) — watchdog proceeding"
+      return 1
+    fi
+  fi
+  return 0
+}
+
+if halted; then
+  log "AFK governance halt is active (governance/state/afk-halt.json) — watchdog standing down."
+  exit 0
+fi
+
+# --- Load the PR --------------------------------------------------------------------------
+PR_JSON=$(gh pr view "$PR" --repo "$REPO" \
+  --json number,state,isDraft,author,labels,headRefOid,updatedAt,mergeable,reviewDecision,body,files \
+  2>/dev/null || echo '')
+if [ -z "$PR_JSON" ]; then
+  log "PR #$PR not found or not readable — nothing to do."
+  exit 0
+fi
+
+STATE=$(jq -r '.state' <<<"$PR_JSON")
+if [ "$STATE" != "OPEN" ]; then
+  log "PR #$PR is $STATE (not OPEN) — watchdog only classifies open PRs."
+  exit 0
+fi
+
+AUTHOR=$(jq -r '.author.login // ""' <<<"$PR_JSON")
+HEAD_SHA=$(jq -r '.headRefOid // ""' <<<"$PR_JSON")
+UPDATED_AT=$(jq -r '.updatedAt // ""' <<<"$PR_JSON")
+MERGEABLE=$(jq -r '.mergeable // "UNKNOWN"' <<<"$PR_JSON")
+REVIEW_DECISION=$(jq -r '.reviewDecision // ""' <<<"$PR_JSON")
+LABELS=$(jq -r '[.labels[].name] | join(" ")' <<<"$PR_JSON")
+
+# --- Jules-authorship guard ----------------------------------------------------------------
+# We recognize a Jules PR by author login (default substring "jules", case-insensitive) OR by
+# the routing `jules` label the afk-router applies. Anything else is left completely untouched.
+is_jules=false
+shopt -s nocasematch
+[[ "$AUTHOR" == *"$JULES_AUTHOR_PATTERN"* ]] && is_jules=true
+shopt -u nocasematch
+grep -qw "jules" <<<"$LABELS" && is_jules=true
+if [ "$is_jules" != "true" ]; then
+  log "PR #$PR (author '$AUTHOR') is not a Jules-authored PR — leaving it untouched."
+  exit 0
+fi
+
+# --- Signal: CI / checks -------------------------------------------------------------------
+# failure | pending | success | none. `gh pr checks` exits non-zero when checks fail/pending,
+# so we capture output without letting `set -e` abort.
+CHECKS=$(gh pr checks "$PR" --repo "$REPO" 2>/dev/null || true)
+ci="none"
+if [ -n "$CHECKS" ]; then
+  if grep -qiE $'\tfail' <<<"$CHECKS" || grep -qiw "fail" <<<"$CHECKS"; then
+    ci="failure"
+  elif grep -qiE "pending|in_progress|queued|expected" <<<"$CHECKS"; then
+    ci="pending"
+  else
+    ci="success"
+  fi
+fi
+
+# --- Signal: review decision ---------------------------------------------------------------
+# GitHub's reviewDecision: APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED | "" (none yet).
+review="none"
+case "$REVIEW_DECISION" in
+  APPROVED)          review="approved" ;;
+  CHANGES_REQUESTED) review="changes_requested" ;;
+esac
+
+# --- Signal: requested-fix addressed (optional, targeted PRs) ------------------------------
+# When a change was requested AND a specific path was named (EXPECT_PATH), treat the fix as
+# "addressed" only if the PR's current file set touches that path. Lets a targeted PR move from
+# needs-agent-revision back to needs-human-review once the agent pushes the expected change.
+fix_addressed="n/a"
+if [ -n "$EXPECT_PATH" ] && [ "$review" = "changes_requested" ]; then
+  if jq -e --arg p "$EXPECT_PATH" '.files[]?.path | select(. == $p)' <<<"$PR_JSON" >/dev/null 2>&1; then
+    fix_addressed="yes"
+  else
+    fix_addressed="no"
+  fi
+fi
+
+# --- Signal: duplicate fan-out -------------------------------------------------------------
+# If this PR links a parent issue (Fixes/Closes #N) and a *newer* open Jules PR links the same
+# issue, this one is the older duplicate (per the PR-hygiene policy: review the most recent).
+duplicate=false
+superseded_by=""
+LINKED_ISSUE=$(jq -r '.body // ""' <<<"$PR_JSON" \
+  | grep -ioE "(clos|fix|resolv)[a-z]* #[0-9]+" | grep -oE "[0-9]+" | head -n1 || true)
+if [ -n "$LINKED_ISSUE" ]; then
+  while read -r other; do
+    [ -z "$other" ] && continue
+    [ "$other" -le "$PR" ] && continue
+    OA=$(gh pr view "$other" --repo "$REPO" --json author,body --jq \
+      '{a:(.author.login//""),b:(.body//"")}' 2>/dev/null || echo '')
+    [ -z "$OA" ] && continue
+    OL=$(jq -r '.a' <<<"$OA")
+    OB=$(jq -r '.b' <<<"$OA")
+    shopt -s nocasematch; oj=false; [[ "$OL" == *"$JULES_AUTHOR_PATTERN"* ]] && oj=true; shopt -u nocasematch
+    OTHER_ISSUE=$(grep -ioE "(clos|fix|resolv)[a-z]* #[0-9]+" <<<"$OB" | grep -oE "[0-9]+" | head -n1 || true)
+    if [ "$oj" = "true" ] && [ "$OTHER_ISSUE" = "$LINKED_ISSUE" ]; then
+      duplicate=true; superseded_by="$other"; break
+    fi
+  done < <(gh pr list --repo "$REPO" --state open --json number --jq '.[].number' 2>/dev/null || true)
+fi
+
+# --- Signal: staleness ---------------------------------------------------------------------
+age_days=0
+if [ -n "$UPDATED_AT" ]; then
+  upd=$(date -u -d "$UPDATED_AT" +%s 2>/dev/null || echo 0)
+  now=$(date -u +%s)
+  [ "$upd" -gt 0 ] && age_days=$(( (now - upd) / 86400 ))
+fi
+
+# --- Signal: new commits -------------------------------------------------------------------
+# No durable state store (that's #136), so "new commit" is carried by the synchronize event.
+new_commits=false
+[ "$EVENT_NAME" = "synchronize" ] && new_commits=true
+
+# --- Classify (first match wins) -----------------------------------------------------------
+# Priority is deliberate: a duplicate is triaged before anything else; a hard CI failure or an
+# explicit changes-requested outranks positive signals; positive signals resolve last.
+state=""
+reason=""
+if [ "$duplicate" = "true" ]; then
+  state="duplicate-agent-pr"
+  reason="A newer open Jules PR (#$superseded_by) targets the same issue (#$LINKED_ISSUE)."
+elif [ "$ci" = "failure" ]; then
+  state="needs-agent-revision"
+  reason="CI is failing on the latest commit — the agent must push a fix."
+elif [ "$review" = "changes_requested" ] && [ "$fix_addressed" != "yes" ]; then
+  state="needs-agent-revision"
+  reason="A reviewer requested changes that are not yet addressed."
+elif [ "$ci" = "pending" ]; then
+  state="jules-waiting"
+  reason="CI is still running on the latest commit."
+elif [ "$ci" = "success" ] && [ "$review" = "approved" ]; then
+  state="ready-to-merge"
+  reason="CI is green and the PR is approved — awaiting a human/Demerzel merge (watchdog never merges)."
+elif [ "$ci" = "success" ] && [ "$review" = "none" ]; then
+  state="needs-human-review"
+  reason="CI is green with no review yet — ready for a human/Demerzel look."
+elif [ "$review" = "changes_requested" ] && [ "$fix_addressed" = "yes" ]; then
+  state="needs-human-review"
+  reason="The requested change to '$EXPECT_PATH' now appears in the PR — re-review."
+elif [ "$new_commits" = "true" ]; then
+  state="jules-updated"
+  reason="Jules pushed new commits (synchronize) — signals not yet resolved."
+elif [ "$age_days" -ge "$STALE_DAYS" ]; then
+  state="stale-jules-pr"
+  reason="No PR activity for ${age_days}d (>= ${STALE_DAYS}d threshold)."
+else
+  state="jules-waiting"
+  reason="No decisive signal yet — waiting on CI or a reviewer."
+fi
+
+# A stale open PR that isn't already terminal is surfaced as stale regardless of a soft state.
+if [ "$age_days" -ge "$STALE_DAYS" ] && [ "$state" = "jules-waiting" ]; then
+  state="stale-jules-pr"
+  reason="No PR activity for ${age_days}d (>= ${STALE_DAYS}d threshold)."
+fi
+
+WANT_LABEL="jules-state:$state"
+
+# --- Emit the machine-readable classification ----------------------------------------------
+# Shape intentionally mirrors examples/agents/jules-watchdog-state.example.json so a later
+# consumer (#136) could persist it verbatim. This script itself writes no durable state.
+jq -n \
+  --arg repo "$REPO" --argjson pr "$PR" --arg agent jules \
+  --arg state "$state" --arg label "$WANT_LABEL" --arg sha "$HEAD_SHA" \
+  --arg ci "$ci" --arg review "$review" --arg mergeable "$MERGEABLE" \
+  --arg fix "$fix_addressed" --argjson age "$age_days" \
+  --arg dup "$duplicate" --arg sup "$superseded_by" \
+  --arg issue "${LINKED_ISSUE:-}" --arg event "$EVENT_NAME" \
+  --arg updated "$UPDATED_AT" --arg reason "$reason" '
+  {
+    repo: $repo, pr: $pr, agent: $agent, state: $state, label: $label,
+    linked_issue: (if $issue == "" then null else ($issue|tonumber) end),
+    head_sha: $sha, event: $event, last_activity_at: $updated,
+    signals: {
+      ci: $ci, review: $review, mergeable: $mergeable,
+      requested_fix_addressed: $fix, age_days: $age,
+      duplicate: ($dup == "true"),
+      superseded_by: (if $sup == "" then null else ($sup|tonumber) end)
+    },
+    reason: $reason
+  }'
+
+log "PR #$PR classified as '$state' (ci=$ci review=$review dup=$duplicate age=${age_days}d) — $reason"
+
+# --- Reflect the state as a mutually-exclusive label ---------------------------------------
+# Ensure the target label exists, add it, then strip any other watchdog state labels. Only a
+# genuine transition changes labels; re-running on an unchanged state is a no-op (no noise).
+DESC="TARS Jules PR watchdog state (#132)"
+gh label create "$WANT_LABEL" --repo "$REPO" --color 1A73E8 --description "$DESC" --force >/dev/null 2>&1 || true
+if ! grep -qw "$WANT_LABEL" <<<"$LABELS"; then
+  gh pr edit "$PR" --repo "$REPO" --add-label "$WANT_LABEL" >/dev/null 2>&1 || true
+  log "Applied $WANT_LABEL to PR #$PR."
+fi
+for l in "${STATE_LABELS[@]}"; do
+  [ "$l" = "$WANT_LABEL" ] && continue
+  if grep -qw "$l" <<<"$LABELS"; then
+    gh pr edit "$PR" --repo "$REPO" --remove-label "$l" >/dev/null 2>&1 || true
+    log "Removed stale $l from PR #$PR."
+  fi
+done
+
+# --- Comment ONLY on the critical CI-failure transition ------------------------------------
+# One comment per failing head SHA (idempotent via a hidden marker) so re-runs never re-spam.
+if [ "$ci" = "failure" ]; then
+  MARKER="<!-- jules-watchdog:ci-fail:${HEAD_SHA} -->"
+  ALREADY=$(gh pr view "$PR" --repo "$REPO" --json comments \
+    --jq "[.comments[].body | select(contains(\"$MARKER\"))] | length" 2>/dev/null || echo 0)
+  if [ "${ALREADY:-0}" -eq 0 ]; then
+    gh pr comment "$PR" --repo "$REPO" --body "$MARKER
+🔴 **Jules PR watchdog — CI failure detected**
+
+The latest commit (\`${HEAD_SHA:0:8}\`) has failing checks, so this PR is now \`${WANT_LABEL}\`. @google-labs-jules please push a fix. The watchdog will not merge and does not bypass human/Demerzel review.
+
+<sub>Automated transition notice — see \`docs/agents/jules-pr-watchdog.md\`. This is the only state the watchdog comments on.</sub>"
+    log "Posted the CI-failure transition comment on PR #$PR (SHA ${HEAD_SHA:0:8})."
+  else
+    log "CI-failure comment already present for SHA ${HEAD_SHA:0:8} — not re-commenting."
+  fi
+fi

--- a/docs/agents/jules-pr-watchdog.md
+++ b/docs/agents/jules-pr-watchdog.md
@@ -1,0 +1,225 @@
+# Jules PR Watchdog
+
+- **Status:** Active (design + classifier script; workflow draft below)
+- **Area:** Cloud Agent Observability
+- **Owner:** TARS Cortex
+- **Version:** 1.0.0
+- **Issue:** [#132](https://github.com/GuitarAlchemist/tars/issues/132)
+
+## Purpose
+
+The AFK router ([`.github/workflows/afk-router.yml`](../../.github/workflows/afk-router.yml)) gets
+cloud-agent work *started* — it routes a triaged `ready-for-agent` issue to Jules/Codex/Claude and
+the agent opens a PR. But once Jules has a PR open, maintainers still have to poll it by hand for:
+
+- new Jules commits,
+- CI/check status changes,
+- mergeability changes,
+- whether a requested fix was actually addressed,
+- PRs that have gone stale waiting on Jules,
+- noisy duplicate PRs from fan-out.
+
+The **Jules PR watchdog** is the finer-grained observer that fills that gap. It reacts to PR events
+(and a low-frequency schedule), classifies a Jules-authored PR into **exactly one** state from the
+vocabulary below, and reflects that state as a label — **without** creating comment noise and
+**without** bypassing human/Demerzel review.
+
+It is deliberately the *transition-detection/classification* layer only. The durable state store
+(`afk-runs.json`, per-run JSON, JSONL events) is [#136](https://github.com/GuitarAlchemist/tars/issues/136)
+and the human HTML dashboard is [#137](https://github.com/GuitarAlchemist/tars/issues/137) — both are
+out of scope here. The classifier writes no durable state; it prints its classification to stdout in a
+shape (`examples/agents/jules-watchdog-state.example.json`) that a future #136 consumer can persist
+verbatim.
+
+## State model
+
+Each open, Jules-authored PR resolves to exactly one **watchdog state**. States are reflected as
+mutually-exclusive labels namespaced `jules-state:<state>` (matching the repo's `worker:*` / `skill:*`
+/ `agent:*` label conventions); applying one removes the others.
+
+| State | Label | Meaning |
+|-------|-------|---------|
+| `jules-waiting` | `jules-state:jules-waiting` | Open, no decisive signal yet — CI running or awaiting a reviewer. |
+| `jules-updated` | `jules-state:jules-updated` | Jules just pushed new commits (via `synchronize`); signals not yet resolved. |
+| `needs-human-review` | `jules-state:needs-human-review` | CI green, no review yet (or a targeted fix now addressed) — ready for a human/Demerzel look. |
+| `needs-agent-revision` | `jules-state:needs-agent-revision` | CI failing, or a reviewer requested changes not yet addressed — the agent must act. |
+| `ready-to-merge` | `jules-state:ready-to-merge` | CI green **and** approved — awaiting a human/Demerzel merge. **The watchdog never merges.** |
+| `stale-jules-pr` | `jules-state:stale-jules-pr` | Open with no activity for `STALE_DAYS` (default 3) and no terminal signal. |
+| `duplicate-agent-pr` | `jules-state:duplicate-agent-pr` | A newer open Jules PR targets the same parent issue (this one is the older duplicate). |
+
+## Transition rules
+
+The classifier reads the currently-observable signals for the PR and applies the **first** matching
+rule (priority is deliberate — a duplicate is triaged first; a hard failure or explicit
+changes-requested outranks positive signals; positive signals resolve last):
+
+1. **Duplicate fan-out** → `duplicate-agent-pr` — a *newer* open Jules PR links the same parent issue
+   (`Fixes/Closes #N`). Aligns with the PR-hygiene policy "review the most recent" (see below).
+2. **CI failure** → `needs-agent-revision` — checks are failing on the latest commit. **This is the
+   only state that also posts a comment** (see policy below).
+3. **Changes requested, not addressed** → `needs-agent-revision` — GitHub `reviewDecision` is
+   `CHANGES_REQUESTED` and (for targeted PRs) the expected path is not yet touched.
+4. **CI pending** → `jules-waiting` — checks still running on the latest commit.
+5. **CI success + approved** → `ready-to-merge` — awaiting a human/Demerzel merge.
+6. **CI success + no review** → `needs-human-review` — green and ready for a human look.
+7. **Targeted fix addressed** → `needs-human-review` — a changes-requested review named a path
+   (`EXPECT_PATH`) and the PR's current file set now includes it — re-review.
+8. **New commits** (`synchronize`) → `jules-updated` — Jules pushed but signals aren't resolved yet.
+9. **Stale** → `stale-jules-pr` — no activity for `≥ STALE_DAYS` and otherwise only `jules-waiting`.
+10. **Default** → `jules-waiting`.
+
+### How each acceptance signal is detected
+
+- **New commits from Jules** — carried by the `pull_request.synchronize` trigger (no durable diff
+  store needed; that would be #136). `EVENT_NAME=synchronize` ⇒ candidate `jules-updated`.
+- **CI/check status changes** — `gh pr checks` classified into `failure | pending | success | none`.
+- **Mergeability changes** — the PR's `mergeable` field is recorded in the classification's
+  `signals.mergeable` (`MERGEABLE | CONFLICTING | UNKNOWN`) for downstream consumers.
+- **Requested fix addressed (targeted PRs)** — optional `EXPECT_PATH`: on a `CHANGES_REQUESTED`
+  review, the fix counts as addressed only if the PR's current files include that path.
+- **Stale PRs** — the PR's own `updatedAt` vs. `STALE_DAYS` (no state store required).
+- **Duplicates** — parent issue parsed from the PR body; the open Jules PR with the highest number
+  wins, older ones become `duplicate-agent-pr`.
+
+## Labels / comments policy
+
+- **Labels change only on a genuine transition.** Re-running on an unchanged state is a no-op — the
+  target label is already present, so nothing is added and nothing else is stripped. No poll-spam.
+- **Comments are posted on exactly one state: `needs-agent-revision` caused by CI failure.** That is
+  the single critical transition where a human/agent must act, per the issue's minimal-noise
+  requirement. The comment is idempotent: a hidden `<!-- jules-watchdog:ci-fail:<sha> -->` marker
+  means at most one comment per failing head SHA, so re-runs and other triggers never re-spam.
+- **No comment for any other state** — `ready-to-merge`, `needs-human-review`, `stale-jules-pr`,
+  `duplicate-agent-pr`, etc. are conveyed by labels only.
+- **Only Jules-authored PRs are touched.** Recognition is by author login (default substring
+  `jules`, case-insensitive) or the routing `jules` label. Any other PR is left completely alone.
+
+## Governance notes
+
+- **Halt gate.** The watchdog reads `governance/state/afk-halt.json` exactly as the afk-router does:
+  a present, unexpired marker means the watchdog **stands down** and makes no labels or comments.
+  (`expires_at` in the past ⇒ treated as expired ⇒ proceed.) See ADR 0004.
+- **Never merges, never approves.** `ready-to-merge` is an *observation*. Merging stays a
+  human/Demerzel action — branch protection and review-gating hold by default.
+- **Never bypasses review.** The watchdog only labels and (once) comments; it changes no review
+  state and requests no approvals.
+- **Minimal permissions.** The workflow needs `contents: read`, `pull-requests: write` (labels +
+  the single comment), and `checks: read` / `actions: read` (CI status). Nothing else.
+
+### Interaction with the already-merged policies
+
+- **PR hygiene** ([`cloud-agent-pr-hygiene.md`](./cloud-agent-pr-hygiene.md)) — the
+  `duplicate-agent-pr` rule mechanizes hygiene rule #1 ("review the most recent; older duplicates
+  are candidates to close"). The watchdog only *flags* the older duplicate; a human still decides to
+  close it, using the documented duplicate-close template.
+- **Backpressure / locks** ([`backpressure-decision.example.json`](../../examples/agents/backpressure-decision.example.json)) —
+  the watchdog is read-mostly and event-driven; it acquires no locks and opens no PRs, so it never
+  competes for the global WIP limit. Its labels are a cheap input a backpressure decision can read
+  (e.g. treat `ready-to-merge` PRs as draining the queue, `stale-jules-pr` as recoverable slots).
+- **AFK Live Agent Board** ([`afk-live-agent-board.md`](./afk-live-agent-board.md)) — the watchdog's
+  state vocabulary is the same one the board's per-run `state` field uses, so a #136 consumer can map
+  a classification straight onto a run record without translation.
+
+## Non-goals
+
+- No autonomous merge. No approvals.
+- No replacement for CI — it reads CI, it doesn't gate on it.
+- No high-frequency busy-loop polling — reactive events plus a low-frequency schedule.
+- No comment for unchanged or non-critical state.
+- No durable state artifacts (#136) and no HTML dashboard (#137).
+
+## Files
+
+- [`.github/scripts/jules-pr-watchdog.sh`](../../.github/scripts/jules-pr-watchdog.sh) — the classifier.
+- [`examples/agents/jules-watchdog-state.example.json`](../../examples/agents/jules-watchdog-state.example.json) —
+  the machine-readable classification the script prints.
+- Workflow draft — below (see note on wiring).
+
+## Workflow draft
+
+> **Wiring note.** This PR was opened by the Claude GitHub App, whose permissions do not allow
+> committing under `.github/workflows/`. A maintainer should add the file below as
+> `.github/workflows/jules-pr-watchdog.yml`. It is otherwise ready to run and calls only the
+> committed classifier script.
+
+```yaml
+name: Jules PR watchdog
+
+# Finer-grained observability for Jules-authored PRs (issue #132). Reacts to PR events and a
+# low-frequency schedule, classifies each Jules PR into one jules-state:* label, and comments only
+# on the critical CI-failure transition. Never merges; never bypasses review; halt-gated on
+# governance/state/afk-halt.json. See docs/agents/jules-pr-watchdog.md.
+
+on:
+  pull_request_target:
+    types: [synchronize, opened, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+  workflow_run:
+    workflows: [".NET"]
+    types: [completed]
+  schedule:
+    - cron: '23 */6 * * *'   # low-frequency sweep for staleness/duplicates
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to classify
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: read
+  actions: read
+
+concurrency:
+  # One classification per PR at a time; never cancel an in-flight run.
+  group: jules-watchdog-${{ github.event.pull_request.number || github.event.workflow_run.id || github.event.inputs.pr || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout (read the governance halt marker + the classifier script)
+        uses: actions/checkout@v4
+
+      # Event-driven paths: a single PR number is available directly.
+      - name: Classify the triggering PR
+        if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' || github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number || github.event.inputs.pr }}
+          EVENT_NAME: ${{ github.event.action || github.event_name }}
+        run: bash .github/scripts/jules-pr-watchdog.sh
+
+      # workflow_run gives a head SHA, not a PR — resolve the open PR(s) for that SHA.
+      - name: Classify the PR(s) for a completed check run
+        if: ${{ github.event_name == 'workflow_run' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          EVENT_NAME: workflow_run
+        run: |
+          set -euo pipefail
+          for PR in $(gh pr list --repo "$REPO" --state open --search "$HEAD_SHA" \
+                        --json number --jq '.[].number'); do
+            PR="$PR" bash .github/scripts/jules-pr-watchdog.sh
+          done
+
+      # Scheduled sweep: re-classify every open PR (catches staleness + duplicates).
+      - name: Scheduled sweep of open PRs
+        if: ${{ github.event_name == 'schedule' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: schedule
+        run: |
+          set -euo pipefail
+          for PR in $(gh pr list --repo "$REPO" --state open --json number --jq '.[].number'); do
+            PR="$PR" bash .github/scripts/jules-pr-watchdog.sh
+          done
+```

--- a/examples/agents/jules-watchdog-state.example.json
+++ b/examples/agents/jules-watchdog-state.example.json
@@ -1,0 +1,21 @@
+{
+  "repo": "GuitarAlchemist/tars",
+  "pr": 149,
+  "agent": "jules",
+  "state": "needs-agent-revision",
+  "label": "jules-state:needs-agent-revision",
+  "linked_issue": 132,
+  "head_sha": "0123456789abcdef0123456789abcdef01234567",
+  "event": "workflow_run",
+  "last_activity_at": "2026-06-30T13:48:36Z",
+  "signals": {
+    "ci": "failure",
+    "review": "none",
+    "mergeable": "MERGEABLE",
+    "requested_fix_addressed": "n/a",
+    "age_days": 0,
+    "duplicate": false,
+    "superseded_by": null
+  },
+  "reason": "CI is failing on the latest commit — the agent must push a fix."
+}


### PR DESCRIPTION
## Summary

Implements #132 (authored by the `@claude` delegation lane, run [28559657723](https://github.com/GuitarAlchemist/tars/actions/runs/28559657723), 6m02s). A conservative Jules-PR watchdog: given one PR it classifies observable signals (new commits, CI, mergeability, requested-fix follow-through, staleness, duplicate fan-out) into exactly one mutually-exclusive `jules-state:*` label from the issue's vocabulary.

- `.github/scripts/jules-pr-watchdog.sh` — classifier (labels only on real transitions; comments only on the CI-failure transition, idempotent per head SHA; halt-gated on `governance/state/afk-halt.json`; never merges/approves; Jules-authored PRs only)
- `docs/agents/jules-pr-watchdog.md` — state model + transition rules + the workflow YAML as a ready-to-wire draft
- `examples/agents/jules-watchdog-state.example.json`

#136 (state artifacts) and #137 (dashboard) deliberately out of scope. Inert until the workflow is wired — that follows in the next PR (App can't push under `.github/workflows/`).

Fixes #132

## Review mode

Mode:
- focused-review (script on the observation path; write surface = labels + one idempotent comment)

Risks / rollback:
- Inert until wired / git revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih

---
_Generated by [Claude Code](https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih)_