### PR TITLE
Refactor promotion store and gate to eliminate global state

### DIFF
--- a/v2/src/Tars.Evolution/GaPatternSeeder.fs
+++ b/v2/src/Tars.Evolution/GaPatternSeeder.fs
@@ -186,4 +186,6 @@ module GaPatternSeeder =
     /// Run the promotion pipeline on GA-discovered patterns.
     let seed (minOccurrences: int) : PromotionPipeline.PipelineResult list =
         let artifacts = gaTraceArtifacts ()
-        PromotionPipeline.run minOccurrences artifacts
+        let store = PromotionStore.createDefault ()
+        let gate = PromotionGate.createDefault None
+        PromotionPipeline.run store gate minOccurrences artifacts

--- a/v2/src/Tars.Evolution/GrammarDistillation.fs
+++ b/v2/src/Tars.Evolution/GrammarDistillation.fs
@@ -281,7 +281,7 @@ module GrammarDistillation =
     // =========================================================================
 
     /// Convert a TypedProduction to a WeightedRule for the Bayesian system.
-    let toWeightedRule (production: TypedProduction) : WeightedGrammar.WeightedRule =
+    let toWeightedRule (production: TypedProduction) : WeightedRule =
         { PatternId = production.Id
           PatternName = production.Name
           Level = production.SuggestedLevel
@@ -292,7 +292,7 @@ module GrammarDistillation =
           Confidence = min 1.0 (float production.TraceCount / 10.0)
           SuccessRate = production.SuccessRate
           SelectionCount = production.TraceCount
-          Source = WeightedGrammar.Evolved
+          Source = Evolved
           LastUpdated = production.LastUpdated }
 
     // =========================================================================

--- a/v2/src/Tars.Evolution/GrammarMlBridge.fs
+++ b/v2/src/Tars.Evolution/GrammarMlBridge.fs
@@ -222,8 +222,8 @@ module GrammarMlBridge =
     /// Use ix prediction as a Bayesian prior for a new production's weight.
     let applyPredictivePrior
         (prediction: MlPrediction)
-        (rule: WeightedGrammar.WeightedRule)
-        : WeightedGrammar.WeightedRule =
+        (rule: WeightedRule)
+        : WeightedRule =
 
         // Blend ix prediction with default prior, weighted by ix confidence
         let blendedRate =
@@ -233,7 +233,7 @@ module GrammarMlBridge =
         { rule with
             SuccessRate = blendedRate
             Confidence = max rule.Confidence (prediction.Confidence * 0.5)
-            Source = WeightedGrammar.Evolved }
+            Source = Evolved }
 
     // =========================================================================
     // Integration 3: Breed new productions via ix_evolution
@@ -314,9 +314,9 @@ module GrammarMlBridge =
     let evolveAsync
         (callIx: IxCaller)
         (productions: TypedProduction list)
-        (existingWeights: WeightedGrammar.WeightedRule list)
+        (existingWeights: WeightedRule list)
         (config: GrammarMlConfig)
-        : Async<Result<WeightedGrammar.WeightedRule list * BreedingResult option, string>> =
+        : Async<Result<WeightedRule list * BreedingResult option, string>> =
         async {
             if productions.Length < 3 then
                 return Error "Need at least 3 productions to train a model"

--- a/v2/src/Tars.Evolution/McpGaTraceBridge.fs
+++ b/v2/src/Tars.Evolution/McpGaTraceBridge.fs
@@ -58,7 +58,9 @@ module McpGaTraceBridge =
                       Promotions = 0; Rejections = 0
                       Details = ["No GA trace files found in ~/.ga/traces/"] }, jsonOptions))
             else
-                let results = PromotionPipeline.run minOcc artifacts
+                let store = PromotionStore.createDefault ()
+                let gate = PromotionGate.createDefault None
+                let results = PromotionPipeline.run store gate minOcc artifacts
                 let promotions = results |> List.filter (fun r ->
                     match r.Decision with GovernanceDecision.Approve _ -> true | _ -> false)
                 let rejections = results |> List.filter (fun r ->
@@ -78,7 +80,7 @@ module McpGaTraceBridge =
                     PipelineResults = results.Length
                     Promotions = promotions.Length
                     Rejections = rejections.Length
-                    Details = details
+                    Details = (details |> Seq.toList)
                 }
                 Result.Ok (JsonSerializer.Serialize(response, jsonOptions))
         with ex ->

--- a/v2/src/Tars.Evolution/McpGrammarTools.fs
+++ b/v2/src/Tars.Evolution/McpGrammarTools.fs
@@ -80,14 +80,15 @@ module McpGrammarTools =
     let private grammarUpdate (input: string) : Result<string, string> =
         try
             let req = JsonSerializer.Deserialize<UpdateInput>(input, jsonOptions)
-            let rules = WeightedGrammar.load ()
+            let store = PromotionStore.createDefault ()
+            let rules = store.GetWeights()
             match rules |> List.tryFind (fun r -> r.PatternId = req.PatternId) with
             | None -> Result.Error $"Rule not found: {req.PatternId}"
             | Some rule ->
                 let updated = WeightedGrammar.updateWeight WeightedGrammar.defaultConfig rule req.Success
                 let newRules = rules |> List.map (fun r ->
                     if r.PatternId = req.PatternId then updated else r)
-                WeightedGrammar.save newRules
+                store.SaveWeights newRules
                 let response = {
                     PatternId = req.PatternId
                     OldWeight = rule.Weight

--- a/v2/src/Tars.Evolution/McpPatternResources.fs
+++ b/v2/src/Tars.Evolution/McpPatternResources.fs
@@ -223,8 +223,9 @@ module McpPatternResources =
     let getPromotionStatus (_input: string) : Async<Result<string, string>> =
         async {
             try
-                let records = PromotionPipeline.getRecurrenceRecords ()
-                let lineage = PromotionPipeline.getLineageRecords ()
+                let store = PromotionStore.createDefault ()
+                let records = PromotionPipeline.getRecurrenceRecords store
+                let lineage = PromotionPipeline.getLineageRecords store
 
                 let recurrenceOutputs = records |> List.map StructuredOutput.fromRecurrence
                 let byLevel =
@@ -256,7 +257,8 @@ module McpPatternResources =
     let getPromotionLineage (_input: string) : Async<Result<string, string>> =
         async {
             try
-                let lineage = PromotionPipeline.getLineageRecords ()
+                let store = PromotionStore.createDefault ()
+                let lineage = PromotionPipeline.getLineageRecords store
 
                 let outputs =
                     lineage
@@ -286,7 +288,7 @@ module McpPatternResources =
         }
 
     /// Run the promotion pipeline and return structured JSON results.
-    let runPromotionPipeline (input: string) : Async<Result<string, string>> =
+    let runPromotionPipeline (llm: ILlmService option) (input: string) : Async<Result<string, string>> =
         async {
             try
                 let minOccurrences =
@@ -294,8 +296,9 @@ module McpPatternResources =
                     | true, v when v > 0 -> v
                     | _ -> 3
 
+                let store = PromotionStore.createDefault ()
                 // Use existing recurrence records if available, otherwise create test data
-                let existingRecords = PromotionPipeline.getRecurrenceRecords ()
+                let existingRecords = PromotionPipeline.getRecurrenceRecords store
                 let artifacts =
                     if existingRecords.IsEmpty then
                         // No data yet — return empty run
@@ -314,8 +317,9 @@ module McpPatternResources =
                                   Timestamp = DateTime.UtcNow
                                   RollbackExpansion = None } : PromotionPipeline.TraceArtifact))
 
