### PR TITLE
refactor(evolution): IPromotionStore + single-verdict PromotionGate (#42) + governance bump

### DIFF
--- a/v2/src/Tars.Evolution/GaPatternSeeder.fs
+++ b/v2/src/Tars.Evolution/GaPatternSeeder.fs
@@ -186,4 +186,4 @@ module GaPatternSeeder =
     /// Run the promotion pipeline on GA-discovered patterns.
     let seed (minOccurrences: int) : PromotionPipeline.PipelineResult list =
         let artifacts = gaTraceArtifacts ()
-        PromotionPipeline.run minOccurrences artifacts
+        PromotionPipeline.run PromotionPipeline.defaultStore minOccurrences artifacts

--- a/v2/src/Tars.Evolution/McpGaTraceBridge.fs
+++ b/v2/src/Tars.Evolution/McpGaTraceBridge.fs
@@ -58,7 +58,7 @@ module McpGaTraceBridge =
                       Promotions = 0; Rejections = 0
                       Details = ["No GA trace files found in ~/.ga/traces/"] }, jsonOptions))
             else
-                let results = PromotionPipeline.run minOcc artifacts
+                let results = PromotionPipeline.run PromotionPipeline.defaultStore minOcc artifacts
                 let promotions = results |> List.filter (fun r ->
                     match r.Decision with GovernanceDecision.Approve _ -> true | _ -> false)
                 let rejections = results |> List.filter (fun r ->

--- a/v2/src/Tars.Evolution/McpPatternResources.fs
+++ b/v2/src/Tars.Evolution/McpPatternResources.fs
@@ -314,7 +314,7 @@ module McpPatternResources =
                                   Timestamp = DateTime.UtcNow
                                   RollbackExpansion = None } : PromotionPipeline.TraceArtifact))
 
-                let results = PromotionPipeline.run minOccurrences artifacts
+                let results = PromotionPipeline.run PromotionPipeline.defaultStore minOccurrences artifacts
                 let json = StructuredOutput.pipelineRunToJson results artifacts.Length
                 return Ok json
             with ex ->

--- a/v2/src/Tars.Evolution/PromotionGate.fs
+++ b/v2/src/Tars.Evolution/PromotionGate.fs
@@ -1,0 +1,48 @@
+module Tars.Evolution.PromotionGate
+
+/// The single decision point for a promotion candidate.
+///
+/// Previously the pipeline asked the Grammar Governor for a decision and then
+/// SEPARATELY re-inspected `RoundtripValidation.SemanticMatch` to override an
+/// Approve into a Reject — a verdict leak that produced two competing
+/// decisions outside the gate. This module folds both concerns into ONE
+/// verdict: the governor evaluates the criteria, and if it approves, the
+/// injected round-trip validator has the final say. Callers consume
+/// `Verdict.Decision` and never re-inspect the round-trip afterward.
+
+open System
+
+/// A round-trip validator: given a candidate the governor approved, produce a
+/// structural round-trip result. Injected so the gate — not the pipeline —
+/// owns the semantic-match decision.
+type RoundtripValidator = PromotionCandidate -> RoundtripValidation.RoundtripResult
+
+/// The single governance verdict: the final decision plus the round-trip
+/// evidence that produced it (present only when the governor approved and the
+/// candidate was therefore round-trip-checked).
+type Verdict = {
+    Decision: GovernanceDecision
+    Roundtrip: RoundtripValidation.RoundtripResult option
+}
+
+/// Decide a candidate's fate in one place. The Grammar Governor evaluates the
+/// criteria; on approval the injected validator gates the promotion on
+/// round-trip semantic fidelity. Non-approvals pass through untouched.
+let decide
+    (validate: RoundtripValidator)
+    (existing: RecurrenceRecord list)
+    (candidate: PromotionCandidate)
+    : Verdict =
+    match GrammarGovernor.evaluate existing candidate with
+    | Approve _ as approved ->
+        let rt = validate candidate
+        if rt.Passed then
+            { Decision = approved; Roundtrip = Some rt }
+        else
+            let reason =
+                sprintf "Round-trip validation failed (semantic match: %.2f). %s"
+                    rt.SemanticMatch
+                    (rt.Issues |> String.concat "; ")
+            { Decision = Reject reason; Roundtrip = Some rt }
+    | other ->
+        { Decision = other; Roundtrip = None }

