### PR TITLE
fix(ci): avoid submodule updater SIGPIPE

### DIFF
--- a/.github/workflows/submodule-auto-update.yml
+++ b/.github/workflows/submodule-auto-update.yml
@@ -101,7 +101,7 @@ jobs:
 
           # Get recent commit messages for PR body
           cd governance/demerzel
-          CHANGES=$(git log --oneline "$CURRENT..$LATEST" | head -15)
+          CHANGES=$(git log --oneline --max-count=15 "$CURRENT..$LATEST")
           cd ../..
 
           gh pr create \


### PR DESCRIPTION
## Outcome

Eliminates the deterministic exit-141 failure in the scheduled Demerzel submodule updater.

## Root cause

The workflow runs Bash with `pipefail`; `git log ... | head -15` makes `git log` receive SIGPIPE once `head` has enough rows. With a sufficiently stale submodule, that aborts the job after the bot branch is created and leaves orphan branches behind.

## Fix

Use Git's native `--max-count=15` limit, preserving the PR summary while removing the failing pipeline.

## Verification

- Confirmed the failing expression exists on the current default branch.
- The replacement has no pipeline and preserves identical output cardinality.
- One workflow file changed; no product code or cross-repo contract changed.

Protected workflow path: human review remains required.

Fixes #205