### PR TITLE
Unify Pattern Compilation and LLM-JSON Response Parsing Seams

### DIFF
--- a/v2/src/Tars.Cortex/ClaudeCodeBridge.fs
+++ b/v2/src/Tars.Cortex/ClaudeCodeBridge.fs
@@ -178,13 +178,7 @@ module ClaudeCodeBridge =
             let patternKind = selector.Recommend(goal, cogState)
 
             // Compile plan based on selected pattern
-            let plan =
-                match patternKind with
-                | ChainOfThought -> compiler.CompileChainOfThought(maxSteps, goal)
-                | ReAct -> compiler.CompileReAct([ "search"; "read"; "write" ], maxSteps, goal)
-                | GraphOfThoughts -> compiler.CompileGraphOfThoughts(3, 3, goal)
-                | TreeOfThoughts -> compiler.CompileTreeOfThoughts(3, 2, goal)
-                | _ -> compiler.CompileChainOfThought(maxSteps, goal)
+            let plan = compiler.CompileFor(patternKind, goal)
 
             let planId = plan.Id.ToString()
 

--- a/v2/src/Tars.Cortex/PatternCompiler.fs
+++ b/v2/src/Tars.Cortex/PatternCompiler.fs
@@ -458,7 +458,7 @@ module PatternCompiler =
                 let compiler = this :> IPatternCompiler
                 match kind with
                 | ChainOfThought -> compiler.CompileChainOfThought(5, goal)
-                | ReAct -> compiler.CompileReAct([ "search"; "calculate"; "read" ], 10, goal)
+                | ReAct -> compiler.CompileReAct([ "search"; "calculate"; "read"; "write" ], 10, goal)
                 | GraphOfThoughts -> compiler.CompileGraphOfThoughts(3, 3, goal)
                 | TreeOfThoughts -> compiler.CompileTreeOfThoughts(3, 2, goal)
                 | PlanAndExecute -> compiler.CompileChainOfThought(3, goal)

