### PR TITLE
Add human-readable HTML AFK Agent Board dashboard

### DIFF
--- a/docs/agents/live/afk-board.md
+++ b/docs/agents/live/afk-board.md
@@ -1,0 +1,22 @@
+# AFK Live Agent Board
+
+*Last Updated:* 2026-08-08 20:09:25 UTC
+
+This is the human-readable Markdown view of the parallel cloud-agent tracking system. The static [HTML Dashboard](./html/index.html) is also available for live scanning.
+
+## Summary Counts
+
+| Metric | Count |
+|--------|-------|
+| **Total Active Runs** | 1 |
+| **Needs Human Review** | 0 |
+| **Blocked Runs** | 0 |
+| **CI Failing Runs** | 0 |
+| **Stale Runs** | 0 |
+| **Completed (Done) Runs** | 0 |
+
+## Active Runs
+
+| Issue / Task | Agent | PR | State | Risk | Last Signal | Next Action |
+|---|---|---|---|---|---|---
+| #115 - PR exists but needs revision before merge. | Jules | #129 | `needs-agent-revision` | MEDIUM | 2026-06-28T13:02:41Z | Agent should patch workflow path handling and avoid overwriting merged skill docs. |

--- a/docs/agents/live/html/afk-board.css
+++ b/docs/agents/live/html/afk-board.css
@@ -1,0 +1,284 @@
+:root {
+    --bg-color: #f6f8fa;
+    --text-color: #1f2328;
+    --border-color: #d0d7de;
+    --card-bg: #ffffff;
+    --column-bg: #f1f2f4;
+    --link-color: #0969da;
+    --header-bg: #24292f;
+    --header-text: #ffffff;
+
+    --risk-low: #2da44e;
+    --risk-medium: #bf8700;
+    --risk-high: #cf222e;
+
+    --tag-bg: #ddf4ff;
+    --tag-text: #0969da;
+
+    --alert-bg: #fff8c5;
+    --alert-text: #9a6700;
+    --alert-border: #d4a72c;
+
+    --error-bg: #ffebe9;
+    --error-text: #cf222e;
+    --error-border: #ff8182;
+
+    --success-bg: #dafbe1;
+    --success-text: #1a7f37;
+    --success-border: #4ac26b;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    padding: 0 0 40px 0;
+    line-height: 1.5;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+header {
+    background-color: var(--header-bg);
+    color: var(--header-text);
+    padding: 24px;
+    margin-bottom: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
+header h1 {
+    margin-top: 0;
+    margin-bottom: 12px;
+    font-size: 26px;
+    font-weight: 600;
+}
+
+.summary {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+}
+
+.summary-item {
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--header-text);
+    padding: 8px 16px;
+    border-radius: 6px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.last-updated {
+    font-size: 13px;
+    color: #c9d1d9;
+    margin: 0;
+}
+
+/* Board Layout */
+.board {
+    display: flex;
+    gap: 16px;
+    overflow-x: auto;
+    padding: 0 24px 20px 24px;
+    flex-grow: 1;
+    scroll-behavior: smooth;
+}
+
+.column {
+    background-color: var(--column-bg);
+    border-radius: 8px;
+    min-width: 310px;
+    max-width: 310px;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border-color);
+}
+
+.column h2 {
+    font-size: 14px;
+    padding: 12px 16px;
+    margin: 0;
+    border-bottom: 1px solid var(--border-color);
+    font-weight: 600;
+    color: #57606a;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.column h2::after {
+    content: attr(data-count);
+    background: rgba(0, 0, 0, 0.08);
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.cards {
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    overflow-y: auto;
+    max-height: calc(100vh - 240px);
+    flex-grow: 1;
+}
+
+/* Card Styling */
+.card {
+    background-color: var(--card-bg);
+    border-radius: 6px;
+    border: 1px solid var(--border-color);
+    padding: 14px;
+    box-shadow: 0 1px 3px rgba(31, 35, 40, 0.08);
+    font-size: 13px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.card:hover, .card:focus-within {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(31, 35, 40, 0.12);
+    outline: none;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+
+.card-title {
+    font-weight: 600;
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.card-title a {
+    color: var(--text-color);
+    text-decoration: none;
+}
+
+.card-title a:hover, .card-title a:focus {
+    color: var(--link-color);
+    text-decoration: underline;
+}
+
+.card-meta {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.tag {
+    background-color: var(--tag-bg);
+    color: var(--tag-text);
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: capitalize;
+}
+
+.risk-low { border-left: 4px solid var(--risk-low); }
+.risk-medium { border-left: 4px solid var(--risk-medium); }
+.risk-high { border-left: 4px solid var(--risk-high); }
+
+.tag.risk-low { background-color: #dafbe1; color: var(--risk-low); }
+.tag.risk-medium { background-color: #fff8c5; color: #9a6700; }
+.tag.risk-high { background-color: #ffebe9; color: var(--risk-high); }
+
+.card-body {
+    color: #57606a;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.card-body strong {
+    color: var(--text-color);
+}
+
+.card-links {
+    margin-top: 4px;
+    padding-top: 8px;
+    border-top: 1px dashed var(--border-color);
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    font-size: 12px;
+    align-items: center;
+}
+
+.card-links a {
+    color: var(--link-color);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.card-links a:hover, .card-links a:focus {
+    text-decoration: underline;
+}
+
+/* Alerts and Markers */
+.marker-container {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.marker {
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.marker-warning {
+    background-color: var(--alert-bg);
+    color: var(--alert-text);
+    border: 1px solid var(--alert-border);
+}
+
+.marker-error {
+    background-color: var(--error-bg);
+    color: var(--error-text);
+    border: 1px solid var(--error-border);
+}
+
+.marker-success {
+    background-color: var(--success-bg);
+    color: var(--success-text);
+    border: 1px solid var(--success-border);
+}
+
+.empty-state {
+    color: #57606a;
+    font-style: italic;
+    text-align: center;
+    padding: 24px 0;
+    border: 1px dashed var(--border-color);
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.02);
+}
+
+footer {
+    text-align: center;
+    padding: 24px;
+    font-size: 12px;
+    color: #57606a;
+    border-top: 1px solid var(--border-color);
+    margin-top: auto;
+}

--- a/docs/agents/live/html/afk-board.js
+++ b/docs/agents/live/html/afk-board.js
@@ -1,0 +1,239 @@
+async function fetchBoardData() {
+    try {
+        const response = await fetch('./afk-runs.json', { cache: 'no-store' });
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+        return data;
+    } catch (error) {
+        console.error('Failed to fetch board data:', error);
+        return null;
+    }
+}
+
+function escapeHTML(str) {
+    if (str == null) return '';
+    return String(str)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
+function formatRef(ref) {
+    if (!ref) return '';
+    const val = String(ref).trim();
+    if (val.startsWith('#') || isNaN(val)) {
+        return val;
+    }
+    return '#' + val;
+}
+
+function getGithubUrl(ref, type) {
+    if (!ref) return '#';
+    const cleanRef = String(ref).replace('#', '').trim();
+    if (!isNaN(cleanRef)) {
+        // Assume default repo matches typical GuitarAlchemist repo
+        return `https://github.com/GuitarAlchemist/tars/pull/${cleanRef}`;
+    }
+    return ref;
+}
+
+function createCardHTML(run) {
+    const risk = escapeHTML(run.risk || 'low');
+    const riskClass = `risk-${risk.toLowerCase()}`;
+    const agent = escapeHTML(run.agent || 'Unknown');
+
+    const tags = [];
+    if (agent) tags.push(`<span class="tag">Agent: ${agent}</span>`);
+
+    let markersHTML = '';
+    const markers = [];
+
+    // Check various representations of markers
+    if (run.is_stale || run.state === 'stale') {
+        markers.push('<div class="marker marker-warning">⚠️ Stale</div>');
+    }
+    if (run.is_blocked || run.state === 'blocked') {
+        markers.push('<div class="marker marker-error">🚫 Blocked</div>');
+    }
+    if (run.is_duplicate || run.state === 'duplicate' || run.state === 'duplicate-agent-pr') {
+        markers.push('<div class="marker marker-warning">📋 Duplicate</div>');
+    }
+    if (run.ci_failing || run.state === 'ci-failing') {
+        markers.push('<div class="marker marker-error">❌ CI Failing</div>');
+    }
+    if (run.needs_human_review || run.state === 'needs-human-review' || run.state === 'human-review') {
+        markers.push('<div class="marker marker-warning">👀 Needs Human Review</div>');
+    }
+    if (run.state === 'ci-green') {
+        markers.push('<div class="marker marker-success">✅ CI Green</div>');
+    }
+
+    if (markers.length > 0) {
+        markersHTML = `<div class="marker-container">${markers.join('')}</div>`;
+    }
+
+    let linksHTML = '';
+    const links = [];
+
+    const issue = formatRef(run.issue);
+    const pr = formatRef(run.pr);
+
+    if (run.issue) {
+        const issueUrl = `https://github.com/GuitarAlchemist/tars/issues/${String(run.issue).replace('#', '')}`;
+        links.push(`<a href="${issueUrl}" target="_blank" rel="noopener noreferrer" aria-label="Issue ${issue}">${issue}</a>`);
+    }
+    if (run.pr) {
+        links.push(`<a href="${getGithubUrl(run.pr)}" target="_blank" rel="noopener noreferrer" aria-label="PR ${pr}">PR ${pr}</a>`);
+    }
+
+    if (run.evidence && run.evidence.length > 0) {
+        const evidenceLinks = run.evidence.map(e => {
+            if (e && typeof e === 'object') {
+                const url = e.url || '#';
+                const typeName = e.type || 'finding';
+                const text = e.finding ? `${typeName}: ${e.finding}` : typeName;
+                if (url !== '#') {
+                    return `<a href="${escapeHTML(url)}" target="_blank" rel="noopener noreferrer">${escapeHTML(text)}</a>`;
+                }
+                return `<span>${escapeHTML(text)}</span>`;
+            }
+            return `<span>${escapeHTML(e)}</span>`;
+        }).join(' &middot; ');
+        links.push(`<span class="evidence-links">Evidence: ${evidenceLinks}</span>`);
+    }
+
+    if (links.length > 0) {
+        linksHTML = `<div class="card-links">${links.join(' | ')}</div>`;
+    }
+
+    // Support both 'last_signal' and 'last_signal_at'
+    const signalTime = run.last_signal || run.last_signal_at;
+    const lastSignal = signalTime ? escapeHTML(new Date(signalTime).toLocaleString()) : 'Unknown';
+    const nextAction = escapeHTML(run.next_action || 'None specified');
+    // Support both 'title' and 'summary'
+    const title = escapeHTML(run.title || run.summary || 'Untitled Work');
+
+    return `
+        <div class="card ${riskClass}" role="listitem" tabindex="0">
+            <div class="card-header">
+                <h3 class="card-title">
+                    ${title}
+                </h3>
+            </div>
+            <div class="card-meta">
+                ${tags.join('')}
+                <span class="tag ${riskClass}">Risk: ${risk}</span>
+            </div>
+            ${markersHTML}
+            <div class="card-body">
+                <div><strong>Last signal:</strong> ${lastSignal}</div>
+                <div><strong>Next action:</strong> ${nextAction}</div>
+            </div>
+            ${linksHTML}
+        </div>
+    `;
+}
+
+function renderBoard(data) {
+    if (!data) return;
+
+    // Clear existing cards in all columns
+    const columns = document.querySelectorAll('.column');
+    columns.forEach(col => {
+        const cardsContainer = col.querySelector('.cards');
+        if (cardsContainer) {
+            cardsContainer.innerHTML = '';
+        }
+    });
+
+    const summaryCounts = {
+        total: 0,
+        blocked: 0,
+        needs_review: 0,
+        ci_failing: 0,
+        stale: 0,
+        done: 0
+    };
+
+    data.forEach(run => {
+        summaryCounts.total++;
+        if (run.is_blocked || run.state === 'blocked') summaryCounts.blocked++;
+        if (run.needs_human_review || run.state === 'needs-human-review' || run.state === 'human-review') summaryCounts.needs_review++;
+        if (run.ci_failing || run.state === 'ci-failing') summaryCounts.ci_failing++;
+        if (run.is_stale || run.state === 'stale') summaryCounts.stale++;
+        if (run.state === 'done') summaryCounts.done++;
+
+        // Map state strings to columns cleanly
+        let state = (run.state || 'queued').toLowerCase();
+
+        // Canonical state mapping to align vocabulary & DOM attributes
+        if (state === 'pr-open') state = 'pr-opened';
+        if (state === 'human-review') state = 'needs-human-review';
+
+        const columnContainer = document.querySelector(`.column[data-state="${state}"] .cards`);
+
+        if (columnContainer) {
+            columnContainer.insertAdjacentHTML('beforeend', createCardHTML(run));
+        } else {
+            console.warn(`Unknown state '${state}' mapped for run. Falling back to queued column.`);
+            const queuedCol = document.querySelector(`.column[data-state="queued"] .cards`);
+            if (queuedCol) {
+                queuedCol.insertAdjacentHTML('beforeend', createCardHTML(run));
+            }
+        }
+    });
+
+    // Handle empty columns & update counters in headings
+    columns.forEach(col => {
+        const state = col.getAttribute('data-state');
+        const cardsContainer = col.querySelector('.cards');
+        const header = col.querySelector('h2');
+
+        if (cardsContainer) {
+            const cardCount = cardsContainer.querySelectorAll('.card').length;
+            if (header) {
+                header.setAttribute('data-count', cardCount);
+            }
+            if (cardCount === 0) {
+                cardsContainer.innerHTML = '<div class="empty-state">No work in this state</div>';
+            }
+        }
+    });
+
+    // Update Summary Section with accessible count cards
+    const summaryContainer = document.getElementById('summary-counts');
+    if (summaryContainer) {
+        summaryContainer.innerHTML = `
+            <div class="summary-item" tabindex="0">Total Runs: ${summaryCounts.total}</div>
+            <div class="summary-item" tabindex="0">Needs Review: ${summaryCounts.needs_review}</div>
+            <div class="summary-item" tabindex="0">Blocked: ${summaryCounts.blocked}</div>
+            <div class="summary-item" tabindex="0">CI Failing: ${summaryCounts.ci_failing}</div>
+            <div class="summary-item" tabindex="0">Stale: ${summaryCounts.stale}</div>
+            <div class="summary-item" tabindex="0">Done: ${summaryCounts.done}</div>
+        `;
+    }
+
+    // Update timestamp
+    const timeContainer = document.getElementById('last-updated-time');
+    if (timeContainer) {
+        timeContainer.textContent = new Date().toLocaleString();
+    }
+}
+
+async function refreshBoard() {
+    const boardData = await fetchBoardData();
+    if (boardData) {
+        renderBoard(boardData);
+    }
+}
+
+// Initial load
+document.addEventListener('DOMContentLoaded', () => {
+    refreshBoard();
+    // Refresh every 60 seconds
+    setInterval(refreshBoard, 60_000);
+});

--- a/docs/agents/live/html/afk-runs.json
+++ b/docs/agents/live/html/afk-runs.json
@@ -1,0 +1,20 @@
+[
+  {
+    "issue": "#115",
+    "title": "PR exists but needs revision before merge.",
+    "agent": "Jules",
+    "pr": "#129",
+    "state": "needs-agent-revision",
+    "risk": "medium",
+    "last_signal": "2026-06-28T13:02:41Z",
+    "next_action": "Agent should patch workflow path handling and avoid overwriting merged skill docs.",
+    "evidence": [
+      "review_comment: Skill path should load <skill>.skill.md"
+    ],
+    "is_stale": false,
+    "is_blocked": false,
+    "is_duplicate": false,
+    "ci_failing": false,
+    "needs_human_review": false
+  }
+]

--- a/docs/agents/live/html/index.html
+++ b/docs/agents/live/html/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AFK Live Agent Board</title>
+    <link rel="stylesheet" href="afk-board.css">
+    <!-- Basic fallback in case JS fails -->
+    <noscript>
+        <meta http-equiv="refresh" content="60">
+        <style>
+            .board { display: none; }
+            .noscript-msg { display: block !important; padding: 20px; background: #fff3cd; color: #856404; border: 1px solid #ffeeba; border-radius: 6px; margin-bottom: 20px; }
+        </style>
+    </noscript>
+</head>
+<body>
+    <header role="banner">
+        <h1>AFK Live Agent Board</h1>
+        <div class="summary" id="summary-counts" aria-live="polite">
+            <div class="summary-item">Loading summary...</div>
+        </div>
+        <p class="last-updated">Last refreshed: <span id="last-updated-time">Never</span></p>
+    </header>
+
+    <div class="noscript-msg" style="display: none;">
+        <h2>JavaScript is Disabled</h2>
+        <p>The dynamic dashboard requires JavaScript to fetch and render the latest <code>afk-runs.json</code> state. Please enable JavaScript.</p>
+        <p>Alternatively, you can inspect the <a href="afk-runs.json">afk-runs.json</a> file directly for the raw state data.</p>
+    </div>
+
+    <main class="board" id="board-container" aria-label="Agent Work Board">
+        <!-- Columns represent swimlanes for agent state tracking -->
+        <section class="column" data-state="queued" aria-labelledby="col-queued">
+            <h2 id="col-queued">Queued</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="delegated" aria-labelledby="col-delegated">
+            <h2 id="col-delegated">Delegated</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="agent-working" aria-labelledby="col-agent-working">
+            <h2 id="col-agent-working">Agent Working</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="pr-opened" aria-labelledby="col-pr-opened">
+            <h2 id="col-pr-opened">PR Open</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="needs-agent-revision" aria-labelledby="col-needs-agent-revision">
+            <h2 id="col-needs-agent-revision">Needs Revision</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="needs-human-review" aria-labelledby="col-needs-human-review">
+            <h2 id="col-needs-human-review">Human Review</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="ci-green" aria-labelledby="col-ci-green">
+            <h2 id="col-ci-green">CI Green</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="blocked" aria-labelledby="col-blocked">
+            <h2 id="col-blocked">Blocked</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="done" aria-labelledby="col-done">
+            <h2 id="col-done">Done</h2>
+            <div class="cards" role="list"></div>
+        </section>
+    </main>
+
+    <footer role="contentinfo">
+        <p>This board is part of the cloud-agent observability layer of TARS. Data is generated and updated automatically from agent state artifacts.</p>
+    </footer>
+
+    <script src="afk-board.js"></script>
+</body>
+</html>

--- a/examples/agents/afk-live-dashboard.example.html
+++ b/examples/agents/afk-live-dashboard.example.html
@@ -1,0 +1,645 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AFK Live Agent Board - Interactive Mockup</title>
+    <style>
+        :root {
+            --bg-color: #f6f8fa;
+            --text-color: #1f2328;
+            --border-color: #d0d7de;
+            --card-bg: #ffffff;
+            --column-bg: #f1f2f4;
+            --link-color: #0969da;
+            --header-bg: #24292f;
+            --header-text: #ffffff;
+
+            --risk-low: #2da44e;
+            --risk-medium: #bf8700;
+            --risk-high: #cf222e;
+
+            --tag-bg: #ddf4ff;
+            --tag-text: #0969da;
+
+            --alert-bg: #fff8c5;
+            --alert-text: #9a6700;
+            --alert-border: #d4a72c;
+
+            --error-bg: #ffebe9;
+            --error-text: #cf222e;
+            --error-border: #ff8182;
+
+            --success-bg: #dafbe1;
+            --success-text: #1a7f37;
+            --success-border: #4ac26b;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            margin: 0;
+            padding: 0 0 40px 0;
+            line-height: 1.5;
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }
+
+        header {
+            background-color: var(--header-bg);
+            color: var(--header-text);
+            padding: 24px;
+            margin-bottom: 24px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+        }
+
+        header h1 {
+            margin-top: 0;
+            margin-bottom: 12px;
+            font-size: 26px;
+            font-weight: 600;
+        }
+
+        .summary {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 12px;
+            flex-wrap: wrap;
+        }
+
+        .summary-item {
+            background: rgba(255, 255, 255, 0.15);
+            color: var(--header-text);
+            padding: 8px 16px;
+            border-radius: 6px;
+            border: 1px solid rgba(255, 255, 255, 0.25);
+            font-size: 14px;
+            font-weight: 500;
+        }
+
+        .last-updated {
+            font-size: 13px;
+            color: #c9d1d9;
+            margin: 0;
+        }
+
+        /* Board Layout */
+        .board {
+            display: flex;
+            gap: 16px;
+            overflow-x: auto;
+            padding: 0 24px 20px 24px;
+            flex-grow: 1;
+            scroll-behavior: smooth;
+        }
+
+        .column {
+            background-color: var(--column-bg);
+            border-radius: 8px;
+            min-width: 310px;
+            max-width: 310px;
+            display: flex;
+            flex-direction: column;
+            border: 1px solid var(--border-color);
+        }
+
+        .column h2 {
+            font-size: 14px;
+            padding: 12px 16px;
+            margin: 0;
+            border-bottom: 1px solid var(--border-color);
+            font-weight: 600;
+            color: #57606a;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .column h2::after {
+            content: attr(data-count);
+            background: rgba(0, 0, 0, 0.08);
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 600;
+        }
+
+        .cards {
+            padding: 12px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            overflow-y: auto;
+            max-height: calc(100vh - 240px);
+            flex-grow: 1;
+        }
+
+        /* Card Styling */
+        .card {
+            background-color: var(--card-bg);
+            border-radius: 6px;
+            border: 1px solid var(--border-color);
+            padding: 14px;
+            box-shadow: 0 1px 3px rgba(31, 35, 40, 0.08);
+            font-size: 13px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .card:hover, .card:focus-within {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 8px rgba(31, 35, 40, 0.12);
+            outline: none;
+        }
+
+        .card-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+        }
+
+        .card-title {
+            font-weight: 600;
+            margin: 0;
+            font-size: 14px;
+            line-height: 1.4;
+        }
+
+        .card-title a {
+            color: var(--text-color);
+            text-decoration: none;
+        }
+
+        .card-title a:hover, .card-title a:focus {
+            color: var(--link-color);
+            text-decoration: underline;
+        }
+
+        .card-meta {
+            display: flex;
+            gap: 6px;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+
+        .tag {
+            background-color: var(--tag-bg);
+            color: var(--tag-text);
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-size: 11px;
+            font-weight: 600;
+            text-transform: capitalize;
+        }
+
+        .risk-low { border-left: 4px solid var(--risk-low); }
+        .risk-medium { border-left: 4px solid var(--risk-medium); }
+        .risk-high { border-left: 4px solid var(--risk-high); }
+
+        .tag.risk-low { background-color: #dafbe1; color: var(--risk-low); }
+        .tag.risk-medium { background-color: #fff8c5; color: #9a6700; }
+        .tag.risk-high { background-color: #ffebe9; color: var(--risk-high); }
+
+        .card-body {
+            color: #57606a;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .card-body strong {
+            color: var(--text-color);
+        }
+
+        .card-links {
+            margin-top: 4px;
+            padding-top: 8px;
+            border-top: 1px dashed var(--border-color);
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            font-size: 12px;
+            align-items: center;
+        }
+
+        .card-links a {
+            color: var(--link-color);
+            text-decoration: none;
+            font-weight: 500;
+        }
+
+        .card-links a:hover, .card-links a:focus {
+            text-decoration: underline;
+        }
+
+        /* Alerts and Markers */
+        .marker-container {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .marker {
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 11px;
+            font-weight: 600;
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .marker-warning {
+            background-color: var(--alert-bg);
+            color: var(--alert-text);
+            border: 1px solid var(--alert-border);
+        }
+
+        .marker-error {
+            background-color: var(--error-bg);
+            color: var(--error-text);
+            border: 1px solid var(--error-border);
+        }
+
+        .marker-success {
+            background-color: var(--success-bg);
+            color: var(--success-text);
+            border: 1px solid var(--success-border);
+        }
+
+        .empty-state {
+            color: #57606a;
+            font-style: italic;
+            text-align: center;
+            padding: 24px 0;
+            border: 1px dashed var(--border-color);
+            border-radius: 6px;
+            background: rgba(0, 0, 0, 0.02);
+        }
+
+        footer {
+            text-align: center;
+            padding: 24px;
+            font-size: 12px;
+            color: #57606a;
+            border-top: 1px solid var(--border-color);
+            margin-top: auto;
+        }
+    </style>
+</head>
+<body>
+    <header role="banner">
+        <h1>AFK Live Agent Board - Self-Contained Interactive Mockup</h1>
+        <div class="summary" id="summary-counts" aria-live="polite">
+            <div class="summary-item">Loading summary...</div>
+        </div>
+        <p class="last-updated">Mockup Refreshed: <span id="last-updated-time">Never</span></p>
+    </header>
+
+    <main class="board" id="board-container" aria-label="Agent Work Board">
+        <section class="column" data-state="queued" aria-labelledby="col-queued">
+            <h2 id="col-queued">Queued</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="delegated" aria-labelledby="col-delegated">
+            <h2 id="col-delegated">Delegated</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="agent-working" aria-labelledby="col-agent-working">
+            <h2 id="col-agent-working">Agent Working</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="pr-opened" aria-labelledby="col-pr-opened">
+            <h2 id="col-pr-opened">PR Open</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="needs-agent-revision" aria-labelledby="col-needs-agent-revision">
+            <h2 id="col-needs-agent-revision">Needs Revision</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="needs-human-review" aria-labelledby="col-needs-human-review">
+            <h2 id="col-needs-human-review">Human Review</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="ci-green" aria-labelledby="col-ci-green">
+            <h2 id="col-ci-green">CI Green</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="blocked" aria-labelledby="col-blocked">
+            <h2 id="col-blocked">Blocked</h2>
+            <div class="cards" role="list"></div>
+        </section>
+        <section class="column" data-state="done" aria-labelledby="col-done">
+            <h2 id="col-done">Done</h2>
+            <div class="cards" role="list"></div>
+        </section>
+    </main>
+
+    <footer role="contentinfo">
+        <p>This is a mock demonstration file showing various states of the parallel control plane. For active state, open <a href="../../docs/agents/live/html/index.html">docs/agents/live/html/index.html</a>.</p>
+    </footer>
+
+    <script>
+        // Inline mock database representing diverse examples (stale, blocked, duplicate, etc.)
+        const mockRuns = [
+            {
+                "issue": "#115",
+                "title": "Inject declared cloud-agent skills into Jules prompt",
+                "agent": "Jules",
+                "pr": "#129",
+                "state": "needs-agent-revision",
+                "risk": "medium",
+                "last_signal": "2026-06-28T13:02:41Z",
+                "next_action": "Fix skill path to <skill>.skill.md",
+                "evidence": ["review comment", "changed files", "CI status"],
+                "is_stale": false,
+                "is_blocked": false,
+                "is_duplicate": false,
+                "ci_failing": true,
+                "needs_human_review": false
+            },
+            {
+                "issue": "#136",
+                "title": "Define AFK JSON/JSONL state artifacts",
+                "agent": "Codex",
+                "pr": "#140",
+                "state": "pr-opened",
+                "risk": "low",
+                "last_signal": "2026-06-28T14:10:00Z",
+                "next_action": "Wait for review",
+                "evidence": ["PR open"],
+                "is_stale": false,
+                "is_blocked": false,
+                "is_duplicate": false,
+                "ci_failing": false,
+                "needs_human_review": true
+            },
+            {
+                "issue": "#132",
+                "title": "Fix agent memory leak in test suite",
+                "agent": "Claude",
+                "pr": null,
+                "state": "agent-working",
+                "risk": "high",
+                "last_signal": "2026-06-28T14:15:00Z",
+                "next_action": "Run tests locally",
+                "evidence": [],
+                "is_stale": false,
+                "is_blocked": false,
+                "is_duplicate": false,
+                "ci_failing": false,
+                "needs_human_review": false
+            },
+            {
+                "issue": "#99",
+                "title": "Implement multi-agent routing selector",
+                "agent": "Jules",
+                "pr": "#101",
+                "state": "blocked",
+                "risk": "high",
+                "last_signal": "2026-06-25T10:00:00Z",
+                "next_action": "Requires resolution of upstream dependency Issue #88",
+                "evidence": ["blocker label applied"],
+                "is_stale": false,
+                "is_blocked": true,
+                "is_duplicate": false,
+                "ci_failing": false,
+                "needs_human_review": false
+            },
+            {
+                "issue": "#112",
+                "title": "Refactor state vector indexing",
+                "agent": "Codex",
+                "pr": "#113",
+                "state": "done",
+                "risk": "low",
+                "last_signal": "2026-06-27T09:30:00Z",
+                "next_action": "PR merged successfully",
+                "evidence": ["merge commit"],
+                "is_stale": false,
+                "is_blocked": false,
+                "is_duplicate": false,
+                "ci_failing": false,
+                "needs_human_review": false
+            },
+            {
+                "issue": "#120",
+                "title": "Duplicate work: optimize LLM request context size",
+                "agent": "Claude",
+                "pr": "#122",
+                "state": "needs-agent-revision",
+                "risk": "medium",
+                "last_signal": "2026-06-28T02:00:00Z",
+                "next_action": "Superseded by Codex PR #123",
+                "evidence": ["duplicate label"],
+                "is_stale": true,
+                "is_blocked": false,
+                "is_duplicate": true,
+                "ci_failing": false,
+                "needs_human_review": false
+            },
+            {
+                "issue": "#142",
+                "title": "Integrate AFK board into CI system",
+                "agent": "Jules",
+                "pr": null,
+                "state": "queued",
+                "risk": "low",
+                "last_signal": "2026-06-28T15:00:00Z",
+                "next_action": "Waiting on dispatcher run",
+                "evidence": [],
+                "is_stale": false,
+                "is_blocked": false,
+                "is_duplicate": false,
+                "ci_failing": false,
+                "needs_human_review": false
+            }
+        ];
+
+        function escapeHTML(str) {
+            if (str == null) return '';
+            return String(str)
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#039;");
+        }
+
+        function formatRef(ref) {
+            if (!ref) return '';
+            const val = String(ref).trim();
+            if (val.startsWith('#') || isNaN(val)) {
+                return val;
+            }
+            return '#' + val;
+        }
+
+        function createCardHTML(run) {
+            const risk = escapeHTML(run.risk || 'low');
+            const riskClass = `risk-${risk.toLowerCase()}`;
+            const agent = escapeHTML(run.agent || 'Unknown');
+
+            const tags = [];
+            if (agent) tags.push(`<span class="tag">Agent: ${agent}</span>`);
+
+            let markersHTML = '';
+            const markers = [];
+
+            if (run.is_stale || run.state === 'stale') {
+                markers.push('<div class="marker marker-warning">⚠️ Stale</div>');
+            }
+            if (run.is_blocked || run.state === 'blocked') {
+                markers.push('<div class="marker marker-error">🚫 Blocked</div>');
+            }
+            if (run.is_duplicate || run.state === 'duplicate' || run.state === 'duplicate-agent-pr') {
+                markers.push('<div class="marker marker-warning">📋 Duplicate</div>');
+            }
+            if (run.ci_failing || run.state === 'ci-failing') {
+                markers.push('<div class="marker marker-error">❌ CI Failing</div>');
+            }
+            if (run.needs_human_review || run.state === 'needs-human-review' || run.state === 'human-review') {
+                markers.push('<div class="marker marker-warning">👀 Needs Human Review</div>');
+            }
+            if (run.state === 'ci-green') {
+                markers.push('<div class="marker marker-success">✅ CI Green</div>');
+            }
+
+            if (markers.length > 0) {
+                markersHTML = `<div class="marker-container">${markers.join('')}</div>`;
+            }
+
+            let linksHTML = '';
+            const links = [];
+
+            const issue = formatRef(run.issue);
+            const pr = formatRef(run.pr);
+
+            if (run.issue) {
+                const issueUrl = `https://github.com/GuitarAlchemist/tars/issues/${String(run.issue).replace('#', '')}`;
+                links.push(`<a href="${issueUrl}" target="_blank" rel="noopener noreferrer">${issue}</a>`);
+            }
+            if (run.pr) {
+                links.push(`<a href="#" onclick="alert('This is a mockup link'); return false;">PR ${pr}</a>`);
+            }
+
+            if (run.evidence && run.evidence.length > 0) {
+                const evidenceLinks = run.evidence.map(e => `<span>${escapeHTML(e)}</span>`).join(' &middot; ');
+                links.push(`<span class="evidence-links">Evidence: ${evidenceLinks}</span>`);
+            }
+
+            if (links.length > 0) {
+                linksHTML = `<div class="card-links">${links.join(' | ')}</div>`;
+            }
+
+            const signalTime = run.last_signal || run.last_signal_at;
+            const lastSignal = signalTime ? escapeHTML(new Date(signalTime).toLocaleString()) : 'Unknown';
+            const nextAction = escapeHTML(run.next_action || 'None specified');
+            const title = escapeHTML(run.title || run.summary || 'Untitled Work');
+
+            return `
+                <div class="card ${riskClass}" role="listitem" tabindex="0">
+                    <div class="card-header">
+                        <h3 class="card-title">
+                            ${title}
+                        </h3>
+                    </div>
+                    <div class="card-meta">
+                        ${tags.join('')}
+                        <span class="tag ${riskClass}">Risk: ${risk}</span>
+                    </div>
+                    ${markersHTML}
+                    <div class="card-body">
+                        <div><strong>Last signal:</strong> ${lastSignal}</div>
+                        <div><strong>Next action:</strong> ${nextAction}</div>
+                    </div>
+                    ${linksHTML}
+                </div>
+            `;
+        }
+
+        function renderBoard(data) {
+            const columns = document.querySelectorAll('.column');
+            columns.forEach(col => {
+                const cardsContainer = col.querySelector('.cards');
+                if (cardsContainer) {
+                    cardsContainer.innerHTML = '';
+                }
+            });
+
+            const summaryCounts = {
+                total: 0,
+                blocked: 0,
+                needs_review: 0,
+                ci_failing: 0,
+                stale: 0,
+                done: 0
+            };
+
+            data.forEach(run => {
+                summaryCounts.total++;
+                if (run.is_blocked || run.state === 'blocked') summaryCounts.blocked++;
+                if (run.needs_human_review || run.state === 'needs-human-review' || run.state === 'human-review') summaryCounts.needs_review++;
+                if (run.ci_failing || run.state === 'ci-failing') summaryCounts.ci_failing++;
+                if (run.is_stale || run.state === 'stale') summaryCounts.stale++;
+                if (run.state === 'done') summaryCounts.done++;
+
+                let state = (run.state || 'queued').toLowerCase();
+                if (state === 'pr-open') state = 'pr-opened';
+                if (state === 'human-review') state = 'needs-human-review';
+
+                const columnContainer = document.querySelector(`.column[data-state="${state}"] .cards`);
+
+                if (columnContainer) {
+                    columnContainer.insertAdjacentHTML('beforeend', createCardHTML(run));
+                } else {
+                    const queuedCol = document.querySelector(`.column[data-state="queued"] .cards`);
+                    if (queuedCol) {
+                        queuedCol.insertAdjacentHTML('beforeend', createCardHTML(run));
+                    }
+                }
+            });
+
+            columns.forEach(col => {
+                const cardsContainer = col.querySelector('.cards');
+                const header = col.querySelector('h2');
+
+                if (cardsContainer) {
+                    const cardCount = cardsContainer.querySelectorAll('.card').length;
+                    if (header) {
+                        header.setAttribute('data-count', cardCount);
+                    }
+                    if (cardCount === 0) {
+                        cardsContainer.innerHTML = '<div class="empty-state">No work in this state</div>';
+                    }
+                }
+            });
+
+            const summaryContainer = document.getElementById('summary-counts');
+            if (summaryContainer) {
+                summaryContainer.innerHTML = `
+                    <div class="summary-item" tabindex="0">Total Runs: ${summaryCounts.total}</div>
+                    <div class="summary-item" tabindex="0">Needs Review: ${summaryCounts.needs_review}</div>
+                    <div class="summary-item" tabindex="0">Blocked: ${summaryCounts.blocked}</div>
+                    <div class="summary-item" tabindex="0">CI Failing: ${summaryCounts.ci_failing}</div>
+                    <div class="summary-item" tabindex="0">Stale: ${summaryCounts.stale}</div>
+                    <div class="summary-item" tabindex="0">Done: ${summaryCounts.done}</div>
+                `;
+            }
+
+            const timeContainer = document.getElementById('last-updated-time');
+            if (timeContainer) {
+                timeContainer.textContent = new Date().toLocaleString();
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            renderBoard(mockRuns);
+        });
+    </script>
+</body>
+</html>

--- a/tools/agents/render-afk-board.ps1
+++ b/tools/agents/render-afk-board.ps1
@@ -1,0 +1,171 @@
+# tools/agents/render-afk-board.ps1 - Generate the human-readable HTML and Markdown boards from JSON artifacts in PowerShell.
+
+$ErrorActionPreference = "Stop"
+
+# Locate Repo Root
+$gitRoot = git rev-parse --show-toplevel 2>$null
+if ($null -eq $gitRoot) {
+    $RepoRoot = Get-Location
+} else {
+    $RepoRoot = $gitRoot
+}
+
+Write-Host "=== Rendering AFK Live Agent Board (PowerShell) ==="
+
+$GovRunsDir = Join-Path $RepoRoot "governance/agents/live/runs"
+$HtmlOutDir = Join-Path $RepoRoot "docs/agents/live/html"
+$HtmlOutFile = Join-Path $HtmlOutDir "afk-runs.json"
+$MdOutFile = Join-Path $RepoRoot "docs/agents/live/afk-board.md"
+
+# Ensure output directories exist
+if (-not (Test-Path $HtmlOutDir)) {
+    New-Item -ItemType Directory -Force -Path $HtmlOutDir | Out-Null
+}
+
+$compiledRuns = @()
+
+# 1. Gather runs from governance/agents/live/runs/*.json
+if (Test-Path $GovRunsDir) {
+    $jsonFiles = Get-ChildItem -Path $GovRunsDir -Filter "*.json" | Sort-Object Name
+    foreach ($file in $jsonFiles) {
+        try {
+            $content = Get-Content -Raw -Path $file.FullName -ErrorAction Stop
+            $runData = ConvertFrom-Json $content
+
+            $state = if ($runData.state) { $runData.state } else { "queued" }
+
+            # Synthesize flags based on state vocabulary
+            $isStale = ($state -eq "stale") -or ($runData.is_stale -eq $true)
+            $isBlocked = ($state -eq "blocked") -or ($runData.is_blocked -eq $true)
+            $isDuplicate = ($state -in @("duplicate", "duplicate-agent-pr")) -or ($runData.is_duplicate -eq $true)
+            $ciFailing = ($state -eq "ci-failing") -or ($runData.ci_failing -eq $true)
+            $needsReview = ($state -in @("needs-human-review", "human-review")) -or ($runData.needs_human_review -eq $true)
+
+            $evidence = @()
+            if ($runData.evidence) {
+                foreach ($e in $runData.evidence) {
+                    if ($e -is [string]) {
+                        $evidence += $e
+                    } elseif ($null -ne $e.type) {
+                        $finding = if ($e.finding) { $e.finding } else { "Reference" }
+                        $evidence += "$($e.type): $finding"
+                    }
+                }
+            }
+
+            $issue = if ($runData.issue) {
+                if ($runData.issue.ToString().StartsWith("#")) { $runData.issue.ToString() } else { "#" + $runData.issue.ToString() }
+            } else {
+                ""
+            }
+
+            $pr = if ($runData.pr) {
+                if ($runData.pr.ToString().StartsWith("#")) { $runData.pr.ToString() } else { "#" + $runData.pr.ToString() }
+            } else {
+                ""
+            }
+
+            $agent = if ($runData.agent) { $runData.agent.ToString() } else { "Unknown" }
+            # Capitalize agent name
+            if ($agent.Length -gt 0) {
+                $agent = $agent.Substring(0,1).ToUpper() + $agent.Substring(1)
+            }
+
+            $normalizedRun = [PSCustomObject]@{
+                issue              = $issue
+                title              = if ($runData.summary) { $runData.summary } else { "Untitled Agent Run" }
+                agent              = $agent
+                pr                 = $pr
+                state              = $state
+                risk               = if ($runData.risk) { $runData.risk } else { "low" }
+                last_signal        = if ($runData.last_signal_at) { $runData.last_signal_at } else { if ($runData.last_signal) { $runData.last_signal } else { "" } }
+                next_action        = if ($runData.next_action) { $runData.next_action } else { "None specified" }
+                evidence           = $evidence
+                is_stale           = [bool]$isStale
+                is_blocked         = [bool]$isBlocked
+                is_duplicate       = [bool]$isDuplicate
+                ci_failing         = [bool]$ciFailing
+                needs_human_review = [bool]$needsReview
+            }
+            $compiledRuns += $normalizedRun
+        } catch {
+            Write-Warning "Failed to parse $($file.Name): $_"
+        }
+    }
+}
+
+# 2. Write compiled runs array into HTML folder
+try {
+    $jsonOut = ConvertTo-Json -InputObject $compiledRuns -Depth 100
+    [System.IO.File]::WriteAllText($HtmlOutFile, $jsonOut)
+    Write-Host "Successfully compiled $($compiledRuns.Count) runs into $HtmlOutFile"
+} catch {
+    Write-Error "Failed to write compiled runs to $HtmlOutFile: $_"
+}
+
+# 3. Generate Markdown Board
+try {
+    $timestamp = [DateTime]::UtcNow.ToString("yyyy-MM-dd HH:mm:ss UTC")
+
+    $totalCount = $compiledRuns.Count
+    $reviewCount = ($compiledRuns | Where-Object { $_.needs_human_review -or $_.state -eq "needs-human-review" }).Count
+    $blockedCount = ($compiledRuns | Where-Object { $_.is_blocked -or $_.state -eq "blocked" }).Count
+    $failingCount = ($compiledRuns | Where-Object { $_.ci_failing -or $_.state -eq "ci-failing" }).Count
+    $staleCount = ($compiledRuns | Where-Object { $_.is_stale -or $_.state -eq "stale" }).Count
+    $doneCount = ($compiledRuns | Where-Object { $_.state -eq "done" }).Count
+
+    $mdContent = @"
+# AFK Live Agent Board
+
+*Last Updated:* $timestamp
+
+This is the human-readable Markdown view of the parallel cloud-agent tracking system. The static [HTML Dashboard](./html/index.html) is also available for live scanning.
+
+## Summary Counts
+
+| Metric | Count |
+|--------|-------|
+| **Total Active Runs** | $totalCount |
+| **Needs Human Review** | $reviewCount |
+| **Blocked Runs** | $blockedCount |
+| **CI Failing Runs** | $failingCount |
+| **Stale Runs** | $staleCount |
+| **Completed (Done) Runs** | $doneCount |
+
+## Active Runs
+
+"@
+
+    if ($compiledRuns.Count -gt 0) {
+        $mdContent += "`n| Issue / Task | Agent | PR | State | Risk | Last Signal | Next Action |`n"
+        $mdContent += "|---|---|---|---|---|---|---|`n"
+        foreach ($run in $compiledRuns) {
+            $issueStr = if ($run.issue) { $run.issue } else { "N/A" }
+            $titleStr = $run.title
+            $agentStr = $run.agent
+            $prStr = if ($run.pr) { $run.pr } else { "None" }
+            $stateStr = $run.state
+            $riskStr = $run.risk.ToUpper()
+            $signalStr = if ($run.last_signal) { $run.last_signal } else { "N/A" }
+            $actionStr = $run.next_action
+
+            $stateLabel = $stateStr
+            if ($run.is_stale) { $stateLabel += " ⚠️ STALE" }
+            if ($run.is_blocked) { $stateLabel += " 🚫 BLOCKED" }
+            if ($run.is_duplicate) { $stateLabel += " 📋 DUPLICATE" }
+            if ($run.ci_failing) { $stateLabel += " ❌ FAILING" }
+            if ($run.needs_human_review) { $stateLabel += " 👀 NEEDS REVIEW" }
+
+            $mdContent += "| $issueStr - $titleStr | $agentStr | $prStr | `$stateLabel` | $riskStr | $signalStr | $actionStr |`n"
+        }
+    } else {
+        $mdContent += "*No active cloud agent work is currently registered.*\n"
+    }
+
+    [System.IO.File]::WriteAllText($MdOutFile, $mdContent)
+    Write-Host "Successfully generated Markdown board in $MdOutFile"
+} catch {
+    Write-Error "Failed to write Markdown board: $_"
+}
+
+Write-Host "=== Rendering Completed ==="

--- a/tools/agents/render-afk-board.sh
+++ b/tools/agents/render-afk-board.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# tools/agents/render-afk-board.sh - Generate the human-readable HTML and Markdown boards from JSON artifacts.
+
+set -euo pipefail
+
+# Ensure we run from the repo root
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+echo "=== Rendering AFK Live Agent Board ==="
+
+# Define paths
+GOV_LIVE_DIR="governance/agents/live"
+RUNS_DIR="${GOV_LIVE_DIR}/runs"
+HTML_OUT_DIR="docs/agents/live/html"
+MD_OUT_FILE="docs/agents/live/afk-board.md"
+
+# Ensure output directories exist
+mkdir -p "${HTML_OUT_DIR}"
+
+# Run Python compilation logic for robustness
+python3 - << 'EOF'
+import os
+import json
+from datetime import datetime, timezone
+
+gov_runs_dir = "governance/agents/live/runs"
+html_out_file = "docs/agents/live/html/afk-runs.json"
+md_out_file = "docs/agents/live/afk-board.md"
+
+compiled_runs = []
+
+# 1. Gather runs from governance/agents/live/runs/*.json
+if os.path.exists(gov_runs_dir):
+    for filename in sorted(os.listdir(gov_runs_dir)):
+        if filename.endswith(".json"):
+            filepath = os.path.join(gov_runs_dir, filename)
+            try:
+                with open(filepath, "r", encoding="utf-8") as f:
+                    run_data = json.load(f)
+
+                    # Normalize fields for unified schema
+                    state = run_data.get("state", "queued")
+
+                    # Synthesize flags based on state vocabulary
+                    is_stale = state == "stale" or run_data.get("is_stale", False)
+                    is_blocked = state == "blocked" or run_data.get("is_blocked", False)
+                    is_duplicate = state in ["duplicate", "duplicate-agent-pr"] or run_data.get("is_duplicate", False)
+                    ci_failing = state == "ci-failing" or run_data.get("ci_failing", False)
+                    needs_human_review = state in ["needs-human-review", "human-review"] or run_data.get("needs_human_review", False)
+
+                    # Map into unified array element
+                    normalized_run = {
+                        "issue": f"#{run_data.get('issue')}" if run_data.get("issue") and not str(run_data.get("issue")).startswith("#") else run_data.get("issue", ""),
+                        "title": run_data.get("summary", "Untitled Agent Run"),
+                        "agent": run_data.get("agent", "Unknown").capitalize(),
+                        "pr": f"#{run_data.get('pr')}" if run_data.get("pr") and not str(run_data.get("pr")).startswith("#") else (run_data.get("pr") or ""),
+                        "state": state,
+                        "risk": run_data.get("risk", "low"),
+                        "last_signal": run_data.get("last_signal_at", run_data.get("last_signal", "")),
+                        "next_action": run_data.get("next_action", "None specified"),
+                        "evidence": [
+                            e if isinstance(e, str) else f"{e.get('type', 'link')}: {e.get('finding', 'Reference')}"
+                            for e in run_data.get("evidence", [])
+                        ],
+                        "is_stale": is_stale,
+                        "is_blocked": is_blocked,
+                        "is_duplicate": is_duplicate,
+                        "ci_failing": ci_failing,
+                        "needs_human_review": needs_human_review
+                    }
+                    compiled_runs.append(normalized_run)
+            except Exception as e:
+                print(f"Warning: Failed to parse {filename}: {e}")
+
+# 2. Write the compiled runs array into the HTML folder
+try:
+    with open(html_out_file, "w", encoding="utf-8") as f:
+        json.dump(compiled_runs, f, indent=2)
+    print(f"Successfully compiled {len(compiled_runs)} runs into {html_out_file}")
+except Exception as e:
+    print(f"Error: Failed to write compiled runs: {e}")
+
+# 3. Generate the Markdown Board for GitHub review
+try:
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    # Calculate counters
+    total_count = len(compiled_runs)
+    review_count = sum(1 for r in compiled_runs if r.get("needs_human_review") or r.get("state") == "needs-human-review")
+    blocked_count = sum(1 for r in compiled_runs if r.get("is_blocked") or r.get("state") == "blocked")
+    failing_count = sum(1 for r in compiled_runs if r.get("ci_failing") or r.get("state") == "ci-failing")
+    stale_count = sum(1 for r in compiled_runs if r.get("is_stale") or r.get("state") == "stale")
+    done_count = sum(1 for r in compiled_runs if r.get("state") == "done")
+
+    md_content = f"""# AFK Live Agent Board
+
+*Last Updated:* {timestamp}
+
+This is the human-readable Markdown view of the parallel cloud-agent tracking system. The static [HTML Dashboard](./html/index.html) is also available for live scanning.
+
+## Summary Counts
+
+| Metric | Count |
+|--------|-------|
+| **Total Active Runs** | {total_count} |
+| **Needs Human Review** | {review_count} |
+| **Blocked Runs** | {blocked_count} |
+| **CI Failing Runs** | {failing_count} |
+| **Stale Runs** | {stale_count} |
+| **Completed (Done) Runs** | {done_count} |
+
+## Active Runs
+
+"""
+    if compiled_runs:
+        md_content += "| Issue / Task | Agent | PR | State | Risk | Last Signal | Next Action |\n"
+        md_content += "|---|---|---|---|---|---|---\n"
+        for run in compiled_runs:
+            issue_str = run.get("issue", "N/A")
+            title_str = run.get("title", "Untitled")
+            agent_str = run.get("agent", "Unknown")
+            pr_str = run.get("pr") or "None"
+            state_str = run.get("state", "queued")
+            risk_str = run.get("risk", "low").upper()
+            signal_str = run.get("last_signal", "N/A")
+            action_str = run.get("next_action", "N/A")
+
+            # Add markers to State
+            state_label = state_str
+            if run.get("is_stale"):
+                state_label += " ⚠️ STALE"
+            if run.get("is_blocked"):
+                state_label += " 🚫 BLOCKED"
+            if run.get("is_duplicate"):
+                state_label += " 📋 DUPLICATE"
+            if run.get("ci_failing"):
+                state_label += " ❌ FAILING"
+            if run.get("needs_human_review"):
+                state_label += " 👀 NEEDS REVIEW"
+
+            md_content += f"| {issue_str} - {title_str} | {agent_str} | {pr_str} | `{state_label}` | {risk_str} | {signal_str} | {action_str} |\n"
+    else:
+        md_content += "*No active cloud agent work is currently registered.*\n"
+
+    with open(md_out_file, "w", encoding="utf-8") as f:
+        f.write(md_content)
+    print(f"Successfully generated Markdown board in {md_out_file}")
+
+except Exception as e:
+    print(f"Error: Failed to write Markdown board: {e}")
+EOF
+
+echo "=== Rendering Completed ==="


### PR DESCRIPTION
This contribution implements a modern, accessible, responsive Kanban-style dashboard and static Markdown table view for tracking parallel cloud agents (Jules, Codex, Claude) in TARS. It includes cross-platform generator scripts (Bash/Python and PowerShell) that compile state JSON files under governance into unified state artifacts, a self-contained mockup, and full keyboard-navigable styling without external dependencies.

Fixes #137

---
*PR created automatically by Jules for task [5741676607076158650](https://jules.google.com/task/5741676607076158650) started by @spareilleux*