--- a/v2/src/Tars.Evolution/PromotionPipeline.fs
+++ b/v2/src/Tars.Evolution/PromotionPipeline.fs
@@ -12,80 +12,21 @@ open System.Text.Json
 open System.Text.Json.Serialization
 
 // ─────────────────────────────────────────────────────────────────────
-// State: persistent recurrence and lineage stores
+// State: injectable promotion store (recurrence + lineage + weights)
 // ─────────────────────────────────────────────────────────────────────
 
-let private recurrenceStore =
-    System.Collections.Concurrent.ConcurrentDictionary<string, RecurrenceRecord>()
-
-let private lineageStore =
-    System.Collections.Concurrent.ConcurrentDictionary<string, LineageRecord>()
-
+/// JSON options for the directory-scoped helpers at the bottom of this file.
 let private jsonOptions =
     let o = JsonSerializerOptions(JsonSerializerDefaults.General)
     o.Converters.Add(JsonFSharpConverter())
     o.WriteIndented <- true
     o
 
-let private getPromotionDir () =
-    let dir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        ".tars", "promotion")
-    if not (Directory.Exists dir) then
-        Directory.CreateDirectory dir |> ignore
-    dir
-
-/// Save recurrence and lineage stores to disk.
-let save () =
-    try
-        let dir = getPromotionDir ()
-        let recurrencePath = Path.Combine(dir, "recurrence.json")
-        let lineagePath = Path.Combine(dir, "lineage.json")
-
-        let recurrenceData = recurrenceStore.Values |> Seq.toList
-        let lineageData = lineageStore.Values |> Seq.toList
-
-        File.WriteAllText(recurrencePath, JsonSerializer.Serialize(recurrenceData, jsonOptions))
-        File.WriteAllText(lineagePath, JsonSerializer.Serialize(lineageData, jsonOptions))
-        Ok (recurrenceData.Length, lineageData.Length)
-    with ex ->
-        Error $"Failed to save promotion state: {ex.Message}"
-
-/// Load recurrence and lineage stores from disk.
-let load () =
-    try
-        let dir = getPromotionDir ()
-        let recurrencePath = Path.Combine(dir, "recurrence.json")
-        let lineagePath = Path.Combine(dir, "lineage.json")
-
-        if File.Exists recurrencePath then
-            let json = File.ReadAllText(recurrencePath)
-            let records = JsonSerializer.Deserialize<RecurrenceRecord list>(json, jsonOptions)
-            for r in records do
-                recurrenceStore.[r.PatternName] <- r
-
-        if File.Exists lineagePath then
-            let json = File.ReadAllText(lineagePath)
-            let records = JsonSerializer.Deserialize<LineageRecord list>(json, jsonOptions)
-            for r in records do
-                lineageStore.[r.Id] <- r
-
-        Ok (recurrenceStore.Count, lineageStore.Count)
-    with ex ->
-        Error $"Failed to load promotion state: {ex.Message}"
-
-/// Initialize: load from disk on first use.
-let private initialized =
-    lazy (
-        match load () with
-        | Ok (r, l) ->
-            if r > 0 || l > 0 then
-                Console.Error.WriteLine($"[Promotion] Loaded {r} recurrence records, {l} lineage records from disk")
-        | Error err ->
-            Console.Error.WriteLine($"[Promotion] {err}")
-    )
-
-let private ensureLoaded () = initialized.Force()
+/// Process-global disk-backed store rooted at ~/.tars/promotion. This is the
+/// default for production callers; tests inject an `InMemoryPromotionStore`
+/// to stay hermetic. The global mutable ConcurrentDictionary state that used
+/// to live here — and leaked across tests — now lives inside the store.
+let defaultStore : IPromotionStore = DiskPromotionStore() :> IPromotionStore
 
 // ─────────────────────────────────────────────────────────────────────
 // Step 1: INSPECT — Analyze completed work artifacts
@@ -110,15 +51,14 @@ let inspect (artifacts: TraceArtifact list) : TraceArtifact list =
 // Step 2: EXTRACT — Pull recurring structural patterns
 // ─────────────────────────────────────────────────────────────────────
 
