### PR TITLE
fix(deps): unblock CI with patched AngleSharp

### DIFF
--- a/v2/src/Tars.LinkedData/Tars.LinkedData.fsproj
+++ b/v2/src/Tars.LinkedData/Tars.LinkedData.fsproj
@@ -19,6 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Pin the patched parser version above dotNetRdf's vulnerable transitive floor. -->
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
     <PackageReference Include="dotNetRdf" Version="3.4.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## What changed

- pins `AngleSharp` 1.5.2 in `Tars.LinkedData`
- overrides dotNetRdf 3.4.1's vulnerable transitive AngleSharp 1.3.0 floor

## Why

GitHub advisory GHSA-pgww-w46g-26qg marks AngleSharp versions below 1.5.0 vulnerable. Because TARS treats NuGet audit warnings as errors, every project downstream of `Tars.LinkedData` failed during restore with NU1902, blocking the main build before compilation.

## Impact

Restores main-branch CI package restore while preserving the existing dotNetRdf version and public API. The explicit pin is localized to the package owner.

## Validation

- `dotnet restore v2/Tars.sln -v minimal`: pass; NU1902 cleared
- `dotnet build v2/Tars.sln -v minimal`: pass, 0 errors
- `dotnet test v2/Tars.sln --no-build -v minimal`: 973 passed, 4 expected sandbox skips, 1 pre-existing `Golden Run: Demo Ping` process-timeout failure
- isolated rerun of the GoldenRun suite reproduces the same timeout and does not exercise AngleSharp or linked-data parsing

Human review is intentionally required because this changes an `.fsproj` one-way-door file.

Fixes #197
