### PR TITLE
fix(governance): protect agent-blackbox.policy.json from self-modification

### DIFF
--- a/agent-blackbox.policy.json
+++ b/agent-blackbox.policy.json
@@ -5,6 +5,7 @@
     "warn": 0.6
   },
   "blocked_paths": [
+    "agent-blackbox.policy.json",
     ".github/workflows/**",
     "infra/production/**",
     "billing/**",


### PR DESCRIPTION
Closes a guardrail loophole observed twice in Demerzel during today's queue cleanup: a gated PR could edit the very policy that gates it. One-line, strictly-tightening change: `agent-blackbox.policy.json` added to its own `blocked_paths`. JSON validated locally. Same fix applied across Demerzel, ga, ix, and agent-blackbox in parallel PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQUHbM37zpDJ1nRe7E9SN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQUHbM37zpDJ1nRe7E9SN9)_