### PR TITLE
chore(ci): drop the pay-per-use fallback now the OAuth token is provisioned

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,11 +29,9 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Subscription OAuth token ($0/call) — preferred. Set org-wide via:
-          # claude setup-token && gh secret set CLAUDE_CODE_OAUTH_TOKEN --org GuitarAlchemist
+          # Subscription OAuth token ($0/call). Provisioned on this repo
+          # 2026-07-31, which retires the TEMPORARY pay-per-use
+          # ANTHROPIC_API_KEY fallback this step used to carry: that secret was
+          # never set here, so the fallback resolved to empty and only ever
+          # added a metered-spend path that could not have worked anyway.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # TEMPORARY pay-per-use fallback (2026-07-01): remove once the OAuth
-          # token is provisioned, then revoke the key. This lane only fires on
-          # explicit @claude mentions from OWNER/MEMBER/COLLABORATOR, so spend
-          # is human-initiated and bounded.
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## What

Removes `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` from the `@claude` mention step in `.github/workflows/claude.yml`.

## Why

The step carried this, verbatim:

> `# TEMPORARY pay-per-use fallback (2026-07-01): remove once the OAuth token is provisioned, then revoke the key.`

`CLAUDE_CODE_OAUTH_TOKEN` was provisioned on this repo on **2026-07-31**, so the stated condition is met.

Worth noting: `ANTHROPIC_API_KEY` was **never set on this repo** — the secret list is `AGENT_BLACKBOX_TOKEN`, `JULES_API_KEY`, `PAT_TOKEN`. So the fallback resolved to empty and could not have worked. Removing it costs no capability and closes a metered-spend path that was only ever theoretical.

## Context — both Claude lanes were dark until today

This is the reason the change matters beyond tidiness:

- `claude-code-review.yml` gates on `secrets.CLAUDE_CODE_OAUTH_TOKEN != ''` and **skips green** when the token is absent. That is deliberate and correct (fail-green beats failing red on every PR), but it meant every tars PR reported a ~3-second `claude-review` **pass** while reviewing nothing. PR #218 is an example.
- `claude.yml` had no working credential either, per the above.

No workflow change was needed to fix that — only the secret. This PR just retires the now-dead fallback.

## Note on this repo's review config

`claude-code-review.yml` here is **more cost-safe than ix's** and should stay as it is:

| | tars | ix |
|---|---|---|
| Triggers | `opened, reopened, ready_for_review` | + `synchronize` |
| Concurrency | cancels in-flight | — |
| Drafts | skipped | — |

ix re-reviews on every push; tars deliberately fires once per PR.

## Verification

This PR is itself the live test — it should draw a **real** `claude-review` run (non-trivial `num_turns`, `is_error: false`), not the 3-second skip. Validated the edited YAML parses and that the action step now has exactly `claude_code_oauth_token` + `github_token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)