-let extract (artifacts: TraceArtifact list) : RecurrenceRecord list =
-    ensureLoaded ()
+let extractInto (store: IPromotionStore) (artifacts: TraceArtifact list) : RecurrenceRecord list =
     artifacts
     |> List.groupBy (fun a -> a.PatternName)
     |> List.map (fun (name, group) ->
         let existing =
-            match recurrenceStore.TryGetValue(name) with
-            | true, r -> r
-            | false, _ ->
+            match store.TryGetRecurrence name with
+            | Some r -> r
+            | None ->
                 { PatternId = Guid.NewGuid().ToString("N").[..7]
                   PatternName = name
                   FirstSeen = DateTime.UtcNow
@@ -143,8 +83,12 @@ let extract (artifacts: TraceArtifact list) : RecurrenceRecord list =
                 Contexts = (existing.Contexts @ newContexts) |> List.distinct
                 AverageScore = avgScore }
 
-        recurrenceStore.[name] <- updated
+        store.UpsertRecurrence updated
         updated)
+
+/// Extract using the process-global default store (backward-compatible entry point).
+let extract (artifacts: TraceArtifact list) : RecurrenceRecord list =
+    extractInto defaultStore artifacts
 
 // ─────────────────────────────────────────────────────────────────────
 // Step 3: CLASSIFY — Determine if promotion is warranted
@@ -233,7 +177,7 @@ let validate
 // Step 6: PERSIST — Store the decision and update lineage
 // ─────────────────────────────────────────────────────────────────────
 
-let persist (candidate: PromotionCandidate) (decision: GovernanceDecision) : LineageRecord =
+let persistInto (store: IPromotionStore) (candidate: PromotionCandidate) (decision: GovernanceDecision) : LineageRecord =
     let lineage = {
         Id = Guid.NewGuid().ToString("N").[..7]
         PatternId = candidate.Record.PatternId
@@ -248,7 +192,7 @@ let persist (candidate: PromotionCandidate) (decision: GovernanceDecision) : Lin
         Confidence = float (PromotionCriteria.score candidate.Criteria) / 8.0
     }
 
-    lineageStore.[lineage.Id] <- lineage
+    store.AddLineage lineage
 
     // If approved, update the recurrence record's level
     match decision with
@@ -259,13 +203,17 @@ let persist (candidate: PromotionCandidate) (decision: GovernanceDecision) : Lin
                 PromotionHistory =
                     candidate.Record.PromotionHistory
                     @ [ (candidate.ProposedLevel, DateTime.UtcNow) ] }
-        recurrenceStore.[candidate.Record.PatternName] <- updated
+        store.UpsertRecurrence updated
     | _ -> ()
 
     // Persist to disk after each decision
-    save () |> ignore
+    store.Flush ()
 
     lineage
+
+/// Persist using the process-global default store (backward-compatible entry point).
+let persist (candidate: PromotionCandidate) (decision: GovernanceDecision) : LineageRecord =
+    persistInto defaultStore candidate decision
 
 // ─────────────────────────────────────────────────────────────────────
 // Step 7: GOVERN — Grammar Governor makes final decision
@@ -286,18 +234,19 @@ type PipelineResult = {
     RoundtripValidation: RoundtripValidation.RoundtripResult option
 }
 
-/// Run the full 7-step promotion pipeline on a batch of trace artifacts.
+/// Run the full 7-step promotion pipeline on a batch of trace artifacts against
+/// a caller-supplied store (inject `defaultStore` for the process-global disk
+/// store, or an `InMemoryPromotionStore` for hermetic tests).
 /// Uses probabilistic weights to rank candidates and updates weights from outcomes.
-let run (minOccurrences: int) (artifacts: TraceArtifact list) : PipelineResult list =
-    ensureLoaded ()
-    let existing = recurrenceStore.Values |> Seq.toList
+let run (store: IPromotionStore) (minOccurrences: int) (artifacts: TraceArtifact list) : PipelineResult list =
+    let existing = store.GetRecurrence ()
 
     // Load probabilistic weights (empty list on first run)
-    let mutable weights = WeightedGrammar.load ()
+    let mutable weights = store.LoadWeights ()
 
     // Steps 1-2: Inspect and Extract
     let inspected = artifacts |> inspect
-    let records = inspected |> extract
+    let records = inspected |> extractInto store
 
     // Build a lookup of rollback expansions by pattern name
     let rollbackByPattern =
@@ -332,23 +281,12 @@ let run (minOccurrences: int) (artifacts: TraceArtifact list) : PipelineResult l
                 |> propose candidate.Record.PatternName rollback
                 |> validate existing None
 
