### PR TITLE
fix: make CI health sweeper inspect the exact build job

### DIFF
--- a/.github/workflows/ci-health-sweeper.yml
+++ b/.github/workflows/ci-health-sweeper.yml
@@ -9,7 +9,7 @@ name: CI Health Sweeper
 #
 # Single tracking issue => idempotent, no spam. Recovery auto-close => the loop
 # tells you what it observed ("activity detection"). Scoped to the `.NET`
-# workflow / `build` job — the gate that branch protection actually enforces.
+# workflow / exact `build` job — the gate that branch protection actually enforces.
 
 on:
   schedule:
@@ -36,22 +36,36 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Latest .NET run on main.
+          # Latest .NET run on main. The workflow-level conclusion is NOT the
+          # source of truth because optional jobs (for example build-selfhosted)
+          # can be cancelled while the required `build` job is green.
           RUN=$(gh run list --repo "$REPO" --workflow ".NET" --branch main --limit 1 \
-                  --json conclusion,status,headSha,url --jq '.[0] // empty')
+                  --json databaseId,headSha,url --jq '.[0] // empty')
           if [ -z "$RUN" ]; then
             echo "No .NET runs on main yet — nothing to sweep."
             exit 0
           fi
-          STATUS=$(echo "$RUN" | jq -r '.status')
-          CONCLUSION=$(echo "$RUN" | jq -r '.conclusion')
+
+          RUN_ID=$(echo "$RUN" | jq -r '.databaseId')
           URL=$(echo "$RUN" | jq -r '.url')
           SHA=$(echo "$RUN" | jq -r '.headSha' | cut -c1-8)
-          echo "Latest .NET run on main: status=$STATUS conclusion=$CONCLUSION sha=$SHA"
 
-          # Only act on completed runs.
+          # Resolve the exact required job by name. Do not use prefix/fuzzy
+          # matching and do not inherit the overall workflow conclusion.
+          BUILD=$(gh run view "$RUN_ID" --repo "$REPO" --json jobs \
+                    --jq '[.jobs[] | select(.name == "build")][0] // empty')
+          if [ -z "$BUILD" ]; then
+            echo "Required build job not found in latest .NET run $RUN_ID — refusing to classify workflow-level status as build health."
+            exit 0
+          fi
+
+          STATUS=$(echo "$BUILD" | jq -r '.status')
+          CONCLUSION=$(echo "$BUILD" | jq -r '.conclusion')
+          echo "Latest required build job on main: status=$STATUS conclusion=$CONCLUSION sha=$SHA"
+
+          # Only act on completed required-build jobs.
           if [ "$STATUS" != "completed" ]; then
-            echo "Run still in progress — skipping this sweep."
+            echo "Required build job still in progress — skipping this sweep."
             exit 0
           fi
 


### PR DESCRIPTION
## What changed

- Stop using the overall `.NET` workflow conclusion as the health signal.
- Resolve the latest run ID, inspect its jobs, and select the exact job named `build`.
- Refuse to classify workflow-level status when the required `build` job cannot be found.
- Preserve the existing single-issue, report-only behavior.

## Why

The CI health sweeper claims to monitor the required `build` gate, but it was actually reading the overall workflow conclusion. A cancelled optional `build-selfhosted` job therefore kept #197 red even when the canonical `build` job succeeded.

Observed example from run `28710524517`:

```text
build             completed / success
build-selfhosted  completed / cancelled
```

The workflow conclusion was cancelled, but the required build gate was green.

## Impact

The sweeper now reports only the exact required `build` job and cannot conflate it with `build-selfhosted` or other optional lanes.

## Validation

- Scoped to `.github/workflows/ci-health-sweeper.yml` only.
- Uses `gh run list --json databaseId` followed by `gh run view --json jobs`, both supported by current GitHub CLI.
- Exact job-name match: `.name == "build"`.

Closes #202. After merge, manually dispatch the sweeper once; if the required `build` job is green, #197 should auto-close.