### PR TITLE
feat(devcontainer): Codespaces environment — .NET 10, pwsh, gh, node, claude

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "TARS",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/dotnet:2": { "version": "10.0" },
+    "ghcr.io/devcontainers/features/powershell:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": { "version": "lts" }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ionide.ionide-fsharp",
+        "ms-dotnettools.csdevkit",
+        "anthropic.claude-code"
+      ]
+    }
+  },
+  // Working directory is v2/ (see CLAUDE.md). Full build/test:
+  //   cd v2 && dotnet build && dotnet test
+  "postCreateCommand": "npm install -g @anthropic-ai/claude-code"
+}


### PR DESCRIPTION
## Summary

Adds `.devcontainer/devcontainer.json` so a Codespace on this repo can run `cd v2 && dotnet build && dotnet test` out of the box: .NET 10 SDK, PowerShell (.claude/hooks), gh CLI, Node LTS, Claude Code CLI preinstalled, Ionide for F#.

Same motivation as GuitarAlchemist/ga#499: tablet-browser terminal access (`claude setup-token`) and a standardized SDK environment for cloud agents — e.g. the pending #45→#53 stacked-refactor validation and the 12 Dependabot alerts both need this toolchain.

## Review mode
- fast-review (additive config; no CI/runtime impact)

Risks / rollback
- None until someone opens a Codespace / delete the directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih

---
_Generated by [Claude Code](https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih)_