-                let results = PromotionPipeline.run minOccurrences artifacts
-                let json = StructuredOutput.pipelineRunToJson results artifacts.Length
+                let gate = PromotionGate.createDefault llm
+                let results = PromotionPipeline.run store gate minOccurrences artifacts
+                let json = StructuredOutput.pipelineRunToJson store results artifacts.Length
                 return Ok json
             with ex ->
                 return Error (sprintf "Failed to run promotion pipeline: %s" ex.Message)
@@ -377,4 +381,4 @@ module McpPatternResources =
             Version = "1.0"
             ParentVersion = None
             CreatedAt = DateTime.UtcNow
-            Execute = runPromotionPipeline } ]
+            Execute = runPromotionPipeline llm } ]

--- a/v2/src/Tars.Evolution/PromotionGate.fs
+++ b/v2/src/Tars.Evolution/PromotionGate.fs
@@ -1,0 +1,28 @@
+namespace Tars.Evolution
+
+open System
+
+type DefaultPromotionGate(validator: IRoundtripValidator) =
+    interface IPromotionGate with
+        member _.Decide(existing: RecurrenceRecord list, candidate: PromotionCandidate) : GovernanceDecision * RoundtripResult option =
+            let rawDecision = GrammarGovernor.evaluate existing candidate
+
+            match rawDecision with
+            | Approve _ ->
+                let rtResult = validator.Validate candidate
+                if rtResult.Passed then
+                    rawDecision, Some rtResult
+                else
+                    let reason =
+                        sprintf "Round-trip validation failed (semantic match: %.2f). %s"
+                            rtResult.SemanticMatch
+                            (rtResult.Issues |> String.concat "; ")
+                    Reject reason, Some rtResult
+            | _ ->
+                rawDecision, None
+
+module PromotionGate =
+    let create validator = DefaultPromotionGate(validator) :> IPromotionGate
+    let createDefault (llm: Tars.Llm.ILlmService option) =
+        let validator = RoundtripValidation.DefaultRoundtripValidator(llm) :> IRoundtripValidator
+        create validator

--- a/v2/src/Tars.Evolution/PromotionIndex.fs
+++ b/v2/src/Tars.Evolution/PromotionIndex.fs
@@ -36,24 +36,25 @@ module PromotionIndex =
         o.Converters.Add(JsonFSharpConverter())
         o
 
-    let private indexPath () =
-        let dir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".tars", "promotion")
+    let private indexPath (promotionDir: string option) =
+        let dir =
+            match promotionDir with
+            | Some d -> d
+            | None ->
+                Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".tars", "promotion")
         if not (Directory.Exists dir) then
             Directory.CreateDirectory dir |> ignore
         Path.Combine(dir, "index.json")
 
     // ── Build index from live promotion stores ──────────────────────
 
-    /// Build the index from explicit records/weights/lineage. Pure: no I/O,
-    /// no global state — the testable core shared by the live and
-    /// directory-scoped builders below.
-    let buildFrom
-        (records: RecurrenceRecord list)
-        (weights: WeightedGrammar.WeightedRule list)
-        (lineage: LineageRecord list)
-        : PromotionIndexData =
+    /// Build the index from an explicit IPromotionStore. Pure-ish: no global state.
+    let buildFrom (store: IPromotionStore) : PromotionIndexData =
+        let records = store.GetRecurrenceRecords()
+        let weights = store.GetWeights()
+        let lineage = store.GetLineageRecords()
 
         // Find the most recent rollback expansion from lineage for each pattern
         let rollbackByPattern =
@@ -95,21 +96,13 @@ module PromotionIndex =
           GeneratedAt = DateTime.UtcNow
           PatternCount = entries.Length }
 
-    /// Build the index from the live, process-global promotion stores.
+    /// Build the index from the default promotion store.
     let build () : PromotionIndexData =
-        buildFrom
-            (PromotionPipeline.getRecurrenceRecords ())
-            (WeightedGrammar.load ())
-            (PromotionPipeline.getLineageRecords ())
+        buildFrom (PromotionStore.createDefault ())
 
-    /// Build the index from an isolated promotion directory (reads disk
-    /// directly, bypassing the shared in-memory store). Hermetic and
-    /// parallel-safe — the basis for deterministic tests.
+    /// Build the index from an isolated promotion directory.
     let buildFromDir (promotionDir: string) : PromotionIndexData =
-        buildFrom
-            (PromotionPipeline.recurrenceRecordsFrom promotionDir)
-            (WeightedGrammar.loadFrom promotionDir)
-            (PromotionPipeline.lineageRecordsFrom promotionDir)
+        buildFrom (PromotionStore.createFileNamed promotionDir)
 
     /// Persist the index to a specific promotion directory.
     let saveTo (promotionDir: string) (index: PromotionIndexData) : unit =
@@ -123,7 +116,7 @@ module PromotionIndex =
     let save (index: PromotionIndexData) : unit =
         try
             let json = JsonSerializer.Serialize(index, jsonOptions)
-            File.WriteAllText(indexPath (), json)
+            File.WriteAllText(indexPath None, json)
         with _ -> () // Best-effort
 
     /// Load a persisted index from a specific promotion directory.
@@ -140,7 +133,7 @@ module PromotionIndex =
     /// Load the persisted index from disk.
     let load () : PromotionIndexData option =
         try
-            let path = indexPath ()
+            let path = indexPath None
             if File.Exists path then
                 let json = File.ReadAllText path
                 Some (JsonSerializer.Deserialize<PromotionIndexData>(json, jsonOptions))

--- a/v2/src/Tars.Evolution/PromotionPipeline.fs
+++ b/v2/src/Tars.Evolution/PromotionPipeline.fs
@@ -7,85 +7,6 @@ module Tars.Evolution.PromotionPipeline
 /// recur across tasks are promoted up the staircase, gated by the Grammar Governor.
 
 open System
