### PR TITLE
feat(dsl): make wot.ebnf describe the language WotParser actually accepts

### DIFF
--- a/v2/.gitignore
+++ b/v2/.gitignore
@@ -15,6 +15,11 @@
 *.log
 *.tmp
 *.trsx
+# ...except test fixtures, which are part of the suite rather than runtime
+# output. Without this, a new .wot.trsx fixture is silently untracked and any
+# test asserting over it passes locally and is vacuous in CI. sample.wot.trsx
+# predates this rule and is tracked only because it was force-added.
+!tests/Tars.Tests/WorkflowOfThought/fixtures/*.trsx
 log_output_*
 benchmark_results_*.csv
 build_*.txt

--- a/v2/grammars/wot.ebnf
+++ b/v2/grammars/wot.ebnf
@@ -1,29 +1,167 @@
-(* Workflow of Thought DSL grammar for constrained LLM generation *)
-(* Used with vLLM guided_decoding to ensure valid WoT programs *)
+(* Workflow of Thought DSL — the language Tars.DSL.Wot.WotParser accepts.
 
-workflow    ::= meta? node+ edge*
-meta        ::= "META" "{" meta_field* "}"
-meta_field  ::= identifier ":" string_literal
+   SOUNDNESS CONTRACT
+   Every string this grammar generates must parse cleanly under WotParser.
+   The converse does NOT hold, deliberately: WotParser is forgiving — it
+   ignores unrecognised lines, tolerates missing sections, and accepts
+   unquoted values. This grammar describes the intended *well-formed subset*,
+   which is what a constrained decoder should be held to. Asserting the
+   reverse direction would mean encoding the parser's tolerance for garbage.
 
-node        ::= node_kind identifier title? "{" node_body "}"
-node_kind   ::= "REASON" | "WORK"
-title       ::= "title" ":" string_literal
+   Enforced by tests/Tars.Tests/WotGrammarConformanceTests.fs. Change
+   WotParser's accepted vocabulary and that harness fails until this agrees.
 
-node_body   ::= (input_decl | output_decl | tool_decl | transform_decl)*
-input_decl  ::= "input" ":" identifier ("," identifier)*
-output_decl ::= "output" ":" identifier ("," identifier)*
-tool_decl   ::= "tool" ":" identifier
-transform_decl ::= "transform" ":" transformation
+   WHY WHITESPACE IS EXPLICIT
+   This grammar exists to drive constrained decoding (vLLM structured
+   outputs, llama.cpp GBNF). Neither has a notion of implicit whitespace:
+   what the grammar does not say is legal, the decoder cannot emit. So `ws`
+   (optional) and `sp` (required) appear everywhere the parser tolerates or
+   demands spacing. `sp` is not decoration — WotParser's node/edge header
+   regexes use `\s+`, so `node"a"{` is a parse error while `node "a" {` is not.
 
-transformation ::= "Refine" | "Aggregate" | "Generate" | "Score" | "Critique" | "Merge"
+   WHY NEWLINES ARE EXPLICIT
+   WotParser is a line-based state machine, not a token stream:
+     - a section header must be the last token on its line, ending in "{"
+       (`startsWith "meta" line && line.EndsWith("{")`)
+     - a closing brace must stand alone on its line (`elif line = "}"`)
+     - `checks` must end its line with "[", and the matching "]" stands alone
+     - an `args = { ... }` object must fit entirely on one line — it is parsed
+       from that single line and is never continued
+   The previous version of this file modelled none of this and used a syntax
+   (META/REASON/EDGE with ":" separators) that WotParser never accepted at
+   all, so any decoder constrained by it emitted 100% unparseable output.
 
-edge        ::= "EDGE" identifier "->" identifier condition?
-condition   ::= "when" expression
+   Text is matched after CRLF normalisation, because WotParser reads through
+   File.ReadAllLines, which strips carriage returns before any rule sees them.
 
-expression  ::= identifier comparator value
-comparator  ::= "==" | "!=" | ">" | "<" | ">=" | "<="
-value       ::= string_literal | number | "true" | "false"
+   String bodies may contain `${name}` interpolation references. Those are
+   ordinary string content — the parser resolves them after parsing, so they
+   need no production of their own.
+*)
 
-identifier     ::= [a-zA-Z_] [a-zA-Z0-9_]*
-string_literal ::= '"' [^"]* '"'
-number         ::= [0-9]+ ("." [0-9]+)?
+file            ::= trivia meta_block? trivia inputs_block? trivia policy_block? trivia workflow_block trivia
+
+(* ── whitespace, line structure, trivia ───────────────────────────────── *)
+hs              ::= " " | "\t"
+ws              ::= hs*
+sp              ::= hs+
+nl              ::= "\n"
+eol             ::= ws nl
+not_nl          ::= [^\n]
+blank_line      ::= ws nl
+comment_line    ::= ws "//" not_nl* nl
+trivia          ::= (blank_line | comment_line)*
+
+eq              ::= ws "=" ws
+colon           ::= ws ":" ws
+comma           ::= ws "," ws
+close_brace     ::= ws "}" eol
+close_bracket   ::= ws "]" eol
+
+(* ── meta ─────────────────────────────────────────────────────────────── *)
+meta_block      ::= ws "meta" ws "{" eol (trivia meta_field)* trivia close_brace
+meta_field      ::= ws meta_key eq string_literal eol
+meta_key        ::= "name" | "version" | "risk" | "description"
+                  | "domain" | "difficulty"
+
+(* ── inputs: free-form keys, each a named value the workflow can read ──── *)
+inputs_block    ::= ws "inputs" ws "{" eol (trivia input_field)* trivia close_brace
+input_field     ::= ws identifier eq string_literal eol
+
+(* ── policy: execution budget and the tool allow-list ─────────────────── *)
+policy_block    ::= ws "policy" ws "{" eol (trivia policy_field)* trivia close_brace
+policy_field    ::= ws "allowed_tools" eq string_list eol
+                  | ws "max_tool_calls" eq integer eol
+                  | ws "max_tokens" eq integer eol
+                  | ws "max_time_ms" eq integer eol
+
+(* ── workflow: the node graph. The quoted name is optional and read for
+      documentation only — WotParser takes the workflow name from
+      meta.name, never from here. ─────────────────────────────────────── *)
+workflow_block  ::= ws "workflow" (sp string_literal)? ws "{" eol (trivia workflow_item)* trivia close_brace
+workflow_item   ::= node | parallel_block | edge
+
+(* A parallel block groups nodes for concurrent execution. Edges may not
+   appear inside it: WotParser only collects node ids while the block is
+   open, so an edge there would escape the group. *)
+parallel_block  ::= ws "parallel" ws "{" eol (trivia node)+ trivia close_brace
+
+(* ── node ──────────────────────────────────────────────────────────────
+   Three header forms, and only these three. Attribute order is fixed —
+   `agent` may not precede or replace `kind` — because WotParser matches
+   each whole header with a single regex rather than parsing attributes
+   independently. *)
+node            ::= node_header eol (trivia node_field)* trivia close_brace
+node_header     ::= ws "node" sp node_id sp "kind" eq quoted_kind sp "agent" eq quoted_name ws "{"
+                  | ws "node" sp node_id sp "kind" eq quoted_kind ws "{"
+                  | ws "node" sp node_id ws "{"
+
+(* Quotes around an id are optional — every id-matching regex in WotParser
+   spells them `"?`. The planner's own output in .wot/plans uses the bare
+   form (`node analyze_implementation kind="work" {`), so excluding it would
+   make this grammar reject the very generator it exists to constrain. *)
+node_id         ::= '"' identifier '"' | identifier
+quoted_name     ::= '"' identifier '"'
+
+(* An unrecognised kind silently degrades to `reason`, so the grammar admits
+   only the two intentional values. *)
+quoted_kind     ::= '"' node_kind '"'
+node_kind       ::= "reason" | "work"
+
+node_field      ::= ws "goal" eq string_literal eol
+                  | ws "output" eq string_literal eol
+                  | ws "input" eq (string_list | string_literal) eol
+                  | ws "invariants" eq string_list eol
+                  | ws "constraints" eq string_list eol
+                  | ws "tool" eq string_literal eol
+                  | ws "verdict" eq string_literal eol
+                  | ws "condition" eq string_literal eol
+                  | ws "kind" eq quoted_kind eol
+                  | ws "args" eq args_object eol
+                  | checks_block
+
+(* ── checks: one JSON-ish object per line. `checks [` and `checks = [` are
+      both accepted — WotParser only requires the line to end in "[". A
+      trailing comma after an item is tolerated. ──────────────────────── *)
+checks_block    ::= ws "checks" (eq | ws) "[" eol (trivia check_item)* trivia close_bracket
+check_item      ::= ws check_object ws ","? eol
+
+check_object    ::= "{" ws check_type_non_empty comma check_value ws "}"
+                  | "{" ws check_type_contains comma check_value comma check_needle ws "}"
+                  | "{" ws check_type_regex comma check_value comma check_pattern ws "}"
+                  | "{" ws check_type_schema comma check_value comma check_schema ws "}"
+                  | "{" ws check_type_tool comma check_tool comma check_args comma check_check ws "}"
+
+check_type_non_empty ::= '"type"' colon '"non_empty"'
+check_type_contains  ::= '"type"' colon '"contains"'
+check_type_regex     ::= '"type"' colon '"regex"'
+check_type_schema    ::= '"type"' colon '"schema"'
+check_type_tool      ::= '"type"' colon '"tool_result"'
+
+(* Every one of these is extracted with `"([^"]+)"`, so the value must be
+   non-empty — an empty string would make the field invisible to the parser
+   and the check would be silently dropped. *)
+check_value     ::= '"value"' colon json_string
+check_needle    ::= '"needle"' colon json_string
+check_pattern   ::= '"pattern"' colon json_string
+check_schema    ::= '"schema"' colon json_string
+check_tool      ::= '"tool"' colon json_string
+check_args      ::= '"args"' colon args_object
+check_check     ::= '"check"' colon json_string
+
+(* ── edge: plain successor link. WotParser has no `when`/condition support
+      on edges — a per-node `condition` field carries that instead. ───── *)
+edge            ::= ws "edge" sp node_id ws "->" ws node_id eol
+
+(* ── shared terminals ─────────────────────────────────────────────────── *)
+args_object     ::= "{" ws (arg_pair (comma arg_pair)*)? ws "}"
+arg_pair        ::= json_string colon json_string
+
+string_list     ::= "[" ws (string_literal (list_sep string_literal)*)? ws "]"
+list_sep        ::= ws ("," | ";") ws
+
+identifier      ::= [A-Za-z0-9_\-]+
+string_literal  ::= '"' not_quote* '"'
+json_string     ::= '"' not_quote+ '"'
+not_quote       ::= [^"\n]
+integer         ::= [0-9]+

--- a/v2/tests/Tars.Tests/Tars.Tests.fsproj
+++ b/v2/tests/Tars.Tests/Tars.Tests.fsproj
@@ -132,10 +132,16 @@
     <Compile Include="LocalModelPoolTests.fs" />
     <Compile Include="ToolInvokerTests.fs" />
     <Compile Include="ReasonFeedbackTests.fs" />
+    <Compile Include="WotGrammarConformanceTests.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Include="WorkflowOfThought\fixtures\**\*" CopyToOutputDirectory="PreserveNewest" />
+    <!-- The grammar under test, and the parser source it must stay in step with.
+         WotGrammarConformanceTests reads both: the grammar to recognise fixtures,
+         the parser source to detect keys added to one side but not the other. -->
+    <Content Include="..\..\grammars\wot.ebnf" Link="grammars\wot.ebnf" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\src\Tars.DSL\Wot\WotParser.fs" Link="sources\WotParser.fs" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/v2/tests/Tars.Tests/WorkflowOfThought/fixtures/full_surface.wot.trsx
+++ b/v2/tests/Tars.Tests/WorkflowOfThought/fixtures/full_surface.wot.trsx
@@ -1,0 +1,75 @@
+// Full-surface conformance fixture: exercises every construct declared in
+// grammars/wot.ebnf. Both WotParser and the EBNF recognizer must accept it.
+// The .wot/ corpus is gitignored, so this tracked file is the real gate.
+meta {
+  name = "full_surface"
+  version = "1.0.0"
+  risk = "low"
+  description = "Exercises every construct in grammars/wot.ebnf"
+  domain = "conformance"
+  difficulty = "easy"
+}
+
+inputs {
+  topic = "conformance"
+  expected_answer = "42"
+}
+
+policy {
+  allowed_tools = ["web_search", "math_eval"]
+  max_tool_calls = 3
+  max_tokens = 2048
+  max_time_ms = 60000
+}
+
+workflow "full_surface" {
+
+  // long node header: id + kind + agent, in that fixed order
+  node "plan" kind="reason" agent="Planner" {
+    goal = "Plan the work for ${topic}"
+    output = "plan"
+    invariants = ["no_speculation"]
+    constraints = ["show_reasoning_before_solution"]
+  }
+
+  // parallel group: nodes only, no edges inside
+  parallel {
+    node "search" kind="work" {
+      input = ["plan"]
+      tool = "web_search"
+      args = { "query": "${topic} latest" }
+      output = "hits"
+    }
+
+    node "recall" kind="reason" {
+      input = ["plan"]
+      goal = "Recall what is already known about ${topic}"
+      output = "recalled"
+    }
+  }
+
+  // short node header: no kind, no agent — kind defaults to reason
+  node "compute" {
+    input = ["hits", "recalled"]
+    goal = "Compute the answer"
+    output = "computed_answer"
+    condition = "hits_non_empty"
+    verdict = "accept"
+  }
+
+  // scalar input form, and every check type
+  node "verify" kind="work" {
+    input = "computed_answer"
+    output = "final_verdict"
+    checks = [
+      { "type": "non_empty", "value": "${computed_answer}" },
+      { "type": "contains", "value": "${computed_answer}", "needle": "${expected_answer}" },
+      { "type": "regex", "value": "${computed_answer}", "pattern": "[0-9]+" },
+      { "type": "schema", "value": "${computed_answer}", "schema": "number" },
+      { "type": "tool_result", "tool": "math_eval", "args": { "expression": "${computed_answer}" }, "check": "0" }
+    ]
+  }
+
+  edge "plan" -> "compute"
+  edge "compute" -> "verify"
+}

--- a/v2/tests/Tars.Tests/WotGrammarConformanceTests.fs
+++ b/v2/tests/Tars.Tests/WotGrammarConformanceTests.fs
@@ -1,0 +1,541 @@
+namespace Tars.Tests
+
+open System
+open System.Collections.Generic
+open System.IO
+open System.Text
+open System.Text.RegularExpressions
+open Xunit
+open Tars.DSL.Wot
+
+/// Item 4 slice C — grammars/wot.ebnf must describe the language WotParser
+/// actually accepts.
+///
+/// Before this, the two had no surface syntax in common at all: the grammar
+/// specified `META { k: "v" }`, `REASON id { input: a }` and `EDGE a -> b when
+/// x == "y"`, while the parser accepts `meta { k = "v" }`, `node "id"
+/// kind="reason" { input = ["a"] }` and `edge "a" -> "b"`. Every string the old
+/// grammar generated was unparseable. Nothing caught it because nothing loaded
+/// the file — `withNamedGrammar dir "wot"` would have worked, but no call site
+/// ever asked for it.
+///
+/// The gate here is SOUNDNESS, not equivalence: everything the grammar
+/// generates must parse under WotParser. The reverse is deliberately untested —
+/// WotParser ignores unrecognised lines and tolerates unquoted values, so
+/// asserting the converse would mean encoding its tolerance for garbage.
+module WotGrammarConformanceTests =
+
+    // ────────────────────────────────────────────────────────────────────────
+    // A recognizer for the EBNF subset grammars/wot.ebnf uses.
+    //
+    // Deliberately small, with two documented limitations that this grammar
+    // does not exercise:
+    //   * left recursion yields [] rather than looping (guarded, not supported)
+    //   * a repetition with min >= 2 may under-report when the inner expression
+    //     is ambiguous; only ? * + appear here, whose min is 0 or 1
+    // Anything outside the subset raises instead of silently passing.
+    // ────────────────────────────────────────────────────────────────────────
+    module private Ebnf =
+
+        type Expr =
+            | Lit of string
+            | Cls of ranges: (char * char) list * negated: bool
+            | Ref of string
+            | Cat of Expr list
+            | Alt of Expr list
+            | Rep of Expr * min: int * max: int option
+
+        /// Strips (* ... *) comments. Non-nesting, and it would corrupt a
+        /// literal containing "(*" — wot.ebnf has none, and a stray strip
+        /// surfaces as a parse failure rather than a silent pass.
+        let private stripComments (text: string) =
+            let sb = StringBuilder()
+            let mutable i = 0
+
+            while i < text.Length do
+                if i + 1 < text.Length && text[i] = '(' && text[i + 1] = '*' then
+                    let mutable j = i + 2
+
+                    while j + 1 < text.Length && not (text[j] = '*' && text[j + 1] = ')') do
+                        j <- j + 1
+
+                    i <- if j + 1 < text.Length then j + 2 else text.Length
+                else
+                    sb.Append(text[i]) |> ignore
+                    i <- i + 1
+
+            sb.ToString()
+
+        let private parseRhs (name: string) (src: string) : Expr =
+            let mutable i = 0
+            let skipWs () = while i < src.Length && Char.IsWhiteSpace src[i] do i <- i + 1
+
+            let decodeEscape (c: char) =
+                match c with
+                | 'n' -> '\n'
+                | 't' -> '\t'
+                | 'r' -> '\r'
+                | other -> other
+
+            let readLiteral (closing: char) =
+                let sb = StringBuilder()
+
+                while i < src.Length && src[i] <> closing do
+                    if src[i] = '\\' && i + 1 < src.Length then
+                        sb.Append(decodeEscape src[i + 1]) |> ignore
+                        i <- i + 2
+                    else
+                        sb.Append(src[i]) |> ignore
+                        i <- i + 1
+
+                if i >= src.Length then
+                    failwithf "%s: unterminated literal" name
+
+                i <- i + 1
+                sb.ToString()
+
+            let readClass () =
+                i <- i + 1 // consume '['
+                let negated = i < src.Length && src[i] = '^'
+                if negated then i <- i + 1
+                let ranges = ResizeArray<char * char>()
+
+                let readChar () =
+                    if src[i] = '\\' && i + 1 < src.Length then
+                        let c = decodeEscape src[i + 1]
+                        i <- i + 2
+                        c
+                    else
+                        let c = src[i]
+                        i <- i + 1
+                        c
+
+                while i < src.Length && src[i] <> ']' do
+                    let a = readChar ()
+
+                    if i + 1 < src.Length && src[i] = '-' && src[i + 1] <> ']' then
+                        i <- i + 1
+                        ranges.Add(a, readChar ())
+                    else
+                        ranges.Add(a, a)
+
+                if i >= src.Length then
+                    failwithf "%s: unterminated character class" name
+
+                i <- i + 1
+                Cls(List.ofSeq ranges, negated)
+
+            let rec parseAlt () =
+                let first = parseCat ()
+                let alts = ResizeArray<Expr>([ first ])
+                skipWs ()
+
+                while i < src.Length && src[i] = '|' do
+                    i <- i + 1
+                    alts.Add(parseCat ())
+                    skipWs ()
+
+                if alts.Count = 1 then first else Alt(List.ofSeq alts)
+
+            and parseCat () =
+                let parts = ResizeArray<Expr>()
+                let mutable go = true
+
+                while go do
+                    skipWs ()
+
+                    if i >= src.Length || src[i] = '|' || src[i] = ')' then
+                        go <- false
+                    else
+                        parts.Add(parsePostfix ())
+
+                if parts.Count = 1 then parts[0] else Cat(List.ofSeq parts)
+
+            and parsePostfix () =
+                let a = parseAtom ()
+
+                if i < src.Length then
+                    match src[i] with
+                    | '?' ->
+                        i <- i + 1
+                        Rep(a, 0, Some 1)
+                    | '*' ->
+                        i <- i + 1
+                        Rep(a, 0, None)
+                    | '+' ->
+                        i <- i + 1
+                        Rep(a, 1, None)
+                    | _ -> a
+                else
+                    a
+
+            and parseAtom () =
+                skipWs ()
+
+                if i >= src.Length then
+                    failwithf "%s: unexpected end of production" name
+
+                match src[i] with
+                | '(' ->
+                    i <- i + 1
+                    let e = parseAlt ()
+                    skipWs ()
+
+                    if i >= src.Length || src[i] <> ')' then
+                        failwithf "%s: expected ')'" name
+
+                    i <- i + 1
+                    e
+                | '"' ->
+                    i <- i + 1
+                    Lit(readLiteral '"')
+                | '\'' ->
+                    i <- i + 1
+                    Lit(readLiteral '\'')
+                | '[' -> readClass ()
+                | c when Char.IsLetter c || c = '_' ->
+                    let start = i
+
+                    while i < src.Length && (Char.IsLetterOrDigit src[i] || src[i] = '_') do
+                        i <- i + 1
+
+                    Ref(src.Substring(start, i - start))
+                | c -> failwithf "%s: unsupported character '%c' in production" name c
+
+            let e = parseAlt ()
+            skipWs ()
+
+            if i < src.Length then
+                failwithf "%s: trailing input at offset %d: %s" name i (src.Substring i)
+
+            e
+
+        /// name ::= rhs, with continuation lines folded into the previous rule.
+        let parse (text: string) : Map<string, Expr> =
+            let rxHead = Regex(@"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*::=(.*)$")
+
+            let lines = (stripComments text).Replace("\r\n", "\n").Split('\n')
+            let order = ResizeArray<string>()
+            let bodies = Dictionary<string, StringBuilder>()
+
+            for line in lines do
+                let m = rxHead.Match line
+
+                if m.Success then
+                    let n = m.Groups[1].Value
+
+                    if bodies.ContainsKey n then
+                        failwithf "duplicate rule '%s'" n
+
+                    order.Add n
+                    bodies[n] <- StringBuilder(m.Groups[2].Value)
+                elif order.Count > 0 && not (String.IsNullOrWhiteSpace line) then
+                    bodies[order[order.Count - 1]].Append(' ').Append(line) |> ignore
+
+            order
+            |> Seq.map (fun n -> n, parseRhs n (bodies[n].ToString()))
+            |> Map.ofSeq
+
+        /// Rules referenced but never defined — a typo here would otherwise
+        /// only show up as a mysterious rejection.
+        let undefinedRefs (g: Map<string, Expr>) : string list =
+            let rec refs e =
+                match e with
+                | Ref n -> [ n ]
+                | Cat xs
+                | Alt xs -> xs |> List.collect refs
+                | Rep(x, _, _) -> refs x
+                | Lit _
+                | Cls _ -> []
+
+            g
+            |> Map.toList
+            |> List.collect (snd >> refs)
+            |> List.distinct
+            |> List.filter (fun n -> not (g.ContainsKey n))
+            |> List.sort
+
+        /// Returns whether `start` derives the whole of `text`, plus the
+        /// furthest offset any terminal matched. On rejection that offset is
+        /// where the derivation ran out of options — the practical way to find
+        /// which line a grammar/parser divergence sits on.
+        let acceptsWithFurthest (g: Map<string, Expr>) (start: string) (text: string) : bool * int =
+            let memo = Dictionary<struct (string * int), int list>()
+            let mutable steps = 0
+            let mutable furthest = 0
+
+            let rec ends (e: Expr) (pos: int) : int list =
+                steps <- steps + 1
+
+                if steps > 5_000_000 then
+                    failwith "EBNF recognizer step budget exhausted — the grammar is pathologically ambiguous"
+
+                match e with
+                | Lit t ->
+                    if pos + t.Length <= text.Length && String.CompareOrdinal(text, pos, t, 0, t.Length) = 0 then
+                        if pos + t.Length > furthest then furthest <- pos + t.Length
+                        [ pos + t.Length ]
+                    else
+                        []
+                | Cls(ranges, negated) ->
+                    if pos >= text.Length then
+                        []
+                    else
+                        let c = text[pos]
+                        let inside = ranges |> List.exists (fun (a, b) -> c >= a && c <= b)
+
+                        if inside <> negated then
+                            if pos + 1 > furthest then furthest <- pos + 1
+                            [ pos + 1 ]
+                        else
+                            []
+                | Ref n ->
+                    let key = struct (n, pos)
+
+                    match memo.TryGetValue key with
+                    | true, cached -> cached
+                    | _ ->
+                        memo[key] <- [] // left-recursion guard
+
+                        let body =
+                            match g.TryFind n with
+                            | Some b -> b
+                            | None -> failwithf "undefined rule '%s'" n
+
+                        let r = ends body pos
+                        memo[key] <- r
+                        r
+                | Cat parts ->
+                    parts
+                    |> List.fold (fun acc p -> acc |> List.collect (ends p) |> List.distinct) [ pos ]
+                | Alt alts -> alts |> List.collect (fun a -> ends a pos) |> List.distinct
+                | Rep(inner, mn, mx) ->
+                    let acc = HashSet<int>()
+                    if mn = 0 then acc.Add pos |> ignore
+                    let seen = HashSet<int>([ pos ])
+                    let mutable frontier = [ pos ]
+                    let mutable k = 0
+                    let mutable go = true
+
+                    while go && not frontier.IsEmpty do
+                        k <- k + 1
+
+                        // `seen` filters both zero-width matches and revisits,
+                        // which is what guarantees termination.
+                        let next =
+                            frontier |> List.collect (ends inner) |> List.distinct |> List.filter seen.Add
+
+                        if k >= mn then
+                            for p in next do
+                                acc.Add p |> ignore
+
+                        frontier <- next
+
+                        match mx with
+                        | Some m when k >= m -> go <- false
+                        | _ -> ()
+
+                    acc |> List.ofSeq |> List.sortDescending
+
+            let ok = ends (Ref start) 0 |> List.contains text.Length
+            ok, furthest
+
+        /// True when `start` derives the whole of `text`.
+        let accepts (g: Map<string, Expr>) (start: string) (text: string) : bool =
+            acceptsWithFurthest g start text |> fst
+
+    // ── loading ─────────────────────────────────────────────────────────────
+
+    let private baseDir = AppContext.BaseDirectory
+
+    let private grammarPath = Path.Combine(baseDir, "grammars", "wot.ebnf")
+
+    let private fixturePath (name: string) =
+        Path.Combine(baseDir, "WorkflowOfThought", "fixtures", name)
+
+    /// Both adjustments mirror File.ReadAllLines, which is how WotParser reads
+    /// input, so the grammar models post-ReadAllLines text:
+    ///   * carriage returns are stripped before any rule sees them
+    ///   * a final line with no trailing newline is still a line
+    /// The second matters: 3 of the 25 corpus plans end with `}` and no
+    /// newline. Weakening `eol` to `nl?` in the grammar would have admitted
+    /// them too, but at the cost of making every newline optional — which is
+    /// exactly the line orientation this grammar exists to pin down.
+    let private normalize (s: string) =
+        let lf = s.Replace("\r\n", "\n").Replace("\r", "\n")
+        if lf.EndsWith "\n" || lf = "" then lf else lf + "\n"
+
+    let private grammar =
+        lazy
+            (Assert.True(File.Exists grammarPath, $"grammar not copied to output: {grammarPath}")
+             Ebnf.parse (File.ReadAllText grammarPath))
+
+    let private grammarAccepts (text: string) =
+        Ebnf.accepts grammar.Value "file" (normalize text)
+
+    /// "<line>: <text>" for the furthest point the grammar reached — where the
+    /// derivation ran out of options. Without this a rejection is just `false`,
+    /// and finding the offending construct in a 70-line workflow is guesswork.
+    let private rejectionSite (text: string) =
+        let t = normalize text
+        let _, furthest = Ebnf.acceptsWithFurthest grammar.Value "file" t
+        let consumed = t.Substring(0, min furthest t.Length)
+        let line = 1 + (consumed |> Seq.filter ((=) '\n') |> Seq.length)
+        let lines = t.Split('\n')
+        let offending = if line - 1 < lines.Length then lines[line - 1].Trim() else "<end of input>"
+        $"line {line}: {offending}"
+
+    let private parserAccepts (text: string) =
+        let lines = (normalize text).Split('\n') |> Array.toList
+        match WotParser.parseLines lines with
+        | Ok _ -> true
+        | Error _ -> false
+
+    // ── the grammar itself is well-formed ───────────────────────────────────
+
+    [<Fact>]
+    let ``wot.ebnf parses and defines every rule it references`` () =
+        let g = grammar.Value
+        Assert.NotEmpty(g)
+        let missing = Ebnf.undefinedRefs g
+
+        Assert.True(
+            List.isEmpty missing,
+            $"""wot.ebnf references undefined rules: {String.Join(", ", missing)}"""
+        )
+
+        Assert.True(g.ContainsKey "file", "wot.ebnf must define the `file` start rule")
+
+    // ── soundness: what the grammar admits, the parser accepts ──────────────
+
+    [<Theory>]
+    [<InlineData("sample.wot.trsx")>]
+    [<InlineData("full_surface.wot.trsx")>]
+    let ``fixture is accepted by both the grammar and WotParser`` (fixture: string) =
+        let path = fixturePath fixture
+        Assert.True(File.Exists path, $"missing fixture: {path}")
+        let text = File.ReadAllText path
+
+        // Order matters for the failure message: a grammar that is too narrow
+        // is the likely defect, so report it first and distinctly.
+        Assert.True(
+            grammarAccepts text,
+            $"grammars/wot.ebnf rejects {fixture}, which WotParser accepts — {rejectionSite text}"
+        )
+
+        Assert.True(parserAccepts text, $"WotParser rejects {fixture}")
+
+    /// The construct-by-construct soundness check. Each snippet is a complete
+    /// workflow the grammar admits; WotParser must accept every one.
+    [<Theory>]
+    [<InlineData("goal", "    goal = \"do the thing\"")>]
+    [<InlineData("output", "    output = \"result\"")>]
+    [<InlineData("input list", "    input = [\"a\", \"b\"]")>]
+    [<InlineData("input scalar", "    input = \"a\"")>]
+    [<InlineData("invariants", "    invariants = [\"keep_it\"]")>]
+    [<InlineData("constraints", "    constraints = [\"be_brief\"]")>]
+    [<InlineData("tool", "    tool = \"web_search\"")>]
+    [<InlineData("verdict", "    verdict = \"accept\"")>]
+    [<InlineData("condition", "    condition = \"ready\"")>]
+    [<InlineData("kind in body", "    kind = \"work\"")>]
+    [<InlineData("args", "    args = { \"query\": \"x\" }")>]
+    [<InlineData("comment", "    // just a comment")>]
+    let ``node field the grammar admits is accepted by WotParser`` (label: string) (field: string) =
+        let text =
+            String.Join(
+                "\n",
+                [ "meta {"; "  name = \"t\""; "}"; "workflow \"t\" {"; "  node \"n\" {"; field; "  }"; "}"; "" ]
+            )
+
+        Assert.True(grammarAccepts text, $"grammar rejects its own construct: {label}")
+        Assert.True(parserAccepts text, $"WotParser rejects grammar-legal construct: {label}")
+
+    // ── non-vacuity: the grammar must reject what the parser rejects ─────────
+
+    /// The exact syntax the old wot.ebnf specified. If this ever passes again,
+    /// the file has been reverted to describing a language nothing accepts.
+    [<Fact>]
+    let ``grammar rejects the superseded META/REASON/EDGE syntax`` () =
+        let old =
+            String.Join(
+                "\n",
+                [ "META {"
+                  "  name: \"old\""
+                  "}"
+                  "REASON think title: \"Think\" {"
+                  "  input: a, b"
+                  "  transform: Refine"
+                  "}"
+                  "EDGE think -> act when score >= 0.5"
+                  "" ]
+            )
+
+        Assert.False(grammarAccepts old, "grammar still admits the superseded syntax")
+
+    /// `sp` is load-bearing, not decoration: WotParser's node header regex uses
+    /// `\s+` between `node` and the id, so a decoder allowed to omit that space
+    /// would emit unparseable output. Both must reject it.
+    [<Fact>]
+    let ``grammar and parser agree that the space after node is required`` () =
+        let text =
+            String.Join("\n", [ "meta {"; "  name = \"t\""; "}"; "workflow {"; "  node\"n\"{"; "  }"; "}"; "" ])
+
+        Assert.False(grammarAccepts text, "grammar admits `node\"n\"{`, which WotParser cannot parse")
+        Assert.False(parserAccepts text, "WotParser unexpectedly accepted `node\"n\"{`")
+
+    /// Line orientation is the property the old grammar most badly missed.
+    [<Fact>]
+    let ``grammar rejects a workflow collapsed onto one line`` () =
+        let oneLine = "meta { name = \"t\" } workflow { node \"n\" { goal = \"g\" } }\n"
+        Assert.False(grammarAccepts oneLine, "grammar admits a single-line workflow")
+
+    [<Fact>]
+    let ``grammar rejects a closing brace that shares its line`` () =
+        // WotParser only closes a block on `line = "}"` after trimming, so
+        // trailing content on the brace line leaves the node open.
+        let text =
+            String.Join("\n", [ "meta {"; "  name = \"t\""; "}"; "workflow {"; "  node \"n\" {"; "  } edge \"n\" -> \"n\""; "}"; "" ])
+
+        Assert.False(grammarAccepts text, "grammar admits a closing brace sharing its line")
+
+    [<Fact>]
+    let ``grammar rejects an unknown node kind`` () =
+        // An unrecognised kind silently degrades to `reason` in WotParser, so
+        // the grammar must not let a decoder emit one.
+        let text =
+            String.Join(
+                "\n",
+                [ "meta {"; "  name = \"t\""; "}"; "workflow {"; "  node \"n\" kind=\"ponder\" {"; "  }"; "}"; "" ]
+            )
+
+        Assert.False(grammarAccepts text, "grammar admits kind=\"ponder\"")
+
+    // ── drift detection against the parser's own source ─────────────────────
+
+    /// Reads the keys WotParser matches literally (`Some("goal", v)`) straight
+    /// out of its source and requires each to appear in the grammar. This is
+    /// the direction a behavioural test cannot cover: a key added to the parser
+    /// but not the grammar is invisible until a decoder never emits it.
+    [<Fact>]
+    let ``every key WotParser matches literally appears in the grammar`` () =
+        let src = Path.Combine(baseDir, "sources", "WotParser.fs")
+        Assert.True(File.Exists src, $"WotParser.fs not copied to output: {src}")
+
+        let parserKeys =
+            Regex.Matches(File.ReadAllText src, @"Some\(\s*""([a-z_][a-z0-9_]*)""\s*,")
+            |> Seq.map (fun m -> m.Groups[1].Value)
+            |> Set.ofSeq
+
+        Assert.True(parserKeys.Count > 10, $"extracted only {parserKeys.Count} keys — the regex has drifted")
+
+        let grammarText = File.ReadAllText grammarPath
+
+        let missing =
+            parserKeys
+            |> Set.filter (fun k -> not (grammarText.Contains($"\"{k}\"")))
+            |> Set.toList
+
+        Assert.True(
+            List.isEmpty missing,
+            $"""WotParser recognises keys absent from grammars/wot.ebnf: {String.Join(", ", missing)}"""
+        )


### PR DESCRIPTION
## What

`grammars/wot.ebnf` and `WotParser` described **two different languages** with no surface syntax in common:

| | grammar said | parser accepts |
|---|---|---|
| meta | `META { k: "v" }` | `meta { k = "v" }` |
| node | `REASON id { input: a }` | `node "id" kind="reason" { input = ["a"] }` |
| edge | `EDGE a -> b when x == "y"` | `edge "a" -> "b"` |

Every string the old grammar generated was unparseable. A decoder constrained by it would emit 100% garbage. Nothing caught it because **nothing loads the file** — `withNamedGrammar dir "wot"` resolves, but no call site asks for `"wot"`.

This rewrites it and adds a harness that fails if the two drift apart again.

## Whitespace and newlines are explicit on purpose

Not omitted "for readability" — both are load-bearing:

- **GBNF and vLLM have no implicit whitespace.** What the grammar does not say is legal, the decoder cannot emit.
- `WotParser`'s node/edge header regexes use `\s+`, so `node"a"{` is a parse error while `node "a" {` is not.
- `WotParser` is a **line-based state machine**: section headers must end their line with `{`, closing braces must stand alone on a line, and an `args = { ... }` object must fit on one line.

## The gate is soundness, not equivalence

Everything the grammar generates must parse under `WotParser`. The converse is deliberately **not** asserted — the parser ignores unrecognised lines and accepts unquoted values, so asserting it would mean encoding its tolerance for garbage.

## Verification

21 new tests. Both guards verified **by mutation**, not by assertion:

- dropping `verdict` from the grammar → fails exactly 3 tests (drift detector, fixture gate, per-construct check)
- relaxing one `sp` to `ws` → fails exactly the spacing test

The drift detector extracts the keys `WotParser` matches literally (`Some("goal", v)`) from its own source and requires each to appear in the grammar. That is the direction a behavioural test cannot cover: a key added to the parser but not the grammar is otherwise invisible.

Full suite: **994 passed, 21 of them new.** The one failure, `GoldenRun.Demo Ping`, is pre-existing on `main` — it shells out to `dotnet run` against a 15s budget and takes ~67s cold. The fix (15s → 180s) is commit `85946385` on #207 and is deliberately not duplicated here.

## Corpus findings — a planner defect worth its own issue

Validated against the 25-file local `.wot` corpus. That corpus is **gitignored**, so it cannot be a CI gate; hence the tracked `full_surface.wot.trsx` fixture.

The grammar accepts 10 of 25. All 15 rejections are correct:

- **7 files are zero-byte** — `WotParser` "accepts" an empty file and returns an empty workflow
- **8 use constructs the parser accepts and then silently discards**:
  - `inputs {}` on one line is not recognised as a section at all (it ends with `}`, not `{`), so the whole block is dropped
  - `kind = "start"` / `"end"` silently degrade to `reason`
  - `next = "..."` is dropped entirely

So the planner's generated plans lose their start/end semantics and their `next` edges, silently. That is a planner/parser contract defect, not grammar narrowness.

The corpus did expose two genuine over-narrowings, both fixed:
- **unquoted node ids** — every id regex spells quotes `"?`, and the planner emits the bare form
- **missing trailing newline** on the final `}` — handled by normalising input the way `File.ReadAllLines` does, rather than weakening `eol` to `nl?`, which would have made every newline optional and destroyed the line orientation the grammar exists to pin down

## Also fixed

`v2/.gitignore` ignored `*.trsx`, so the new fixture would have been untracked — the test would pass locally and be **vacuous in CI**. Negated for the fixtures directory so the next fixture is tracked by default. (`sample.wot.trsx` is tracked only because it was force-added.)

## Known, not addressed

`WotParser.fs:75` — `rxArgs` requires a `"` immediately after the closing brace, so `tool_result` args are **silently dropped** for every real corpus line. Out of scope here.

## Review notes

- Expect `risk-report` to flag `policy.one_way_door` for `Tars.Tests.fsproj`; the diff is 5 files.
- `Tars.Tests.fsproj` is also touched by #207, so a small textual conflict is expected whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)