### PR TITLE
feat(arch): pin architecture-refinement lane to claude-sonnet-5

### DIFF
--- a/.github/workflows/architecture-refinement.yml
+++ b/.github/workflows/architecture-refinement.yml
@@ -200,7 +200,7 @@ jobs:
                Check `gh issue list --search "[arch-refinement] ${{ needs.gate.outputs.slug }}"`
                first and do NOT file a duplicate if an open one already covers
                the same candidates.
-          claude_args: '--allowed-tools "Agent,Read,Grep,Glob,Write,Bash(gh issue list:*),Bash(gh issue create:*),Bash(date:*)"'
+          claude_args: '--model claude-sonnet-5 --allowed-tools "Agent,Read,Grep,Glob,Write,Bash(gh issue list:*),Bash(gh issue create:*),Bash(date:*)"'
 
       - name: Commit the report
         shell: bash


### PR DESCRIPTION
## Summary

Mirror of the ga change: `architecture-refinement.yml` now passes `--model claude-sonnet-5` explicitly instead of riding `claude-code-action`'s default. Propose-only scheduled work is where the cheaper tier belongs (subscription cost doctrine, tars#176) — pinning it also makes the daily churn-gate cadence cheaper.

## Impact

One `claude_args` line in one workflow; no build, test, or runtime changes. First effect at the next churn-gated review run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvEdT41S77Lnm6dLBMHJSW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvEdT41S77Lnm6dLBMHJSW)_