-open System.IO
-open System.Text.Json
-open System.Text.Json.Serialization
-
-// ─────────────────────────────────────────────────────────────────────
-// State: persistent recurrence and lineage stores
-// ─────────────────────────────────────────────────────────────────────
-
-let private recurrenceStore =
-    System.Collections.Concurrent.ConcurrentDictionary<string, RecurrenceRecord>()
-
-let private lineageStore =
-    System.Collections.Concurrent.ConcurrentDictionary<string, LineageRecord>()
-
-let private jsonOptions =
-    let o = JsonSerializerOptions(JsonSerializerDefaults.General)
-    o.Converters.Add(JsonFSharpConverter())
-    o.WriteIndented <- true
-    o
-
-let private getPromotionDir () =
-    let dir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        ".tars", "promotion")
-    if not (Directory.Exists dir) then
-        Directory.CreateDirectory dir |> ignore
-    dir
-
-/// Save recurrence and lineage stores to disk.
-let save () =
-    try
-        let dir = getPromotionDir ()
-        let recurrencePath = Path.Combine(dir, "recurrence.json")
-        let lineagePath = Path.Combine(dir, "lineage.json")
-
-        let recurrenceData = recurrenceStore.Values |> Seq.toList
-        let lineageData = lineageStore.Values |> Seq.toList
-
-        File.WriteAllText(recurrencePath, JsonSerializer.Serialize(recurrenceData, jsonOptions))
-        File.WriteAllText(lineagePath, JsonSerializer.Serialize(lineageData, jsonOptions))
-        Ok (recurrenceData.Length, lineageData.Length)
-    with ex ->
-        Error $"Failed to save promotion state: {ex.Message}"
-
-/// Load recurrence and lineage stores from disk.
-let load () =
-    try
-        let dir = getPromotionDir ()
-        let recurrencePath = Path.Combine(dir, "recurrence.json")
-        let lineagePath = Path.Combine(dir, "lineage.json")
-
-        if File.Exists recurrencePath then
-            let json = File.ReadAllText(recurrencePath)
-            let records = JsonSerializer.Deserialize<RecurrenceRecord list>(json, jsonOptions)
-            for r in records do
-                recurrenceStore.[r.PatternName] <- r
-
-        if File.Exists lineagePath then
-            let json = File.ReadAllText(lineagePath)
-            let records = JsonSerializer.Deserialize<LineageRecord list>(json, jsonOptions)
-            for r in records do
-                lineageStore.[r.Id] <- r
-
-        Ok (recurrenceStore.Count, lineageStore.Count)
-    with ex ->
-        Error $"Failed to load promotion state: {ex.Message}"
-
-/// Initialize: load from disk on first use.
-let private initialized =
-    lazy (
-        match load () with
-        | Ok (r, l) ->
-            if r > 0 || l > 0 then
-                Console.Error.WriteLine($"[Promotion] Loaded {r} recurrence records, {l} lineage records from disk")
-        | Error err ->
-            Console.Error.WriteLine($"[Promotion] {err}")
-    )
-
-let private ensureLoaded () = initialized.Force()
 
 // ─────────────────────────────────────────────────────────────────────
 // Step 1: INSPECT — Analyze completed work artifacts
@@ -110,15 +31,16 @@ let inspect (artifacts: TraceArtifact list) : TraceArtifact list =
 // Step 2: EXTRACT — Pull recurring structural patterns
 // ─────────────────────────────────────────────────────────────────────
 
-let extract (artifacts: TraceArtifact list) : RecurrenceRecord list =
-    ensureLoaded ()
+let extract (store: IPromotionStore) (artifacts: TraceArtifact list) : RecurrenceRecord list =
+    let existingRecords = store.GetRecurrenceRecords() |> List.map (fun r -> r.PatternName, r) |> Map.ofList
+
     artifacts
     |> List.groupBy (fun a -> a.PatternName)
     |> List.map (fun (name, group) ->
         let existing =
-            match recurrenceStore.TryGetValue(name) with
-            | true, r -> r
-            | false, _ ->
+            match existingRecords |> Map.tryFind name with
+            | Some r -> r
+            | None ->
                 { PatternId = Guid.NewGuid().ToString("N").[..7]
                   PatternName = name
                   FirstSeen = DateTime.UtcNow
@@ -143,7 +65,7 @@ let extract (artifacts: TraceArtifact list) : RecurrenceRecord list =
                 Contexts = (existing.Contexts @ newContexts) |> List.distinct
                 AverageScore = avgScore }
 
-        recurrenceStore.[name] <- updated
+        store.UpsertRecurrenceRecord updated
         updated)
 
 // ─────────────────────────────────────────────────────────────────────
@@ -171,7 +93,7 @@ let classify (minOccurrences: int) (record: RecurrenceRecord) : PromotionCandida
 /// probability so higher-weight patterns are promoted first.
 let classifyWeighted
     (minOccurrences: int)
-    (weights: WeightedGrammar.WeightedRule list)
+    (weights: WeightedRule list)
     (records: RecurrenceRecord list)
     : PromotionCandidate list =
     records
@@ -233,7 +155,7 @@ let validate
 // Step 6: PERSIST — Store the decision and update lineage
 // ─────────────────────────────────────────────────────────────────────
 
-let persist (candidate: PromotionCandidate) (decision: GovernanceDecision) : LineageRecord =
+let persist (store: IPromotionStore) (candidate: PromotionCandidate) (decision: GovernanceDecision) : LineageRecord =
     let lineage = {
         Id = Guid.NewGuid().ToString("N").[..7]
         PatternId = candidate.Record.PatternId
@@ -248,7 +170,7 @@ let persist (candidate: PromotionCandidate) (decision: GovernanceDecision) : Lin
         Confidence = float (PromotionCriteria.score candidate.Criteria) / 8.0
     }
 
-    lineageStore.[lineage.Id] <- lineage
+    store.AddLineageRecord lineage
 
     // If approved, update the recurrence record's level
     match decision with
@@ -259,11 +181,8 @@ let persist (candidate: PromotionCandidate) (decision: GovernanceDecision) : Lin
                 PromotionHistory =
                     candidate.Record.PromotionHistory
                     @ [ (candidate.ProposedLevel, DateTime.UtcNow) ] }
-        recurrenceStore.[candidate.Record.PatternName] <- updated
+        store.UpsertRecurrenceRecord updated
     | _ -> ()
-
-    // Persist to disk after each decision
-    save () |> ignore
 
     lineage
 
@@ -283,21 +202,20 @@ type PipelineResult = {
     Decision: GovernanceDecision
     Lineage: LineageRecord
     AuditReport: string
-    RoundtripValidation: RoundtripValidation.RoundtripResult option
+    RoundtripValidation: RoundtripResult option
 }
 
 /// Run the full 7-step promotion pipeline on a batch of trace artifacts.
 /// Uses probabilistic weights to rank candidates and updates weights from outcomes.
-let run (minOccurrences: int) (artifacts: TraceArtifact list) : PipelineResult list =
-    ensureLoaded ()
-    let existing = recurrenceStore.Values |> Seq.toList
+let run (store: IPromotionStore) (gate: IPromotionGate) (minOccurrences: int) (artifacts: TraceArtifact list) : PipelineResult list =
+    let existing = store.GetRecurrenceRecords()
 
-    // Load probabilistic weights (empty list on first run)
-    let mutable weights = WeightedGrammar.load ()
+    // Load probabilistic weights
+    let mutable weights = store.GetWeights()
 
     // Steps 1-2: Inspect and Extract
     let inspected = artifacts |> inspect
-    let records = inspected |> extract
+    let records = inspected |> extract store
 
     // Build a lookup of rollback expansions by pattern name
     let rollbackByPattern =
@@ -332,23 +250,7 @@ let run (minOccurrences: int) (artifacts: TraceArtifact list) : PipelineResult l
                 |> propose candidate.Record.PatternName rollback
                 |> validate existing None
 