--- a/v2/src/Tars.Cortex/WoTExecutor.fs
+++ b/v2/src/Tars.Cortex/WoTExecutor.fs
@@ -935,15 +935,6 @@ Respond with ONLY the number of your choice."""
         (context: Tars.Core.AgentContext)
         : Async<WoTResult> =
         async {
-            let plan =
-                match pattern with
-                | ChainOfThought -> compiler.CompileChainOfThought(5, goal)
-                | ReAct -> compiler.CompileReAct([ "search"; "calculate"; "read" ], 10, goal)
-                | GraphOfThoughts -> compiler.CompileGraphOfThoughts(3, 3, goal)
-                | TreeOfThoughts -> compiler.CompileTreeOfThoughts(3, 2, goal)
-                | WorkflowOfThought -> failwith "WoT requires explicit nodes"
-                | PlanAndExecute -> compiler.CompileChainOfThought(3, goal)
-                | Custom _ -> compiler.CompileChainOfThought(3, goal)
-
+            let plan = compiler.CompileFor(pattern, goal)
             return! executor.Execute(plan, context)
         }

--- a/v2/src/Tars.Evolution/ReflectionEngine.fs
+++ b/v2/src/Tars.Evolution/ReflectionEngine.fs
@@ -132,46 +132,29 @@ Reflect on this execution. Output JSON:
 
             try
                 let! resp = llm.CompleteAsync req
-                let text = resp.Text.Trim()
-                let firstBrace = text.IndexOf('{')
-                let lastBrace = text.LastIndexOf('}')
+                use doc = StructuredOutput.parseJson resp.Text
+                let root = doc.RootElement
 
-                if firstBrace >= 0 && lastBrace > firstBrace then
-                    let json = text.Substring(firstBrace, lastBrace - firstBrace + 1)
-                    let doc = JsonDocument.Parse(json)
-                    let root = doc.RootElement
+                let getStr (name: string) (fallback: string) =
+                    let mutable p = JsonElement()
+                    if root.TryGetProperty(name, &p) then p.GetString() else fallback
 
-                    let getStr (name: string) (fallback: string) =
-                        let mutable p = JsonElement()
-                        if root.TryGetProperty(name, &p) then p.GetString() else fallback
+                let getArr (name: string) =
+                    let mutable p = JsonElement()
+                    if root.TryGetProperty(name, &p) && p.ValueKind = JsonValueKind.Array then
+                        p.EnumerateArray() |> Seq.map (fun e -> e.GetString()) |> Seq.toList
+                    else []
 
-                    let getArr (name: string) =
-                        let mutable p = JsonElement()
-                        if root.TryGetProperty(name, &p) && p.ValueKind = JsonValueKind.Array then
-                            p.EnumerateArray() |> Seq.map (fun e -> e.GetString()) |> Seq.toList
-                        else []
-
-                    return
-                        { RunId = Guid.NewGuid().ToString("N").Substring(0, 12)
-                          Goal = goal
-                          IntendedStrategy = getStr "intended_strategy" "unknown"
-                          ActualBehavior = getStr "actual_behavior" "unknown"
-                          Outcome = classifyOutcome comparison
-                          Surprises = getArr "surprises"
-                          LessonsLearned = getArr "lessons_learned"
-                          SuggestedImprovements = getArr "suggested_improvements"
-                          Timestamp = DateTime.UtcNow }
-                else
-                    return
-                        { RunId = Guid.NewGuid().ToString("N").Substring(0, 12)
-                          Goal = goal
-                          IntendedStrategy = "planned execution"
-                          ActualBehavior = sprintf "%d/%d steps completed" comparison.ExecutedSteps comparison.PlannedSteps
-                          Outcome = classifyOutcome comparison
-                          Surprises = []
-                          LessonsLearned = []
-                          SuggestedImprovements = []
-                          Timestamp = DateTime.UtcNow }
+                return
+                    { RunId = Guid.NewGuid().ToString("N").Substring(0, 12)
+                      Goal = goal
+                      IntendedStrategy = getStr "intended_strategy" "unknown"
+                      ActualBehavior = getStr "actual_behavior" "unknown"
+                      Outcome = classifyOutcome comparison
+                      Surprises = getArr "surprises"
+                      LessonsLearned = getArr "lessons_learned"
+                      SuggestedImprovements = getArr "suggested_improvements"
+                      Timestamp = DateTime.UtcNow }
             with _ ->
                 return
                     { RunId = Guid.NewGuid().ToString("N").Substring(0, 12)

--- a/v2/src/Tars.Evolution/RetroactionLoop.fs
+++ b/v2/src/Tars.Evolution/RetroactionLoop.fs
@@ -292,15 +292,10 @@ Output JSON ONLY, no explanation.
 
                 try
                     let! resp = llm.CompleteAsync req |> Async.AwaitTask
-                    let mutable text = resp.Text.Trim()
-                    let firstBrace = text.IndexOf('{')
-                    let lastBrace = text.LastIndexOf('}')
-
-                    if firstBrace >= 0 && lastBrace > firstBrace then
-                        text <- text.Substring(firstBrace, lastBrace - firstBrace + 1)
 
                     // Validate it's parseable JSON
-                    use _doc = JsonDocument.Parse(text)
+                    use doc = StructuredOutput.parseJson resp.Text
+                    let text = doc.RootElement.GetRawText()
 
                     let variant =
                         { original with

--- a/v2/src/Tars.Evolution/SelfImprovement.fs
+++ b/v2/src/Tars.Evolution/SelfImprovement.fs
@@ -69,16 +69,8 @@ Format:
 
                 let! resp = llm.CompleteAsync req
 
-                // Robust JSON extraction
-                let mutable text = resp.Text.Trim()
-                let firstBrace = text.IndexOf('{')
-                let lastBrace = text.LastIndexOf('}')
-
-                if firstBrace >= 0 && lastBrace > firstBrace then
-                    text <- text.Substring(firstBrace, lastBrace - firstBrace + 1)
-
                 try
-                    use doc = JsonDocument.Parse(text)
+                    use doc = StructuredOutput.parseJson resp.Text
                     let root = doc.RootElement
 
                     let getProp (element: JsonElement) (name: string) =

--- a/v2/src/Tars.Evolution/StructuredOutput.fs
+++ b/v2/src/Tars.Evolution/StructuredOutput.fs
@@ -195,3 +195,23 @@ let buildCycleOutput
 /// Serialize a CycleOutput to JSON
 let cycleToJson (output: CycleOutput) : string =
     toJson output
+
+/// <summary>
+/// Extracts and parses robust JSON from LLM responses, stripping conversational filler
+/// and markdown block wrappers using Tars.Llm.JsonParsing.
+/// </summary>
+let parseJson (text: string) : JsonDocument =
+    match Tars.Llm.JsonParsing.tryParseElement text with
+    | Ok elem ->
+        JsonDocument.Parse(elem.GetRawText())
+    | Error firstError ->
+        // Fallback to simpler/original firstBrace/lastBrace extraction if tryParseElement fails
+        let mutable cleaned = text.Trim()
+        let firstBrace = cleaned.IndexOf('{')
+        let lastBrace = cleaned.LastIndexOf('}')
+        if firstBrace >= 0 && lastBrace > firstBrace then
+            cleaned <- cleaned.Substring(firstBrace, lastBrace - firstBrace + 1)
+        try
+            JsonDocument.Parse(cleaned)
+        with ex ->
+            failwithf "Failed to parse JSON: %s (Fallback error: %s)" firstError ex.Message

--- a/v2/src/Tars.Evolution/SymbolicReflector.fs
+++ b/v2/src/Tars.Evolution/SymbolicReflector.fs
@@ -87,15 +87,7 @@ Output ONLY valid JSON.
             try
                 let! resp = llm.CompleteAsync req
 
-                // Robust JSON extraction (same as SelfImprovement)
-                let mutable text = resp.Text.Trim()
-                let firstBrace = text.IndexOf('{')
-                let lastBrace = text.LastIndexOf('}')
-
-                if firstBrace >= 0 && lastBrace > firstBrace then
-                    text <- text.Substring(firstBrace, lastBrace - firstBrace + 1)
-
-                use doc = JsonDocument.Parse(text)
+                use doc = StructuredOutput.parseJson resp.Text
                 let root = doc.RootElement
 
                 // Parse Trigger

--- a/v2/src/Tars.Evolution/TraceCompiler.fs
+++ b/v2/src/Tars.Evolution/TraceCompiler.fs
@@ -86,15 +86,7 @@ OUTPUT FORMAT (JSON ONLY):
             try
                 let! resp = llm.CompleteAsync req |> Async.AwaitTask
 
-                // Robust extraction
-                let mutable text = resp.Text.Trim()
-                let firstBrace = text.IndexOf('{')
-                let lastBrace = text.LastIndexOf('}')
-
-                if firstBrace >= 0 && lastBrace > firstBrace then
-                    text <- text.Substring(firstBrace, lastBrace - firstBrace + 1)
-
-                use doc = JsonDocument.Parse(text)
+                use doc = StructuredOutput.parseJson resp.Text
                 let root = doc.RootElement
 
                 let synth = root.GetProperty("synthesis")


### PR DESCRIPTION
This submission resolves the cortex-evolution shared glue drift and duplication issues. Specifically, it unifies the pattern compilation dispatch to eliminate ReAct tool list divergence, and centralizes inbound LLM-JSON response extraction logic into a robust, reusable parsing seam in StructuredOutput.fs. All v2 tests compile and pass successfully.

Fixes #222

---
*PR created automatically by Jules for task [1183020563305497841](https://jules.google.com/task/1183020563305497841) started by @spareilleux*