### PR TITLE
feat(hooks): land the F# verification gate (#33) with the v2/ skip fixed

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,52 @@
+# tars `.claude/hooks/`
+
+Local Claude Code hooks that wrap agent edits with fast verification gates.
+Mirrors **ix**'s [`.claude/hooks/`](https://github.com/GuitarAlchemist/ix/tree/main/.claude/hooks)
+pattern (Pattern 3 — Cherny self-improvement loops).
+
+Goal: catch the kind of mistake the language compiler can spot in seconds,
+locally, before it becomes a failed CI run.
+
+## Hooks
+
+| Hook | Phase | Matcher | Purpose |
+| ---- | ----- | ------- | ------- |
+| `fsharp-check.sh` | PostToolUse | `Write\|Edit` | Walks up from the edited `*.fs` / `*.fsi` / `*.fsproj` to the containing `.fsproj` and runs `dotnet build --no-restore -nologo -clp:NoSummary -v:q` with a 30s cap. Emits errors/warnings to stderr on failure so the agent sees the diagnostic on the next turn. |
+| `fsharp-format.sh` | PostToolUse | `Write\|Edit` | Opt-in Fantomas formatter (15s cap). No-op when `fantomas` isn't on `dotnet tool list` — graceful degradation, no install required. |
+| `digest-*.ps1` | various | various | Pre-existing session-digest hooks. Not part of this PR. |
+
+## Contract
+
+- **Silent on success.** Emit only when something the agent should see has gone wrong.
+- **Exit non-zero only on real diagnostic content** (stderr lines that name the failing file).
+- **Never block.** PostToolUse hooks are advisory by design; they report, they don't gate.
+- **Fast.** Hard cap via `timeout`. If `dotnet` hangs, the hook exits 0 silently — we never block agent throughput on slow tools.
+- **Graceful degradation.** Missing `dotnet`, missing `fantomas`, missing project file → exit 0.
+- **Skip noise.** Files under `v1/`, `parked_legacy/`, `autonomous_backups/`, `.tars/` are ignored (legacy / generated trees per `CLAUDE.md`). `v2/` is NOT skipped — it is the active codebase (`cd v2` per `CLAUDE.md`).
+- **Skip scripts.** `.fsx` files are eval'd separately, not built.
+
+## Bypass
+
+Per-hook env vars (set in the shell before launching `claude`):
+
+| Variable | Effect |
+| -------- | ------ |
+| `CLAUDE_DISABLE_FSHARP_CHECK=1` | Skip `fsharp-check.sh` entirely. |
+| `CLAUDE_DISABLE_FSHARP_FORMAT=1` | Skip `fsharp-format.sh` entirely. |
+
+Use sparingly — bypassing the check defeats the purpose of the gate. Prefer
+fixing the underlying issue.
+
+## Pattern reference
+
+Both ix and tars apply the same shape:
+
+1. After every `Write` / `Edit`, run the language-native fast check.
+2. On failure, surface the diagnostic on stderr so the model sees it on the
+   next turn and self-corrects.
+3. Keep CI green by catching issues at the keystroke, not on push.
+
+ix uses `cargo check -p <crate>` (Rust). tars uses `dotnet build <project>`
+(F# / .NET). Same pattern, different toolchain.
+
+See ix's `.claude/hooks/rust-check.sh` for the reference implementation.

--- a/.claude/hooks/fsharp-check.sh
+++ b/.claude/hooks/fsharp-check.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Post-edit F# check — runs `dotnet build` on the containing .fsproj after
+# F# file edits. Provides a fast local verification gate so type errors are
+# caught before they reach CI.
+#
+# Pattern: ix/.claude/hooks/rust-check.sh (Pattern 3, Cherny self-improvement loop).
+# Contract: silent on success; exit 0 always (PostToolUse should report, not block).
+#
+# Bypass: set CLAUDE_DISABLE_FSHARP_CHECK=1 to skip.
+
+set -u
+
+# Hard kill-switch
+if [[ -n "${CLAUDE_DISABLE_FSHARP_CHECK:-}" ]]; then
+    exit 0
+fi
+
+TOOL_NAME="${CLAUDE_TOOL_NAME:-}"
+FILE_PATH="${CLAUDE_FILE_PATH:-}"
+
+# Fallback: read from stdin JSON payload if env vars unset
+if [[ -z "$FILE_PATH" ]] && [[ ! -t 0 ]]; then
+    PAYLOAD=$(cat 2>/dev/null || true)
+    if [[ -n "$PAYLOAD" ]]; then
+        # Best-effort extraction without requiring jq
+        FILE_PATH=$(printf '%s' "$PAYLOAD" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+        if [[ -z "$TOOL_NAME" ]]; then
+            TOOL_NAME=$(printf '%s' "$PAYLOAD" | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+        fi
+    fi
+fi
+
+# Only act on Write/Edit if tool name is provided; otherwise allow direct invocation
+if [[ -n "$TOOL_NAME" ]] && [[ ! "$TOOL_NAME" =~ ^(Write|Edit|MultiEdit)$ ]]; then
+    exit 0
+fi
+
+# Need a file path
+if [[ -z "$FILE_PATH" ]]; then
+    exit 0
+fi
+
+# Only F# files (skip .fsx scripts per spec)
+case "$FILE_PATH" in
+    *.fs|*.fsi|*.fsproj) ;;
+    *) exit 0 ;;
+esac
+
+# Skip legacy / generated trees (per CLAUDE.md cleanup notes)
+case "$FILE_PATH" in
+    */v1/*|*/parked_legacy/*|*/autonomous_backups/*|*/.tars/*)
+        exit 0 ;;
+esac
+
+# Resolve project to build
+PROJ=""
+if [[ "$FILE_PATH" == *.fsproj ]]; then
+    PROJ="$FILE_PATH"
+else
+    # Walk up from the file's directory looking for a .fsproj
+    DIR=$(dirname "$FILE_PATH")
+    while [[ -n "$DIR" && "$DIR" != "." && "$DIR" != "/" ]]; do
+        CAND=$(ls "$DIR"/*.fsproj 2>/dev/null | head -1)
+        if [[ -n "$CAND" ]]; then
+            PROJ="$CAND"
+            break
+        fi
+        PARENT=$(dirname "$DIR")
+        # Stop if we can't ascend further
+        if [[ "$PARENT" == "$DIR" ]]; then
+            break
+        fi
+        DIR="$PARENT"
+    done
+fi
+
+if [[ -z "$PROJ" ]]; then
+    exit 0
+fi
+
+# Make sure dotnet is on PATH; otherwise gracefully degrade
+if ! command -v dotnet >/dev/null 2>&1; then
+    exit 0
+fi
+
+# 30-second cap; if dotnet hangs, kill and exit 0 (goal is fast feedback)
+OUTPUT=$(timeout 30 dotnet build --no-restore -nologo -clp:NoSummary -v:q "$PROJ" 2>&1)
+EXIT_CODE=$?
+
+# 124 == timeout reached; treat as non-blocking
+if [[ $EXIT_CODE -eq 124 ]]; then
+    exit 0
+fi
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+    echo "[fsharp-check] dotnet build failed for $(basename "$PROJ"):" >&2
+    # Surface just the error/warning lines, keep context tight
+    printf '%s\n' "$OUTPUT" | grep -E "(error|warning) [A-Z]+[0-9]+" | head -15 >&2
+fi
+
+# Never block — PostToolUse reports, never blocks
+exit 0

--- a/.claude/hooks/fsharp-format.sh
+++ b/.claude/hooks/fsharp-format.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Optional post-edit Fantomas formatter. No-op if fantomas isn't installed.
+# Contract: silent on success; exit 0 always.
+#
+# Bypass: set CLAUDE_DISABLE_FSHARP_FORMAT=1 to skip.
+
+set -u
+
+if [[ -n "${CLAUDE_DISABLE_FSHARP_FORMAT:-}" ]]; then
+    exit 0
+fi
+
+TOOL_NAME="${CLAUDE_TOOL_NAME:-}"
+FILE_PATH="${CLAUDE_FILE_PATH:-}"
+
+# Fallback: read from stdin JSON payload if env vars unset
+if [[ -z "$FILE_PATH" ]] && [[ ! -t 0 ]]; then
+    PAYLOAD=$(cat 2>/dev/null || true)
+    if [[ -n "$PAYLOAD" ]]; then
+        FILE_PATH=$(printf '%s' "$PAYLOAD" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+        if [[ -z "$TOOL_NAME" ]]; then
+            TOOL_NAME=$(printf '%s' "$PAYLOAD" | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+        fi
+    fi
+fi
+
+if [[ -n "$TOOL_NAME" ]] && [[ ! "$TOOL_NAME" =~ ^(Write|Edit|MultiEdit)$ ]]; then
+    exit 0
+fi
+
+if [[ -z "$FILE_PATH" ]]; then
+    exit 0
+fi
+
+# Format only F# source files (not .fsproj / .fsx)
+case "$FILE_PATH" in
+    *.fs|*.fsi) ;;
+    *) exit 0 ;;
+esac
+
+# Skip legacy / generated trees
+case "$FILE_PATH" in
+    */v1/*|*/parked_legacy/*|*/autonomous_backups/*|*/.tars/*)
+        exit 0 ;;
+esac
+
+# Check if fantomas is available (global or local manifest). If not, no-op.
+if ! command -v dotnet >/dev/null 2>&1; then
+    exit 0
+fi
+
+if ! dotnet tool list -g 2>/dev/null | grep -qi '^fantomas[[:space:]]'; then
+    # Not installed globally; check local manifest too
+    if ! dotnet tool list 2>/dev/null | grep -qi '^fantomas[[:space:]]'; then
+        exit 0
+    fi
+fi
+
+# 15s cap
+timeout 15 dotnet fantomas "$FILE_PATH" >/dev/null 2>&1 || true
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,6 +55,19 @@
             "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/.claude/hooks/pr-rationale-capture.ps1"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/fsharp-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/fsharp-format.sh"
+          }
+        ]
       }
     ],
     "Stop": [


### PR DESCRIPTION
## Summary

Lands PR #33 (May 24), which merged cleanly against main until #30 went in first — both append `PostToolUse` entries to `.claude/settings.json` at the same spot, so #33 turned dirty. This integration branch carries #33's exact content (cherry-picked, original authorship preserved as co-author) with two deltas:

1. **settings.json conflict resolved as the union** — `pr-rationale-capture` (from #30) and the `fsharp-check`/`fsharp-format` pair (from #33) both wired under `PostToolUse`.
2. **`v2/` removed from both hooks' skip lists** — as written, the hooks skipped `*/v2/*`, but `v2/` is the *active* codebase (`cd v2` per CLAUDE.md), so the gate would never have checked a single real F# file. `v1/`, `parked_legacy/`, `autonomous_backups/`, `.tars/` remain skipped. README note updated to match.

## Verification

- `bash -n` passes on both hook scripts.
- `.claude/settings.json` parses as valid JSON.
- No changes outside `.claude/`.

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih

---
_Generated by [Claude Code](https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih)_