-            let rawDecision = govern existing candidate
-
-            // Round-trip validation for approved promotions
-            let roundtripResult, decision =
-                match rawDecision with
-                | Approve _ ->
-                    let rtResult = RoundtripValidation.quickValidate candidate
-                    if rtResult.Passed then
-                        Some rtResult, rawDecision
-                    else
-                        let reason =
-                            sprintf "Round-trip validation failed (semantic match: %.2f). %s"
-                                rtResult.SemanticMatch
-                                (rtResult.Issues |> String.concat "; ")
-                        Some rtResult, Reject reason
-                | _ ->
-                    None, rawDecision
+            let decision, roundtripResult = gate.Decide(existing, candidate)
 
             // Update weight from governance outcome (Bayesian update)
             let success = match decision with Approve _ -> true | _ -> false
@@ -358,7 +260,7 @@ let run (minOccurrences: int) (artifacts: TraceArtifact list) : PipelineResult l
                         WeightedGrammar.updateWeight WeightedGrammar.defaultConfig w success
                     else w)
 
-            let lineage = persist candidate decision
+            let lineage = persist store candidate decision
             let report =
                 let govReport = GrammarGovernor.auditReport candidate decision
                 match roundtripResult with
@@ -372,61 +274,20 @@ let run (minOccurrences: int) (artifacts: TraceArtifact list) : PipelineResult l
               RoundtripValidation = roundtripResult })
 
     // Persist updated weights
-    WeightedGrammar.save weights
+    store.SaveWeights weights
 
     results
 
 /// Get all recurrence records (for inspection/debugging)
-let getRecurrenceRecords () : RecurrenceRecord list =
-    ensureLoaded ()
-    recurrenceStore.Values |> Seq.toList
+let getRecurrenceRecords (store: IPromotionStore) : RecurrenceRecord list =
+    store.GetRecurrenceRecords()
 
 /// Get all lineage records
-let getLineageRecords () : LineageRecord list =
-    ensureLoaded ()
-    lineageStore.Values |> Seq.toList
-
-// ── Root-aware store access (hermetic, parallel-safe) ───────────────
-// The functions above read the process-global in-memory store (lazily
-// loaded once from ~/.tars). These read/write a caller-supplied
-// promotion directory directly, so callers (notably tests) can operate
-// on an isolated store without racing the shared one.
-
-/// Read recurrence records straight from a specific promotion directory.
-let recurrenceRecordsFrom (promotionDir: string) : RecurrenceRecord list =
-    try
-        let path = Path.Combine(promotionDir, "recurrence.json")
-        if File.Exists path then
-            JsonSerializer.Deserialize<RecurrenceRecord list>(File.ReadAllText path, jsonOptions)
-        else []
-    with _ -> []
-
-/// Read lineage records straight from a specific promotion directory.
-let lineageRecordsFrom (promotionDir: string) : LineageRecord list =
-    try
-        let path = Path.Combine(promotionDir, "lineage.json")
-        if File.Exists path then
-            JsonSerializer.Deserialize<LineageRecord list>(File.ReadAllText path, jsonOptions)
-        else []
-    with _ -> []
-
-/// Persist recurrence + lineage stores to a specific promotion directory.
-let saveStoresTo
-    (promotionDir: string)
-    (recurrence: RecurrenceRecord list)
-    (lineage: LineageRecord list)
-    : unit =
-    Directory.CreateDirectory promotionDir |> ignore
-    File.WriteAllText(
-        Path.Combine(promotionDir, "recurrence.json"),
-        JsonSerializer.Serialize(recurrence, jsonOptions))
-    File.WriteAllText(
-        Path.Combine(promotionDir, "lineage.json"),
-        JsonSerializer.Serialize(lineage, jsonOptions))
+let getLineageRecords (store: IPromotionStore) : LineageRecord list =
+    store.GetLineageRecords()
 
 /// Get patterns at a specific promotion level
-let getPatternsAtLevel (level: PromotionLevel) : RecurrenceRecord list =
-    ensureLoaded ()
-    recurrenceStore.Values
+let getPatternsAtLevel (store: IPromotionStore) (level: PromotionLevel) : RecurrenceRecord list =
+    store.GetRecurrenceRecords()
     |> Seq.filter (fun r -> r.CurrentLevel = level)
     |> Seq.toList