-            let rawDecision = govern existing candidate
-
-            // Round-trip validation for approved promotions
-            let roundtripResult, decision =
-                match rawDecision with
-                | Approve _ ->
-                    let rtResult = RoundtripValidation.quickValidate candidate
-                    if rtResult.Passed then
-                        Some rtResult, rawDecision
-                    else
-                        let reason =
-                            sprintf "Round-trip validation failed (semantic match: %.2f). %s"
-                                rtResult.SemanticMatch
-                                (rtResult.Issues |> String.concat "; ")
-                        Some rtResult, Reject reason
-                | _ ->
-                    None, rawDecision
+            // ONE verdict from the gate: the Grammar Governor's decision plus
+            // any round-trip override, decided in a single place. The pipeline
+            // never re-inspects SemanticMatch to second-guess the decision.
+            let verdict = PromotionGate.decide RoundtripValidation.quickValidate existing candidate
+            let decision = verdict.Decision
+            let roundtripResult = verdict.Roundtrip
 
             // Update weight from governance outcome (Bayesian update)
             let success = match decision with Approve _ -> true | _ -> false
@@ -358,7 +296,7 @@ let run (minOccurrences: int) (artifacts: TraceArtifact list) : PipelineResult l
                         WeightedGrammar.updateWeight WeightedGrammar.defaultConfig w success
                     else w)
 
-            let lineage = persist candidate decision
+            let lineage = persistInto store candidate decision
             let report =
                 let govReport = GrammarGovernor.auditReport candidate decision
                 match roundtripResult with
@@ -372,19 +310,17 @@ let run (minOccurrences: int) (artifacts: TraceArtifact list) : PipelineResult l
               RoundtripValidation = roundtripResult })
 
     // Persist updated weights
-    WeightedGrammar.save weights
+    store.SaveWeights weights
 
     results
 
 /// Get all recurrence records (for inspection/debugging)
 let getRecurrenceRecords () : RecurrenceRecord list =
-    ensureLoaded ()
-    recurrenceStore.Values |> Seq.toList
+    defaultStore.GetRecurrence ()
 
 /// Get all lineage records
 let getLineageRecords () : LineageRecord list =
-    ensureLoaded ()
-    lineageStore.Values |> Seq.toList
+    defaultStore.GetLineage ()
 
 // ── Root-aware store access (hermetic, parallel-safe) ───────────────
 // The functions above read the process-global in-memory store (lazily
@@ -426,7 +362,5 @@ let saveStoresTo
 
 /// Get patterns at a specific promotion level
 let getPatternsAtLevel (level: PromotionLevel) : RecurrenceRecord list =
-    ensureLoaded ()
-    recurrenceStore.Values
-    |> Seq.filter (fun r -> r.CurrentLevel = level)
-    |> Seq.toList
+    defaultStore.GetRecurrence ()
+    |> List.filter (fun r -> r.CurrentLevel = level)

