### PR TITLE
ci: make build-selfhosted opt-in so it stops leaving a pending check on every PR

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -39,6 +39,14 @@ jobs:
   # SDK if absent). Promote to required only once it's proven stable.
   build-selfhosted:
 
+    # Opt-in: skipped unless the repo variable SELFHOSTED_RUNNER_ENABLED is "true".
+    # `continue-on-error` only covers a job that RUNS and fails — when no self-hosted
+    # runner is registered the job never starts, so it sits `queued` until Actions
+    # expires it 24h later. That left a permanently-pending check on every PR: it
+    # never blocked a merge (`build` is the only required context) but it did make
+    # every PR read as UNSTABLE/BLOCKED, which is noise that hides real failures.
+    # Set the variable when AW-STEF is online: gh variable set SELFHOSTED_RUNNER_ENABLED --body true
+    if: vars.SELFHOSTED_RUNNER_ENABLED == 'true'
     runs-on: [self-hosted, Windows, X64]
     timeout-minutes: 30
     # Don't fail other jobs / the run's required status on self-hosted hiccups.


### PR DESCRIPTION
## Problem

No self-hosted runner is registered on this repo, so `build-selfhosted` never starts. It sits `queued` until Actions expires it 24 hours later, leaving a **permanently-pending check on every PR**.

The job already carries `continue-on-error: true` and a comment saying it can't block merges. That comment is half right:

- **Correct:** it never blocked a merge — branch protection requires only the `build` context, which runs GitHub-hosted and passes.
- **Incorrect about the consequence:** `continue-on-error` applies to a job that *runs and fails*. A job with no available runner never runs, so the flag does nothing for it. Every PR reported as `UNSTABLE`/`BLOCKED` — which is the noise that makes a genuinely failing check easy to miss.

## Change

One `if:` guard, gating the job on a repo variable so it's cleanly **skipped** rather than queued:

```yaml
if: vars.SELFHOSTED_RUNNER_ENABLED == 'true'
```

To re-enable once AW-STEF is back online:

```
gh variable set SELFHOSTED_RUNNER_ENABLED --body true
```

The required `build` job is untouched.

## Verification

Confirmed on the branch this was split from: `build-selfhosted` now reports `skipping` instead of hanging, and `build` still passes (2m22s).

- No self-hosted runners registered: `gh api repos/GuitarAlchemist/tars/actions/runners` returns empty
- Required contexts: `build` only

## Why this is its own PR

`.github/workflows/**` is a blocked path under the Agent Blackbox policy for autonomous changes. It was originally committed inside #207, which pushed that PR's risk score from 0.85 to a critical 1.00. Splitting it out keeps the CI-policy change reviewable on its own instead of buried in a 39-file diff. This PR will still trip `policy.blocked_path` by design — but here it's the entire diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)