--- a/v2/src/Tars.Evolution/PromotionStore.fs
+++ b/v2/src/Tars.Evolution/PromotionStore.fs
@@ -1,0 +1,142 @@
+namespace Tars.Evolution
+
+open System
+open System.IO
+open System.Text.Json
+open System.Text.Json.Serialization
+open System.Collections.Concurrent
+
+module private StoreUtils =
+    let jsonOptions =
+        let o = JsonSerializerOptions(JsonSerializerDefaults.General)
+        o.Converters.Add(JsonFSharpConverter())
+        o.WriteIndented <- true
+        o
+
+    let getDefaultPromotionDir () =
+        let dir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".tars", "promotion")
+        if not (Directory.Exists dir) then
+            Directory.CreateDirectory dir |> ignore
+        dir
+
+/// DTO for JSON serialization of WeightedRule to match legacy format
+type WeightedRuleDto = {
+    PatternId: string
+    PatternName: string
+    Level: string
+    RawScore: int
+    Weight: float
+    Confidence: float
+    SuccessRate: float
+    SelectionCount: int
+    Source: string
+    LastUpdated: string
+}
+
+type InMemoryPromotionStore() =
+    let recurrenceStore = ConcurrentDictionary<string, RecurrenceRecord>()
+    let lineageStore = ConcurrentDictionary<string, LineageRecord>()
+    let mutable weightsStore : WeightedRule list = []
+
+    interface IPromotionStore with
+        member _.GetRecurrenceRecords() = recurrenceStore.Values |> Seq.toList
+        member _.UpsertRecurrenceRecord(r) = recurrenceStore.[r.PatternName] <- r
+        member _.GetLineageRecords() = lineageStore.Values |> Seq.toList
+        member _.AddLineageRecord(l) = lineageStore.[l.Id] <- l
+        member _.GetWeights() = weightsStore
+        member _.SaveWeights(w) = weightsStore <- w
+
+type FilePromotionStore(promotionDir: string) =
+    let recurrencePath = Path.Combine(promotionDir, "recurrence.json")
+    let lineagePath = Path.Combine(promotionDir, "lineage.json")
+    let weightsPath = Path.Combine(promotionDir, "weights.json")
+
+    let toDto (r: WeightedRule) : WeightedRuleDto =
+        { PatternId = r.PatternId
+          PatternName = r.PatternName
+          Level = PromotionLevel.label r.Level
+          RawScore = r.RawScore
+          Weight = r.Weight
+          Confidence = r.Confidence
+          SuccessRate = r.SuccessRate
+          SelectionCount = r.SelectionCount
+          Source = match r.Source with
+                   | Tars -> "tars" | GuitarAlchemist -> "guitar_alchemist"
+                   | MachinDeOuf -> "ix" | Evolved -> "evolved" | Manual -> "manual"
+          LastUpdated = r.LastUpdated.ToString("o") }
+
+    let fromDto (dto: WeightedRuleDto) : WeightedRule =
+        let level =
+            match dto.Level with
+            | "helper" -> Helper | "builder" -> Builder
+            | "dsl_clause" -> DslClause | "grammar_rule" -> GrammarRule
+            | _ -> Implementation
+        let source =
+            match dto.Source with
+            | "guitar_alchemist" -> GuitarAlchemist | "ix" -> MachinDeOuf
+            | "evolved" -> Evolved | "manual" -> Manual | _ -> Tars
+        { PatternId = dto.PatternId
+          PatternName = dto.PatternName
+          Level = level
+          RawScore = dto.RawScore
+          Weight = dto.Weight
+          Confidence = dto.Confidence
+          SuccessRate = dto.SuccessRate
+          SelectionCount = dto.SelectionCount
+          Source = source
+          LastUpdated = try DateTime.Parse(dto.LastUpdated) with _ -> DateTime.UtcNow }
+
+    interface IPromotionStore with
+        member _.GetRecurrenceRecords() =
+            try
+                if File.Exists recurrencePath then
+                    let json = File.ReadAllText(recurrencePath)
+                    JsonSerializer.Deserialize<RecurrenceRecord list>(json, StoreUtils.jsonOptions)
+                else []
+            with _ -> []
+
+        member this.UpsertRecurrenceRecord(r) =
+            let store = this :> IPromotionStore
+            let records = store.GetRecurrenceRecords()
+            let updated =
+                match records |> List.tryFindIndex (fun x -> x.PatternName = r.PatternName) with
+                | Some idx -> records |> List.updateAt idx r
+                | None -> r :: records
+            if not (Directory.Exists promotionDir) then Directory.CreateDirectory promotionDir |> ignore
+            File.WriteAllText(recurrencePath, JsonSerializer.Serialize(updated, StoreUtils.jsonOptions))
+
+        member _.GetLineageRecords() =
+            try
+                if File.Exists lineagePath then
+                    let json = File.ReadAllText(lineagePath)
+                    JsonSerializer.Deserialize<LineageRecord list>(json, StoreUtils.jsonOptions)
+                else []
+            with _ -> []
+
+        member this.AddLineageRecord(l) =
+            let store = this :> IPromotionStore
+            let records = store.GetLineageRecords()
+            let updated = l :: records
+            if not (Directory.Exists promotionDir) then Directory.CreateDirectory promotionDir |> ignore
+            File.WriteAllText(lineagePath, JsonSerializer.Serialize(updated, StoreUtils.jsonOptions))
+
+        member this.GetWeights() =
+            try
+                if File.Exists weightsPath then
+                    let json = File.ReadAllText(weightsPath)
+                    let dtos = JsonSerializer.Deserialize<WeightedRuleDto list>(json, StoreUtils.jsonOptions)
+                    dtos |> List.map fromDto
+                else []
+            with _ -> []
+
+        member this.SaveWeights(weights) =
+            let dtos = weights |> List.map toDto
+            if not (Directory.Exists promotionDir) then Directory.CreateDirectory promotionDir |> ignore
+            File.WriteAllText(weightsPath, JsonSerializer.Serialize(dtos, StoreUtils.jsonOptions))
+
+module PromotionStore =
+    let createInMemory () = InMemoryPromotionStore() :> IPromotionStore
+    let createFileNamed (dir: string) = FilePromotionStore(dir) :> IPromotionStore
+    let createDefault () = createFileNamed (StoreUtils.getDefaultPromotionDir())

--- a/v2/src/Tars.Evolution/PromotionTypes.fs
+++ b/v2/src/Tars.Evolution/PromotionTypes.fs
@@ -79,6 +79,57 @@ type GovernanceDecision =
     | Reject of reason: string
     | Defer of reason: string
 