--- a/v2/src/Tars.Evolution/PromotionStore.fs
+++ b/v2/src/Tars.Evolution/PromotionStore.fs
@@ -1,0 +1,146 @@
+namespace Tars.Evolution
+
+/// Storage seam for the promotion pipeline.
+///
+/// `IPromotionStore` owns the three promotion stores — recurrence records,
+/// lineage records, and probabilistic weights — behind one interface so
+/// callers can swap the process-global disk store for an isolated in-memory
+/// one. The in-memory adapter is what ends test cross-contamination: each
+/// test gets its own store instead of racing the shared `~/.tars` state.
+
+open System
+open System.IO
+open System.Text.Json
+open System.Text.Json.Serialization
+open System.Collections.Concurrent
+
+/// The promotion pipeline's storage abstraction: recurrence + lineage + weights.
+type IPromotionStore =
+    /// All recurrence records currently known to the store.
+    abstract member GetRecurrence: unit -> RecurrenceRecord list
+    /// Look up a recurrence record by its pattern name.
+    abstract member TryGetRecurrence: name: string -> RecurrenceRecord option
+    /// Insert or replace a recurrence record (keyed by PatternName).
+    abstract member UpsertRecurrence: record: RecurrenceRecord -> unit
+    /// All lineage records currently known to the store.
+    abstract member GetLineage: unit -> LineageRecord list
+    /// Append a lineage record (keyed by Id).
+    abstract member AddLineage: record: LineageRecord -> unit
+    /// Load the probabilistic weights associated with this store.
+    abstract member LoadWeights: unit -> WeightedGrammar.WeightedRule list
+    /// Persist the probabilistic weights associated with this store.
+    abstract member SaveWeights: weights: WeightedGrammar.WeightedRule list -> unit
+    /// Flush recurrence + lineage state to durable storage (no-op in memory).
+    abstract member Flush: unit -> unit
+
+/// In-memory adapter — hermetic and parallel-safe. Holds all state in
+/// process memory and never touches disk. This is the adapter tests inject
+/// to avoid contaminating the shared promotion store.
+type InMemoryPromotionStore() =
+    let recurrence = ConcurrentDictionary<string, RecurrenceRecord>()
+    let lineage = ConcurrentDictionary<string, LineageRecord>()
+    let mutable weights : WeightedGrammar.WeightedRule list = []
+
+    interface IPromotionStore with
+        member _.GetRecurrence() = recurrence.Values |> Seq.toList
+        member _.TryGetRecurrence(name) =
+            match recurrence.TryGetValue name with
+            | true, r -> Some r
+            | false, _ -> None
+        member _.UpsertRecurrence(record) = recurrence.[record.PatternName] <- record
+        member _.GetLineage() = lineage.Values |> Seq.toList
+        member _.AddLineage(record) = lineage.[record.Id] <- record
+        member _.LoadWeights() = weights
+        member _.SaveWeights(w) = weights <- w
+        member _.Flush() = ()
+
+/// Disk adapter — the process-global store rooted at ~/.tars/promotion.
+/// Lazily loads recurrence + lineage from disk on first access and flushes
+/// them back after each decision, preserving the pipeline's prior behavior.
+/// Weights are delegated to `WeightedGrammar` (weights.json in the same dir).
+type DiskPromotionStore() =
+    let recurrence = ConcurrentDictionary<string, RecurrenceRecord>()
+    let lineage = ConcurrentDictionary<string, LineageRecord>()
+
+    let jsonOptions =
+        let o = JsonSerializerOptions(JsonSerializerDefaults.General)
+        o.Converters.Add(JsonFSharpConverter())
+        o.WriteIndented <- true
+        o
+
+    let getPromotionDir () =
+        let dir =
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".tars", "promotion")
+        if not (Directory.Exists dir) then
+            Directory.CreateDirectory dir |> ignore
+        dir
+
+    let load () =
+        try
+            let dir = getPromotionDir ()
+            let recurrencePath = Path.Combine(dir, "recurrence.json")
+            let lineagePath = Path.Combine(dir, "lineage.json")
+
+            if File.Exists recurrencePath then
+                let json = File.ReadAllText recurrencePath
+                let records = JsonSerializer.Deserialize<RecurrenceRecord list>(json, jsonOptions)
+                for r in records do
+                    recurrence.[r.PatternName] <- r
+
+            if File.Exists lineagePath then
+                let json = File.ReadAllText lineagePath
+                let records = JsonSerializer.Deserialize<LineageRecord list>(json, jsonOptions)
+                for r in records do
+                    lineage.[r.Id] <- r
+
+            Ok (recurrence.Count, lineage.Count)
+        with ex ->
+            Error $"Failed to load promotion state: {ex.Message}"
+
+    let initialized =
+        lazy (
+            match load () with
+            | Ok (r, l) ->
+                if r > 0 || l > 0 then
+                    Console.Error.WriteLine($"[Promotion] Loaded {r} recurrence records, {l} lineage records from disk")
+            | Error err ->
+                Console.Error.WriteLine($"[Promotion] {err}"))
+
+    let ensureLoaded () = initialized.Force()
+
+    let flush () =
+        try
+            let dir = getPromotionDir ()
+            let recurrenceData = recurrence.Values |> Seq.toList
+            let lineageData = lineage.Values |> Seq.toList
+            File.WriteAllText(
+                Path.Combine(dir, "recurrence.json"),
+                JsonSerializer.Serialize(recurrenceData, jsonOptions))
+            File.WriteAllText(
+                Path.Combine(dir, "lineage.json"),
+                JsonSerializer.Serialize(lineageData, jsonOptions))
+        with _ -> () // best-effort, matches prior save semantics
+
+    interface IPromotionStore with
+        member _.GetRecurrence() =
+            ensureLoaded ()
+            recurrence.Values |> Seq.toList
+        member _.TryGetRecurrence(name) =
+            ensureLoaded ()
+            match recurrence.TryGetValue name with
+            | true, r -> Some r
+            | false, _ -> None
+        member _.UpsertRecurrence(record) =
+            ensureLoaded ()
+            recurrence.[record.PatternName] <- record
+        member _.GetLineage() =
+            ensureLoaded ()
+            lineage.Values |> Seq.toList
+        member _.AddLineage(record) =
+            ensureLoaded ()
+            lineage.[record.Id] <- record
+        member _.LoadWeights() = WeightedGrammar.load ()
+        member _.SaveWeights(w) = WeightedGrammar.save w
+        member _.Flush() = flush ()

