### PR TITLE
fix(harness): set the supported auto-compaction key to 40%

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "40"
+  },
   "enabledPlugins": {
     "ralph-loop@claude-plugins-official": false
   },


### PR DESCRIPTION
## What

Adds an `env` block to `.claude/settings.json` setting `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` to `40`.

```diff
 {
+  "env": {
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "40"
+  },
   "enabledPlugins": {
```

## Why

tars was the **only** repo in the ecosystem with no auto-compaction threshold at all. The 2026-07-21 sweep that corrected the key name everywhere else — ix #253, agent-blackbox #43, fin #3, guitaralchemist.github.io #11, all titled *"fix(harness): use supported auto-compaction key"* — skipped tars precisely because there was no `env` block here to rename.

## Why this key name

`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, **not** the `CLAUDE_CODE_`-prefixed spelling that the pre-sweep repos used. Verified against the installed CLI (2.1.220) rather than from docs:

- The binary reads `process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`. The `CLAUDE_CODE_`-prefixed name appears **zero** times — it is ignored silently, with no warning.
- The consuming code parses it as a percentage and clamps it:

  ```js
  if (n !== void 0 && !isNaN(n) && n > 0 && n <= 100)
      return Math.min(Math.floor(e * (n / 100)), r);
  return r;   // default threshold
  ```

  So the value must be in `(0, 100]`, and `Math.min(…, r)` means an override can only pull compaction **earlier** than the default, never later. `40` is in range and takes effect.

## Scope / risk

Config-only; one file, three added lines. No source, build, or test changes.

Note this does **not** change behaviour for anyone whose user-global `~/.claude/settings.json` already sets the key — project `env` blocks merge with the user block, so 40% was already in force there. The value of this change is portability: fresh clones, other machines, and cloud agents that have no global setting now get the same threshold as every other repo in the ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)