+/// Round-trip validation result.
+type RoundtripResult = {
+    PatternId: string
+    OriginalTemplate: string       // The promoted abstraction
+    ExpandedCode: string           // The lower-level expansion
+    ReconstructedTemplate: string  // Re-abstracted from expanded code
+    SemanticMatch: float           // 0.0-1.0 how similar original and reconstructed are
+    Passed: bool                   // SemanticMatch >= threshold
+    Issues: string list            // Any detected semantic losses
+}
+
+module RoundtripResult =
+    let empty patternId = {
+        PatternId = patternId
+        OriginalTemplate = ""
+        ExpandedCode = ""
+        ReconstructedTemplate = ""
+        SemanticMatch = 0.0
+        Passed = false
+        Issues = []
+    }
+
+/// Source system that produced/evolved a rule's weight
+type RuleSource =
+    | Tars
+    | GuitarAlchemist
+    | MachinDeOuf
+    | Evolved
+    | Manual
+
+/// A grammar rule annotated with probabilistic weight metadata
+type WeightedRule = {
+    PatternId: string
+    PatternName: string
+    Level: PromotionLevel
+    /// Raw 0-8 criteria score from GrammarGovernor
+    RawScore: int
+    /// Current probability weight in [0.0, 1.0]
+    Weight: float
+    /// Bayesian confidence in the weight estimate (higher = more certain)
+    Confidence: float
+    /// Success rate from execution outcomes
+    SuccessRate: float
+    /// How many times this rule has been selected for use
+    SelectionCount: int
+    /// Who/what assigned this weight
+    Source: RuleSource
+    /// When the weight was last updated
+    LastUpdated: DateTime
+}
+
 /// A promotion candidate submitted for governance review
 type PromotionCandidate = {
     Record: RecurrenceRecord
@@ -103,6 +154,23 @@ type LineageRecord = {
     PromotedBy: string
     Confidence: float
 }
+
+/// Store for promotion-related data
+type IPromotionStore =
+    abstract member GetRecurrenceRecords: unit -> RecurrenceRecord list
+    abstract member UpsertRecurrenceRecord: RecurrenceRecord -> unit
+    abstract member GetLineageRecords: unit -> LineageRecord list
+    abstract member AddLineageRecord: LineageRecord -> unit
+    abstract member GetWeights: unit -> WeightedRule list
+    abstract member SaveWeights: WeightedRule list -> unit
+
+/// Validates promotions by expansion and re-abstraction
+type IRoundtripValidator =
+    abstract member Validate: candidate: PromotionCandidate -> RoundtripResult
+
+/// Gates pattern promotions
+type IPromotionGate =
+    abstract member Decide: existing: RecurrenceRecord list * candidate: PromotionCandidate -> GovernanceDecision * RoundtripResult option
 
 /// Layer 4: Evolution metadata attached to grammar nodes
 type EvolutionMetadata = {

--- a/v2/src/Tars.Evolution/ReplicatorDynamics.fs
+++ b/v2/src/Tars.Evolution/ReplicatorDynamics.fs
@@ -87,7 +87,7 @@ module ReplicatorDynamics =
 
     /// Build species from weighted rules with outcome data
     let buildSpecies
-        (rules: WeightedGrammar.WeightedRule list)
+        (rules: WeightedRule list)
         (outcomesById: Map<string, (bool * int64) list>)
         : GrammarSpecies list =
         if rules.IsEmpty then []
@@ -185,7 +185,7 @@ module ReplicatorDynamics =
 
     /// Quick run with default config
     let evolveEcosystem
-        (rules: WeightedGrammar.WeightedRule list)
+        (rules: WeightedRule list)
         (outcomesById: Map<string, (bool * int64) list>)
         : ReplicatorResult =
         let species = buildSpecies rules outcomesById

--- a/v2/src/Tars.Evolution/RetroactionLoop.fs
+++ b/v2/src/Tars.Evolution/RetroactionLoop.fs
@@ -403,6 +403,7 @@ Output JSON ONLY, no explanation.
     /// Feed a completed execution into the promotion pipeline.
     /// Converts cycle data into TraceArtifacts and runs the 7-step loop.
     let feedPromotionPipeline
+        (llm: ILlmService option)
         (problem: Problem)
         (score: ExecutionScore)
         (pattern: PatternDefinition)
@@ -415,7 +416,9 @@ Output JSON ONLY, no explanation.
               Score = score.Overall
               Timestamp = System.DateTime.UtcNow
               RollbackExpansion = pattern.RollbackExpansion }
-        PromotionPipeline.run 3 [ artifact ]
+        let store = PromotionStore.createDefault ()
+        let gate = PromotionGate.createDefault llm
+        PromotionPipeline.run store gate 3 [ artifact ]
 
     // =========================================================================
     // Cycle Metrics
@@ -498,7 +501,7 @@ Output JSON ONLY, no explanation.
                         match newPattern with
                         | Some pattern ->
                             Console.WriteLine("[Retroaction] Feeding promotion pipeline...")
-                            let results = feedPromotionPipeline problem score pattern
+                            let results = feedPromotionPipeline (Some llm) problem score pattern
                             for r in results do
                                 Console.WriteLine(r.AuditReport)
 

--- a/v2/src/Tars.Evolution/RoundtripValidation.fs
+++ b/v2/src/Tars.Evolution/RoundtripValidation.fs
@@ -11,31 +11,6 @@ module Tars.Evolution.RoundtripValidation
 open System
 
 // ─────────────────────────────────────────────────────────────────────
-// Types
-// ─────────────────────────────────────────────────────────────────────
-
-type RoundtripResult = {
-    PatternId: string
-    OriginalTemplate: string       // The promoted abstraction
-    ExpandedCode: string           // The lower-level expansion
-    ReconstructedTemplate: string  // Re-abstracted from expanded code
-    SemanticMatch: float           // 0.0-1.0 how similar original and reconstructed are
-    Passed: bool                   // SemanticMatch >= threshold
-    Issues: string list            // Any detected semantic losses
-}
-
-module RoundtripResult =
-    let empty patternId = {
-        PatternId = patternId
-        OriginalTemplate = ""
-        ExpandedCode = ""
-        ReconstructedTemplate = ""
-        SemanticMatch = 0.0
-        Passed = false
-        Issues = []
-    }
-
-// ─────────────────────────────────────────────────────────────────────
 // Helpers: structural comparison
 // ─────────────────────────────────────────────────────────────────────
 
@@ -287,6 +262,18 @@ ISSUES: <comma-separated list of issues, or "none">"""
                     { structural with
                         Issues = (sprintf "LLM validation failed (%s), fell back to structural" ex.Message) :: structural.Issues }
     }
+
+/// Default implementation of IRoundtripValidator
+type DefaultRoundtripValidator(llm: Tars.Llm.ILlmService option) =
+    interface IRoundtripValidator with
+        member _.Validate(candidate: PromotionCandidate) =
+            match llm with
+            | Some llmSvc ->
+                // Async to Sync for the interface - usually not ideal but for this refactor we'll keep it simple
+                // or we could make the interface async. Given the current pipeline is sync-ish.
+                validateWithLlm llmSvc candidate |> Async.RunSynchronously
+            | None ->
+                quickValidate candidate
 
 // ─────────────────────────────────────────────────────────────────────
 // Audit report

--- a/v2/src/Tars.Evolution/StructuredOutput.fs
+++ b/v2/src/Tars.Evolution/StructuredOutput.fs
@@ -131,9 +131,9 @@ let fromPipelineResult (r: PromotionPipeline.PipelineResult) : GovernanceOutput 
       Timestamp = r.Lineage.PromotedAt.ToString("o") }
 
 /// Convert a batch of pipeline results to a structured run output
-let fromPipelineRun (results: PromotionPipeline.PipelineResult list) (artifactCount: int) : PipelineRunOutput =
+let fromPipelineRun (store: IPromotionStore) (results: PromotionPipeline.PipelineResult list) (artifactCount: int) : PipelineRunOutput =
     let outputs = results |> List.map fromPipelineResult
-    let records = PromotionPipeline.getRecurrenceRecords ()
+    let records = PromotionPipeline.getRecurrenceRecords store
     let avgFitness =
         if records.IsEmpty then 0.0
         else records |> List.averageBy (fun r -> r.AverageScore) |> fun x -> Math.Round(x, 3)
@@ -158,8 +158,8 @@ let toJson<'T> (output: 'T) : string =
     JsonSerializer.Serialize(output, jsonOptions)
 
 /// Serialize a pipeline run to JSON
-let pipelineRunToJson (results: PromotionPipeline.PipelineResult list) (artifactCount: int) : string =
-    fromPipelineRun results artifactCount |> toJson
+let pipelineRunToJson (store: IPromotionStore) (results: PromotionPipeline.PipelineResult list) (artifactCount: int) : string =
+    fromPipelineRun store results artifactCount |> toJson
 
 /// Serialize a single governance decision to JSON
 let governanceToJson (result: PromotionPipeline.PipelineResult) : string =

--- a/v2/src/Tars.Evolution/Tars.Evolution.fsproj
+++ b/v2/src/Tars.Evolution/Tars.Evolution.fsproj
@@ -13,12 +13,14 @@
     <Compile Include="ProblemBank.fs" />
     <Compile Include="GaProblemBank.fs" />
     <Compile Include="PromotionTypes.fs" />
+    <Compile Include="PromotionStore.fs" />
     <Compile Include="GrammarGovernor.fs" />
     <Compile Include="WeightedGrammar.fs" />
     <Compile Include="ResearchTypes.fs" />
     <Compile Include="ResearchWeights.fs" />
     <Compile Include="ResearchCycle.fs" />
     <Compile Include="RoundtripValidation.fs" />
+    <Compile Include="PromotionGate.fs" />
     <Compile Include="PromotionPipeline.fs" />
     <Compile Include="PromotionIndex.fs" />
     <Compile Include="StructuredOutput.fs" />

--- a/v2/src/Tars.Evolution/WeightedGrammar.fs
+++ b/v2/src/Tars.Evolution/WeightedGrammar.fs
@@ -18,35 +18,6 @@ module WeightedGrammar =
     // Types
     // =========================================================================
 
-    /// Source system that produced/evolved a rule's weight
-    type RuleSource =
-        | Tars
-        | GuitarAlchemist
-        | MachinDeOuf
-        | Evolved
-        | Manual
-
-    /// A grammar rule annotated with probabilistic weight metadata
-    type WeightedRule = {
-        PatternId: string
-        PatternName: string
-        Level: PromotionLevel
-        /// Raw 0-8 criteria score from GrammarGovernor
-        RawScore: int
-        /// Current probability weight in [0.0, 1.0]
-        Weight: float
-        /// Bayesian confidence in the weight estimate (higher = more certain)
-        Confidence: float
-        /// Success rate from execution outcomes
-        SuccessRate: float
-        /// How many times this rule has been selected for use
-        SelectionCount: int
-        /// Who/what assigned this weight
-        Source: RuleSource
-        /// When the weight was last updated
-        LastUpdated: DateTime
-    }
-
     /// Configuration for weight computation
     type WeightConfig = {
         /// Softmax temperature: high = uniform, low = winner-take-all
@@ -192,88 +163,16 @@ module WeightedGrammar =
     // Persistence (weights.json alongside recurrence.json)
     // =========================================================================
 
-    /// DTO for JSON serialization
-    type WeightedRuleDto = {
-        PatternId: string
-        PatternName: string
-        Level: string
-        RawScore: int
-        Weight: float
-        Confidence: float
-        SuccessRate: float
-        SelectionCount: int
-        Source: string
-        LastUpdated: string
-    }
-
-    let private toDto (r: WeightedRule) : WeightedRuleDto =
-        { PatternId = r.PatternId
-          PatternName = r.PatternName
-          Level = PromotionLevel.label r.Level
-          RawScore = r.RawScore
-          Weight = r.Weight
-          Confidence = r.Confidence
-          SuccessRate = r.SuccessRate
-          SelectionCount = r.SelectionCount
-          Source = match r.Source with
-                   | Tars -> "tars" | GuitarAlchemist -> "guitar_alchemist"
-                   | MachinDeOuf -> "ix" | Evolved -> "evolved" | Manual -> "manual"
-          LastUpdated = r.LastUpdated.ToString("o") }
-
-    let private fromDto (dto: WeightedRuleDto) : WeightedRule =
-        let level =
-            match dto.Level with
-            | "helper" -> Helper | "builder" -> Builder
-            | "dsl_clause" -> DslClause | "grammar_rule" -> GrammarRule
-            | _ -> Implementation
-        let source =
-            match dto.Source with
-            | "guitar_alchemist" -> GuitarAlchemist | "ix" -> MachinDeOuf
-            | "evolved" -> Evolved | "manual" -> Manual | _ -> Tars
-        { PatternId = dto.PatternId
-          PatternName = dto.PatternName
-          Level = level
-          RawScore = dto.RawScore
-          Weight = dto.Weight
-          Confidence = dto.Confidence
-          SuccessRate = dto.SuccessRate
-          SelectionCount = dto.SelectionCount
-          Source = source
-          LastUpdated = try DateTime.Parse(dto.LastUpdated) with _ -> DateTime.UtcNow }
-
-    let private weightsDir =
-        Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".tars", "promotion")
-
-    let private weightsPath = Path.Combine(weightsDir, "weights.json")
-
-    let private jsonOptions =
-        let opts = JsonSerializerOptions()
-        opts.WriteIndented <- true
-        opts
-
-    /// Save weighted rules to ~/.tars/promotion/weights.json
-    let save (rules: WeightedRule list) : unit =
-        try
-            Directory.CreateDirectory(weightsDir) |> ignore
-            let dtos = rules |> List.map toDto
-            let json = JsonSerializer.Serialize(dtos, jsonOptions)
-            File.WriteAllText(weightsPath, json)
-        with _ -> () // graceful degradation
+    /// Save weighted rules using the provided store.
+    let save (store: IPromotionStore) (rules: WeightedRule list) : unit =
+        store.SaveWeights rules
 
     /// Load weighted rules from a specific promotion directory's weights.json.
-    /// Lets callers (notably hermetic tests) read an isolated store instead of
-    /// the shared ~/.tars one.
     let loadFrom (dir: string) : WeightedRule list =
-        try
-            let path = Path.Combine(dir, "weights.json")
-            if File.Exists(path) then
-                let json = File.ReadAllText(path)
-                let dtos = JsonSerializer.Deserialize<WeightedRuleDto list>(json, jsonOptions)
-                dtos |> List.map fromDto
-            else []
-        with _ -> []
+        let store = PromotionStore.createFileNamed dir
+        store.GetWeights()
 
-    /// Load weighted rules from ~/.tars/promotion/weights.json
-    let load () : WeightedRule list = loadFrom weightsDir
+    /// Load weighted rules from the default promotion store.
+    let load () : WeightedRule list =
+        let store = PromotionStore.createDefault ()
+        store.GetWeights()

--- a/v2/src/Tars.Interface.Cli/Commands/GrammarCommand.fs
+++ b/v2/src/Tars.Interface.Cli/Commands/GrammarCommand.fs
@@ -28,7 +28,8 @@ let private ixBridgeConfig () : MachinBridge.MachinConfig option =
 
 /// Display current weighted grammar rules
 let private showWeights () =
-    let rules = WeightedGrammar.load ()
+    let store = PromotionStore.createDefault ()
+    let rules = store.GetWeights()
     if rules.IsEmpty then
         RichOutput.info "No weighted rules found. Run [bold]tars grammar evolve[/] to initialize."
     else
@@ -64,10 +65,11 @@ let private showWeights () =
 
 /// Run replicator dynamics on the grammar ecosystem
 let private runReplicator (steps: int) =
-    let rules = WeightedGrammar.load ()
+    let store = PromotionStore.createDefault ()
+    let rules = store.GetWeights()
     if rules.IsEmpty then
         // Bootstrap from promotion pipeline
-        let records = PromotionPipeline.getRecurrenceRecords ()
+        let records = PromotionPipeline.getRecurrenceRecords store
         if records.IsEmpty then
             RichOutput.warn "No rules or recurrence records found. Run some workflows first."
         else
@@ -76,7 +78,7 @@ let private runReplicator (steps: int) =
                 let score = min 8 (r.OccurrenceCount + (if r.AverageScore > 0.5 then 3 else 1))
                 (r, score))
             let weighted = WeightedGrammar.fromRecurrenceRecords WeightedGrammar.defaultConfig scored
-            WeightedGrammar.save weighted
+            store.SaveWeights weighted
             RichOutput.ok $"Created [bold]{weighted.Length}[/] weighted rules from recurrence records."
     else
         RichOutput.info $"Running replicator dynamics on [bold]{rules.Length}[/] rules for {steps} steps..."
@@ -139,7 +141,7 @@ let private runReplicator (steps: int) =
                 | Some s -> { r with Weight = s.Proportion; Source = Evolved; LastUpdated = DateTime.UtcNow }
                 | None -> { r with Weight = 0.0; Source = Evolved; LastUpdated = DateTime.UtcNow })
             |> List.filter (fun r -> r.Weight > 0.001)
-        WeightedGrammar.save updatedRules
+        store.SaveWeights updatedRules
         RichOutput.ok $"Saved [bold]{updatedRules.Length}[/] evolved weights."
 
 /// Run MCTS search for WoT workflow derivation

--- a/v2/src/Tars.Interface.Cli/Commands/PromoteCommand.fs
+++ b/v2/src/Tars.Interface.Cli/Commands/PromoteCommand.fs
@@ -34,7 +34,8 @@ let private levelColor = function
 
 /// Show all recurrence records and their current promotion levels.
 let status () =
-    let records = PromotionPipeline.getRecurrenceRecords ()
+    let store = PromotionStore.createDefault ()
+    let records = PromotionPipeline.getRecurrenceRecords store
 
     if jsonMode then
         let outputs = records |> List.map StructuredOutput.fromRecurrence
@@ -85,7 +86,8 @@ let status () =
 
 /// Show lineage records (promotion history).
 let lineage () =
-    let records = PromotionPipeline.getLineageRecords ()
+    let store = PromotionStore.createDefault ()
+    let records = PromotionPipeline.getLineageRecords store
 
     if jsonMode then
         let outputs =
@@ -206,11 +208,13 @@ let runPipeline (minOccurrences: int) =
         AnsiConsole.MarkupLine($"[dim]  Feeding {artifacts.Length} trace artifacts into pipeline...[/]")
         AnsiConsole.WriteLine()
 
-    let results = PromotionPipeline.run minOccurrences artifacts
+    let store = PromotionStore.createDefault ()
+    let gate = PromotionGate.createDefault None
+    let results = PromotionPipeline.run store gate minOccurrences artifacts
 
     if jsonMode then
         // Headless: strict JSON only, no markup
-        printfn "%s" (StructuredOutput.pipelineRunToJson results artifacts.Length)
+        printfn "%s" (StructuredOutput.pipelineRunToJson store results artifacts.Length)
     else
         if results.IsEmpty then
             printDim "  No promotions triggered. Patterns may need more occurrences."
@@ -230,7 +234,7 @@ let runPipeline (minOccurrences: int) =
                 | None -> ()
 
         AnsiConsole.WriteLine()
-        let jsonOutput = StructuredOutput.pipelineRunToJson results artifacts.Length
+        let jsonOutput = StructuredOutput.pipelineRunToJson store results artifacts.Length
         AnsiConsole.MarkupLine("[bold cyan]Structured JSON Output:[/]")
         AnsiConsole.WriteLine(jsonOutput)
 
@@ -238,8 +242,9 @@ let runPipeline (minOccurrences: int) =
 
 /// Generate a full JSON report of current pipeline state.
 let report () =
-    let records = PromotionPipeline.getRecurrenceRecords ()
-    let lineageRecords = PromotionPipeline.getLineageRecords ()
+    let store = PromotionStore.createDefault ()
+    let records = PromotionPipeline.getRecurrenceRecords store
+    let lineageRecords = PromotionPipeline.getLineageRecords store
 
     if jsonMode then
         let fullReport =

--- a/v2/tests/Tars.Tests/GaPatternSeederTests.fs
+++ b/v2/tests/Tars.Tests/GaPatternSeederTests.fs
@@ -53,7 +53,8 @@ type GaPatternSeederTests(output: ITestOutputHelper) =
         output.WriteLine($"(Pipeline returning 0 results means patterns already at max level)")
 
         // Verify recurrence records were created
-        let records = PromotionPipeline.getRecurrenceRecords ()
+        let store = PromotionStore.createDefault ()
+        let records = PromotionPipeline.getRecurrenceRecords store
         let gaRecords = records |> List.filter (fun r -> r.PatternName.StartsWith("ga."))
         output.WriteLine($"GA recurrence records in store: {gaRecords.Length}")
         for r in gaRecords do

--- a/v2/tests/Tars.Tests/GrammarDistillationTests.fs
+++ b/v2/tests/Tars.Tests/GrammarDistillationTests.fs
@@ -201,7 +201,7 @@ module GrammarDistillationTests =
 
         Assert.Equal(production.Id, rule.PatternId)
         Assert.Equal(production.SuccessRate, rule.SuccessRate)
-        Assert.Equal(WeightedGrammar.Evolved, rule.Source)
+        Assert.Equal(Evolved, rule.Source)
         Assert.True(rule.Weight > 0.0)
         Assert.True(rule.RawScore >= 3)
 

--- a/v2/tests/Tars.Tests/GrammarMlBridgeTests.fs
+++ b/v2/tests/Tars.Tests/GrammarMlBridgeTests.fs
@@ -156,7 +156,7 @@ module GrammarMlBridgeTests =
 
         // Blended: 0.9 * 0.8 + original * 0.2
         Assert.True(updated.SuccessRate > rule.SuccessRate * 0.5)
-        Assert.Equal(WeightedGrammar.Evolved, updated.Source)
+        Assert.Equal(Evolved, updated.Source)
 
     [<Fact>]
     let ``applyPredictivePrior with low confidence barely changes rate`` () =

--- a/v2/tests/Tars.Tests/PromotionIndexTests.fs
+++ b/v2/tests/Tars.Tests/PromotionIndexTests.fs
@@ -49,8 +49,10 @@ let private withSeededStore (f: string -> unit) =
     let dir =
         Path.Combine(Path.GetTempPath(), "tars-promo-test-" + Guid.NewGuid().ToString("N"))
     Directory.CreateDirectory dir |> ignore
+    let store = PromotionStore.createFileNamed dir
     try
-        PromotionPipeline.saveStoresTo dir (seededRecords ()) []
+        for r in seededRecords () do
+            store.UpsertRecurrenceRecord r
         f dir
     finally
         try Directory.Delete(dir, true) with _ -> ()

--- a/v2/tests/Tars.Tests/PromotionPipelineTests.fs
+++ b/v2/tests/Tars.Tests/PromotionPipelineTests.fs
@@ -162,7 +162,8 @@ let ``Pipeline extracts and tracks recurrence`` () =
           Score = 0.9; Timestamp = DateTime.UtcNow
           RollbackExpansion = None }
     ]
-    let records = PromotionPipeline.extract (PromotionPipeline.inspect artifacts)
+    let store = PromotionStore.createInMemory ()
+    let records = PromotionPipeline.extract store (PromotionPipeline.inspect artifacts)
     Assert.True(records.Length >= 1)
     let record = records |> List.find (fun r -> r.PatternName = "extract_test")
     Assert.True(record.OccurrenceCount >= 2)
@@ -182,7 +183,9 @@ let ``Pipeline classify returns candidate for sufficient occurrence`` () =
 
 [<Fact>]
 let ``Pipeline full run handles empty input`` () =
-    let results = PromotionPipeline.run 3 []
+    let store = PromotionStore.createInMemory ()
+    let gate = PromotionGate.createDefault None
+    let results = PromotionPipeline.run store gate 3 []
     Assert.Empty(results)
 
 [<Fact>]


### PR DESCRIPTION
This PR refactors the TARS promotion system to use decoupled store and gate abstractions. It introduces IPromotionStore to unify recurrence, lineage, and weight persistence, and IPromotionGate to centralize governance decisions. This eliminates global state in the PromotionPipeline, prevents test cross-contamination via an in-memory store adapter, and fixes a logic leak where semantic match overrides were happening outside the governor.

Fixes #42

---
*PR created automatically by Jules for task [13352222723704742074](https://jules.google.com/task/13352222723704742074) started by @spareilleux*