--- a/v2/src/Tars.Evolution/RetroactionLoop.fs
+++ b/v2/src/Tars.Evolution/RetroactionLoop.fs
@@ -415,7 +415,7 @@ Output JSON ONLY, no explanation.
               Score = score.Overall
               Timestamp = System.DateTime.UtcNow
               RollbackExpansion = pattern.RollbackExpansion }
-        PromotionPipeline.run 3 [ artifact ]
+        PromotionPipeline.run PromotionPipeline.defaultStore 3 [ artifact ]
 
     // =========================================================================
     // Cycle Metrics

--- a/v2/src/Tars.Evolution/Tars.Evolution.fsproj
+++ b/v2/src/Tars.Evolution/Tars.Evolution.fsproj
@@ -19,6 +19,8 @@
     <Compile Include="ResearchWeights.fs" />
     <Compile Include="ResearchCycle.fs" />
     <Compile Include="RoundtripValidation.fs" />
+    <Compile Include="PromotionStore.fs" />
+    <Compile Include="PromotionGate.fs" />
     <Compile Include="PromotionPipeline.fs" />
     <Compile Include="PromotionIndex.fs" />
     <Compile Include="StructuredOutput.fs" />

--- a/v2/src/Tars.Interface.Cli/Commands/PromoteCommand.fs
+++ b/v2/src/Tars.Interface.Cli/Commands/PromoteCommand.fs
@@ -206,7 +206,7 @@ let runPipeline (minOccurrences: int) =
         AnsiConsole.MarkupLine($"[dim]  Feeding {artifacts.Length} trace artifacts into pipeline...[/]")
         AnsiConsole.WriteLine()
 
-    let results = PromotionPipeline.run minOccurrences artifacts
+    let results = PromotionPipeline.run PromotionPipeline.defaultStore minOccurrences artifacts
 
     if jsonMode then
         // Headless: strict JSON only, no markup

--- a/v2/tests/Tars.Tests/PromotionPipelineTests.fs
+++ b/v2/tests/Tars.Tests/PromotionPipelineTests.fs
@@ -182,7 +182,7 @@ let ``Pipeline classify returns candidate for sufficient occurrence`` () =
 
 [<Fact>]
 let ``Pipeline full run handles empty input`` () =
-    let results = PromotionPipeline.run 3 []
+    let results = PromotionPipeline.run (InMemoryPromotionStore()) 3 []
     Assert.Empty(results)
 
 [<Fact>]


### PR DESCRIPTION
## Summary

Two commits, rebased clean onto current `main` (the stale pre-#185/#186/#187 base was dropped; only these two genuinely-new commits replay, no conflict).

- **`refactor(evolution)` — #42**: introduces `IPromotionStore` (recurrence + lineage + weights behind one interface) with `DiskPromotionStore` (the process-global `~/.tars/promotion` state) and `InMemoryPromotionStore` (hermetic, ends test cross-contamination) adapters; `PromotionGate.decide` returns **one** verdict with an injected `RoundtripValidator`; and **removes the verdict leak** where the pipeline re-inspected `RoundtripValidation.SemanticMatch` to override the GrammarGovernor decision. `PromotionPipeline.run` now takes the store as a parameter; the 5 call sites pass `defaultStore`; the empty-input test injects an in-memory store.
- **`chore(governance)`**: Demerzel submodule bumped to master tip `3398d0d3`.

## Verification

⚠️ **This environment has no dotnet SDK — the F# refactor was NOT built locally.** It was reviewed statically (compile-order in `Tars.Evolution.fsproj`, all `PromotionPipeline.run` call sites, zero dangling refs to the removed global-store symbols, `IPromotionStore` fully implemented by both adapters, verdict-leak relocation) with **no P0/P1 found — build-confidence medium-high**. **CI (`.NET` build + test) is the authoritative verification for this PR** — please let it run before merge.

## Scope / doors

Additive/refactor, two-way. Surgical: only the promotion store/gate/pipeline files the issue named + their forced call-site updates. No workflow changes. Follows the F# conventions (immutable types, `Result<>`, `TreatWarningsAsErrors`).

Closes #42

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvEdT41S77Lnm6dLBMHJSW)_